### PR TITLE
fixed a typo

### DIFF
--- a/src/Ceres.MCTS/Search/MCTSBatchParamsManager.cs
+++ b/src/Ceres.MCTS/Search/MCTSBatchParamsManager.cs
@@ -112,7 +112,7 @@ namespace Ceres.MCTS.Search
 }
 
 
-#if nOT
+#if NOT
           if (nodesNN.Count > 10)
           {
             MCTSNode node = nodesNN[^1];


### PR DESCRIPTION
Hi.

I found a typo.

I am not a C# programmer, and don't know whether C# macro is case-sensitive or not.
If it is case-sensitive, this typo may be critical against your intention.
