### PR TITLE
Fix issue 42 where uci options can't be changed after engine initialization

### DIFF
--- a/src/Ceres.Features/UCI/UCIManager.SetOption.cs
+++ b/src/Ceres.Features/UCI/UCIManager.SetOption.cs
@@ -181,6 +181,8 @@ namespace Ceres.Features.UCI
           float moveOverheadMilliseconds = 0;
           SetFloat(value, 0, int.MaxValue, ref moveOverheadMilliseconds);
           moveOverheadSeconds = moveOverheadMilliseconds / 1000f;
+          if (CeresEngine is not null)
+            CeresEngine.SearchParams.MoveOverheadSeconds = moveOverheadSeconds;
           break;
 
         case "smartpruningfactor":
@@ -192,6 +194,8 @@ namespace Ceres.Features.UCI
             futilityPruningDisabled = false;
           else
             OutStream.Write($"Ceres does not support {factor}, only value 0 (indicating turned off) or 1.33 (indicating default) for SmartPruningFactor");
+          if (CeresEngine is not null)
+            CeresEngine.SearchParams.FutilityPruningStopSearchEnabled =  !futilityPruningDisabled;
           break;
 
         case "verbosemovestats":
@@ -236,39 +240,39 @@ namespace Ceres.Features.UCI
 
 
         case "cpuct":
-          SetFloat(value, 0, float.MaxValue, ref cpuct);
+          SetFloat(value, 0, float.MaxValue, ref (CeresEngine is not null ? ref CeresEngine.ChildSelectParams.CPUCT : ref cpuct));
           break;
 
         case "cpuctbase":
-          SetFloat(value, 1, float.MaxValue, ref cpuctBase);
+          SetFloat(value, 1, float.MaxValue, ref (CeresEngine is not null ? ref CeresEngine.ChildSelectParams.CPUCTBase : ref cpuctBase));
           break;
 
         case "cpuctfactor":
-          SetFloat(value, 0, float.MaxValue, ref cpuctFactor);
+          SetFloat(value, 0, float.MaxValue, ref (CeresEngine is not null ? ref CeresEngine.ChildSelectParams.CPUCTFactor : ref cpuctFactor));
           break;
 
         case "cpuctatroot":
-          SetFloat(value, 0, float.MaxValue, ref cpuctAtRoot);
+          SetFloat(value, 0, float.MaxValue, ref (CeresEngine is not null ? ref CeresEngine.ChildSelectParams.CPUCTAtRoot : ref cpuctAtRoot));
           break;
 
         case "cpuctbaseatroot":
-          SetFloat(value, 1, float.MaxValue, ref cpuctBaseAtRoot);
+          SetFloat(value, 1, float.MaxValue, ref (CeresEngine is not null ? ref CeresEngine.ChildSelectParams.CPUCTBaseAtRoot : ref cpuctBaseAtRoot));
           break;
 
         case "cpuctfactoratroot":
-          SetFloat(value, 0, float.MaxValue, ref cpuctFactorAtRoot);
+          SetFloat(value, 0, float.MaxValue, ref (CeresEngine is not null ? ref CeresEngine.ChildSelectParams.CPUCTFactorAtRoot : ref cpuctFactorAtRoot));
           break;
 
         case "policytemperature":
-          SetFloat(value, 0.1f, float.MaxValue, ref policySoftmax);
+          SetFloat(value, 0.1f, float.MaxValue, ref (CeresEngine is not null ? ref CeresEngine.ChildSelectParams.PolicySoftmax : ref policySoftmax));
           break;
 
         case "fpu":
-          SetFloat(value, 0, float.MaxValue, ref fpu);
+          SetFloat(value, 0, float.MaxValue, ref (CeresEngine is not null ? ref CeresEngine.ChildSelectParams.FPUValue : ref fpu));
           break;
 
         case "fpuatroot":
-          SetFloat(value, 0, float.MaxValue, ref fpuAtRoot);
+          SetFloat(value, 0, float.MaxValue, ref (CeresEngine is not null ? ref CeresEngine.ChildSelectParams.FPUValueAtRoot : ref fpuAtRoot));
           break;
       }
     }


### PR DESCRIPTION
``Fixes issue #42. Currently Search and Selection uci parameters cannot be changed after the engine has been initialized which happens after the first go-command. This means that currently user cannot run search with default parameters and then rerun the search with custom parameters without closing the engine in between.

Following shows the issue with current main where following parameters cannot be changed despite issuing _ucinewgame_ after first search: 
`smartpruningfactor, moveoverheadms, cpuct, cpuctbase, cpuctfactor, cpuctatroot, cpuctbaseatroot, cpuctfactoratroot, policytemperature, fpu, fpuatroot`
The latter snippet shows fixed behavior with this pr.

Main:
```*** WARNING: Ceres binaries built in Debug mode and will run much more slowly than Release

|=========================================================|
| Ceres - A Monte Carlo Tree Search Chess Engine          |
|                                                         |
| (c) 2020- David Elliott and the Ceres Authors           |
|   With network backend code from Leela Chess Zero.      |
|                                                         |
|  Version 0.90-rc1  Use help to list available commands. |
|=========================================================|

Ceres user settings loaded from file Ceres.json

Network evaluation configured to use: <NNEvaluatorDef Network=LC0:66997 Device=GPU:0 >

Entering UCI command processing mode.
go nodes 100

Loaded network weights: 66997: 30x384 WDL MLH  from C:\Users\jussi\Documents\lc0_weights\weights_run1_66997.pb.gz

CUDA device 0: GeForce RTX 2070 SMs: 36 Mem: 8gb
info depth 4 seldepth 10 time 105 nodes 66 score cp 11 tbhits 0 nps 628 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 f1e1  string M= 136
info depth 5 seldepth 10 time 130 nodes 100 score cp 10 tbhits 0 nps 770 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 f1e1  string M= 136
bestmove e2e4
ucinewgame
setoption name smartpruningfactor value 0.0
setoption name moveoverheadms value 101
setoption name cpuct value 102
setoption name cpuctbase value 103
setoption name cpuctfactor value 104
setoption name cpuctatroot value 105
setoption name cpuctbaseatroot value 106
setoption name cpuctfactoratroot value 107
setoption name policytemperature value 108
setoption name fpu value 109
setoption name fpuatroot value 110
dump-params
info string No search manager created
go nodes 100
info depth 4 seldepth 9 time 102 nodes 48 score cp 11 tbhits 0 nps 473 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4  string M= 136
info depth 5 seldepth 10 time 135 nodes 100 score cp 10 tbhits 0 nps 742 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 f1e1  string M= 136
bestmove e2e4
dump-params
SearchLimit

ParamsSelect
  RandomizeQ                                                  False
  UCTRootNumeratorExponent                                    0,5
  UCTNonRootNumeratorExponent                                 0,5
  UCTRootDenominatorExponent                                  1
  UCTNonRootDenominatorExponent                               1
  RootCPUCTExtraMultiplierDivisor                             10000
  RootCPUCTExtraMultiplierExponent                            0
  CPUCT                                                       1,745
  CPUCTBase                                                   38739
  CPUCTFactor                                                 3,894
  CPUCTAtRoot                                                 1,745
  CPUCTBaseAtRoot                                             38739
  CPUCTFactorAtRoot                                           3,894
  PolicyDecayFactor                                           0
  PolicyDecayExponent                                         0,38
  VirtualLossDefaultRelative                                  -0,1
  VirtualLossDefaultAbsolute                                  -1
  UseDynamicVLoss                                             False
  PowerMeanNExponent                                          0
  FirstMoveThompsonSamplingFactor                             0
  FPUMode                                                     Reduction
  FPUModeAtRoot                                               Same
  FPUValue                                                    0,33
  FPUValueAtRoot                                              1
  PolicySoftmax                                               1,359
  USE_ZZTUNE                                                  True
  MinPolicyProbability                                        0,005
  RandomizeScale                                              0,099999994
  CPUCTDualSelectorDiffFraction                               0,2

ParamsSearch
  BestMoveMode                                                TopQIfSufficientN
  ApplyTrendBonus                                             False
  MLHBonusFactor                                              0
  AutoOptimizeEnabled                                         True
  TreeReuseEnabled                                            True
  TreeReuseRetainedPositionCacheEnabled                       False
  ReusePositionEvaluationsFromOtherTree                       True
  Contempt                                                    0
  ContemptAutoScaleWeight                                     0
  BatchSizeMultiplier                                         1
  HistoryFillIn                                               True
  EnableTablebases                                            False
  DrawByRepetitionLookbackPlies                               22
  TwofoldDrawEnabled                                          True
  FutilityPruningStopSearchEnabled                            True
  MoveFutilityPruningAggressiveness                           0,4
  GameLimitUsageAggressiveness                                1
  EnableInstamoves                                            True
  PaddedBatchSizing                                           False
  PaddedExtraNodesBase                                        5
  PaddedExtraNodesMultiplier                                  0,03
  TranspositionUseTransposedQ                                 True
  TranspositionUseCluster                                     False
  MoveOverheadSeconds                                         0,25
  TestFlag                                                    False
  TestScalar                                                  0
  USE_CERES_ADJUSTMENTS                                       True
  LC0_DEFAULT_SMART_PRUNING_FACTOR                            1,33

ParamsSearchExecution
  TranspositionMode                                           SingleNodeDeferredCopy
  InFlightThisBatchLinkageEnabled                             True
  InFlightOtherBatchLinkageEnabled                            False
  NodeAnnotationCacheSize                                     750000
* SmartSizeBatches                                            False
* FlowDirectOverlapped                                        False
* FlowDualSelectors                                           False
  FlowSplitSelects                                            True
* RootPreloadDepth                                            2
* RootPreloadWidth                                            2
  MaxBatchSize                                                1024
  DualSelectorAlternateCollisionFraction                      0,25
* SelectParallelEnabled                                       False
  SelectParallelThreshold                                     5
* SetPoliciesParallelEnabled                                  False
  SetPoliciesNumPoliciesPerThread                             32
  ParallelMultiplier                                          1
```

This pr fixes the issue
```
*** WARNING: Ceres binaries built in Debug mode and will run much more slowly than Release

|=========================================================|
| Ceres - A Monte Carlo Tree Search Chess Engine          |
|                                                         |
| (c) 2020- David Elliott and the Ceres Authors           |
|   With network backend code from Leela Chess Zero.      |
|                                                         |
|  Version 0.90-rc1  Use help to list available commands. |
|=========================================================|

Ceres user settings loaded from file Ceres.json

Network evaluation configured to use: <NNEvaluatorDef Network=LC0:66997 Device=GPU:0 >

Entering UCI command processing mode.
go nodes 100

Loaded network weights: 66997: 30x384 WDL MLH  from C:\Users\jussi\Documents\lc0_weights\weights_run1_66997.pb.gz

CUDA device 0: GeForce RTX 2070 SMs: 36 Mem: 8gb
info depth 4 seldepth 10 time 105 nodes 66 score cp 11 tbhits 0 nps 630 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 f1e1  string M= 136
info depth 5 seldepth 10 time 131 nodes 100 score cp 10 tbhits 0 nps 766 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 f1e1  string M= 136
bestmove e2e4
ucinewgame
setoption name smartpruningfactor value 0.0
setoption name moveoverheadms value 101
setoption name cpuct value 102
setoption name cpuctbase value 103
setoption name cpuctfactor value 104
setoption name cpuctatroot value 105
setoption name cpuctbaseatroot value 106
setoption name cpuctfactoratroot value 107
setoption name policytemperature value 108
setoption name fpu value 109
setoption name fpuatroot value 110
dump-params
info string No search manager created
go nodes 100
info depth 5 seldepth 10 time 101 nodes 36 score cp 8 tbhits 0 nps 355 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 f1e1  string M= 137
info depth 4 seldepth 5 time 158 nodes 100 score cp 13 tbhits 0 nps 634 pv d2d4 d7d5 c2c4 e7e6  string M= 136
bestmove d2d4
dump-params
SearchLimit

ParamsSelect
  RandomizeQ                                                  False
  UCTRootNumeratorExponent                                    0,5
  UCTNonRootNumeratorExponent                                 0,5
  UCTRootDenominatorExponent                                  1
  UCTNonRootDenominatorExponent                               1
  RootCPUCTExtraMultiplierDivisor                             10000
  RootCPUCTExtraMultiplierExponent                            0
* CPUCT                                                       102
* CPUCTBase                                                   103
* CPUCTFactor                                                 104
* CPUCTAtRoot                                                 105
* CPUCTBaseAtRoot                                             106
* CPUCTFactorAtRoot                                           107
  PolicyDecayFactor                                           0
  PolicyDecayExponent                                         0,38
  VirtualLossDefaultRelative                                  -0,1
  VirtualLossDefaultAbsolute                                  -1
  UseDynamicVLoss                                             False
  PowerMeanNExponent                                          0
  FirstMoveThompsonSamplingFactor                             0
  FPUMode                                                     Reduction
  FPUModeAtRoot                                               Same
* FPUValue                                                    109
* FPUValueAtRoot                                              110
* PolicySoftmax                                               108
  USE_ZZTUNE                                                  True
  MinPolicyProbability                                        0,005
  RandomizeScale                                              0,099999994
  CPUCTDualSelectorDiffFraction                               0,2

ParamsSearch
  BestMoveMode                                                TopQIfSufficientN
  ApplyTrendBonus                                             False
  MLHBonusFactor                                              0
  AutoOptimizeEnabled                                         True
  TreeReuseEnabled                                            True
  TreeReuseRetainedPositionCacheEnabled                       False
  ReusePositionEvaluationsFromOtherTree                       True
  Contempt                                                    0
  ContemptAutoScaleWeight                                     0
  BatchSizeMultiplier                                         1
  HistoryFillIn                                               True
  EnableTablebases                                            False
  DrawByRepetitionLookbackPlies                               22
  TwofoldDrawEnabled                                          True
* FutilityPruningStopSearchEnabled                            False
  MoveFutilityPruningAggressiveness                           0,4
  GameLimitUsageAggressiveness                                1
  EnableInstamoves                                            True
  PaddedBatchSizing                                           False
  PaddedExtraNodesBase                                        5
  PaddedExtraNodesMultiplier                                  0,03
  TranspositionUseTransposedQ                                 True
  TranspositionUseCluster                                     False
* MoveOverheadSeconds                                         0,101
  TestFlag                                                    False
  TestScalar                                                  0
  USE_CERES_ADJUSTMENTS                                       True
  LC0_DEFAULT_SMART_PRUNING_FACTOR                            1,33

ParamsSearchExecution
  TranspositionMode                                           SingleNodeDeferredCopy
  InFlightThisBatchLinkageEnabled                             True
  InFlightOtherBatchLinkageEnabled                            False
  NodeAnnotationCacheSize                                     750000
* SmartSizeBatches                                            False
* FlowDirectOverlapped                                        False
* FlowDualSelectors                                           False
  FlowSplitSelects                                            True
* RootPreloadDepth                                            2
* RootPreloadWidth                                            2
  MaxBatchSize                                                1024
  DualSelectorAlternateCollisionFraction                      0,25
* SelectParallelEnabled                                       False
  SelectParallelThreshold                                     5
* SetPoliciesParallelEnabled                                  False
  SetPoliciesNumPoliciesPerThread                             32
  ParallelMultiplier                                          1
```

