### PR TITLE
Little code optimization

### DIFF
--- a/src/Ceres.Chess/MoveGen/MGPosition.cs
+++ b/src/Ceres.Chess/MoveGen/MGPosition.cs
@@ -375,7 +375,9 @@ namespace Ceres.Chess.MoveGen
     [ModuleInitializer]
     internal static void ClassInitialize()
     {
-      SquareMap = new Lazy<BitBoard[]>(() => CreateSquareMap());
+      // do not use lambda express here
+      //  "() => CreateSquareMap()" code is not good because it creates inner class or deeper method calls
+      SquareMap = new Lazy<BitBoard[]>(CreateSquareMap);
 
       MGPieceCodeToPieceType = new[] { PieceType.None, PieceType.Pawn, PieceType.Bishop, PieceType.None, PieceType.Rook, PieceType.Knight, PieceType.Queen, PieceType.King,
                                        PieceType.None, PieceType.Pawn, PieceType.Bishop, PieceType.None, PieceType.Rook, PieceType.Knight, PieceType.Queen, PieceType.King };


### PR DESCRIPTION
== EN ==
Using unnecessary lambda expressions lengthens the code, making it difficult to read and slowing execution.

== KR (original text) ==
무분별한 람다식의 사용은 코드를 길게 만들어 읽기 힘들게 만들고, 실행 속도를 늦춥니다.