### PR TITLE
Provide some useful help when CUDA can not be initialized

### DIFF
--- a/src/Ceres.Chess/NNBackends/CUDA/NNBackendLC0_CUDA.cs
+++ b/src/Ceres.Chess/NNBackends/CUDA/NNBackendLC0_CUDA.cs
@@ -239,6 +239,11 @@ namespace Ceres.Chess.NNBackends.CUDA
 
         InitNetwork(net);
       }
+      catch (Exception e) 
+      {
+            Console.WriteLine("Error when initializing CUDA. Did you install NVidia's CUDA? https://developer.nvidia.com/cuda-zone");
+            Console.WriteLine(e);
+      }
       finally
       {
         ExecContext.Device.GraphCaptureRWLock.ExitWriteLock();


### PR DESCRIPTION
If you run Ceres without CUDA installed, it just seems to hang. Catch the exception, and provide a bit more help.