### PR TITLE
Improved Tournament Features

### DIFF
--- a/src/Ceres.Features/Tournaments/TournamentDef.cs
+++ b/src/Ceres.Features/Tournaments/TournamentDef.cs
@@ -134,11 +134,11 @@ namespace Ceres.Features.Tournaments
 
             foreach (var engine in Engines)
             {
-                if (engines.Where(e=>e != engine).Any(e => object.ReferenceEquals(engine,e)))
+                if (engines.Where(e => e != engine).Any(e => object.ReferenceEquals(engine, e)))
                 {
                     throw new Exception("playerDef must be different from each other");
                 }
-            }            
+            }
         }
 
 
@@ -157,8 +157,18 @@ namespace Ceres.Features.Tournaments
             Console.WriteLine($"  Openings  : {OpeningsDescription()}");
             Console.WriteLine($"  Adjudicate: {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp"
                            + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}");
-            Console.WriteLine($"  Player 1  : {Player1Def} ");
-            Console.WriteLine($"  Player 2  : {Player2Def} ");
+            if (Engines.Count > 0)
+            {
+                for (int i = 0; i < Engines.Count; i++)
+                {
+                    Console.WriteLine($"Player {i + 1} : {Engines[i]}");
+                }
+            }
+            else
+            {
+                Console.WriteLine($"  Player 1  : {Player1Def} ");
+                Console.WriteLine($"  Player 2  : {Player2Def} ");
+            }
 
 
             //if (Player1Def.EngineDef is GameEngineDefCeres &&

--- a/src/Ceres.Features/Tournaments/TournamentDef.cs
+++ b/src/Ceres.Features/Tournaments/TournamentDef.cs
@@ -152,7 +152,7 @@ namespace Ceres.Features.Tournaments
 
         public void DumpParams()
         {
-            Console.WriteLine($"TOURNAMENT    {ID}");
+            Console.WriteLine($"TOURNAMENT:  {ID}");
             Console.WriteLine($"  Game Pairs: {NumGamePairs} ");
             Console.WriteLine($"  Openings  : {OpeningsDescription()}");
             Console.WriteLine($"  Adjudicate: {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp"
@@ -161,7 +161,7 @@ namespace Ceres.Features.Tournaments
             {
                 for (int i = 0; i < Engines.Count; i++)
                 {
-                    Console.WriteLine($"Player {i + 1} : {Engines[i]}");
+                    Console.WriteLine($"  Player {i + 1} : {Engines[i]}");
                 }
             }
             else

--- a/src/Ceres.Features/Tournaments/TournamentDef.cs
+++ b/src/Ceres.Features/Tournaments/TournamentDef.cs
@@ -14,8 +14,9 @@
 #region Using directives
 
 using System;
+using System.Collections.Generic;
 using System.IO;
-
+using System.Linq;
 using Ceres.Base.Misc;
 using Ceres.Chess.GameEngines;
 using Ceres.Features.GameEngines;
@@ -25,128 +26,145 @@ using Ceres.Features.Players;
 
 namespace Ceres.Features.Tournaments
 {
-  /// <summary>
-  /// Defines the parameters of a tournament between chess engines.
-  /// </summary>
-  [Serializable]
-  public class TournamentDef
-  {
     /// <summary>
-    /// Descriptive identifying string of tournament.
+    /// Defines the parameters of a tournament between chess engines.
     /// </summary>
-    public string ID;
-
-    /// <summary>
-    /// Optional number of game pairs to run (opponents play both sides in a pair).
-    /// If not specified, one game pair is run for each specified opening position.
-    /// </summary>
-    public int? NumGamePairs;
-
-    /// <summary>
-    /// Target for logging messages.
-    /// </summary>
-    [NonSerialized] public TextWriter Logger = Console.Out;
-
-    /// <summary>
-    /// Definition of the first player engine.
-    /// </summary>
-    public EnginePlayerDef Player1Def;
-
-    /// <summary>
-    /// Definition of the second player engine.
-    /// </summary>
-    public EnginePlayerDef Player2Def;
-
-    /// <summary>
-    /// Optinal definition of engine used to check moves of second player.
-    /// </summary>
-    public EnginePlayerDef CheckPlayer2Def;
-
-    /// <summary>
-    /// If each move in each game should be output to the log/console.
-    /// </summary>
-    public bool ShowGameMoves = true;
-
-    /// <summary>
-    /// Name PGN or EPD file containing set of starting positions to be used.
-    /// If null then chess start position is used for every game.
-    /// The user setting "DirPGN" is consulted to determine the source directory.
-    /// </summary>
-    public string OpeningsFileName;
-
-    /// <summary>
-    /// Starting position for the games (unless OpeningsFileName is specified).
-    /// Defaults to the chess start position is used for every game.
-    /// </summary>
-    public string StartingFEN = null;
-
-    /// <summary>
-    /// If the order of the openings from the book should be randomized.
-    /// </summary>
-    public bool RandomizeOpenings = false;
-
-    /// <summary>
-    /// If tablebases should be consulted for adjudication purposes.
-    /// </summary>
-    public bool UseTablebasesForAdjudication = true;
-
-    /// <summary>
-    /// Minimum absolute evaluation (in centipawns)
-    /// which must be exceeded by both engines
-    /// for a win to be declared by adjudication.
-    /// </summary>
-    public int AdjudicationThresholdCentipawns = 350;
-
-
-    /// <summary>
-    /// Minimum number of moves for which both engines evaluations
-    /// must be more extreme than AdjudicationThresholdCentipawns.
-    /// </summary>
-    public int AdjudicationThresholdNumMoves = 2;
-
-    /// <summary>
-    /// Creation time of tournament (use as a unique ID for generating PGN)
-    /// </summary>
-    public readonly DateTime StartTime;
-
-
-    public TournamentDef(string id, EnginePlayerDef player1Def, EnginePlayerDef player2Def)
+    [Serializable]
+    public class TournamentDef
     {
-      ID = id;
-      Player1Def = player1Def ?? throw new ArgumentNullException(nameof(player1Def));
-      Player2Def = player2Def ?? throw new ArgumentNullException(nameof(player2Def));
-      StartTime = DateTime.Now;
+        /// <summary>
+        /// Descriptive identifying string of tournament.
+        /// </summary>
+        public string ID;
 
-      if (object.ReferenceEquals(player1Def, player2Def))
-      {
-        throw new Exception("player1Def must be different from player2Def");
-      }
-    }
+        /// <summary>
+        /// Optional number of game pairs to run (opponents play both sides in a pair).
+        /// If not specified, one game pair is run for each specified opening position.
+        /// </summary>
+        public int? NumGamePairs;
+
+        /// <summary>
+        /// Target for logging messages.
+        /// </summary>
+        [NonSerialized] public TextWriter Logger = Console.Out;
+
+        public List<EnginePlayerDef> Engines { get; set; } = new List<EnginePlayerDef>();
+
+        /// <summary>
+        /// Definition of the first player engine.
+        /// </summary>
+        public EnginePlayerDef Player1Def;
+
+        /// <summary>
+        /// Definition of the second player engine.
+        /// </summary>
+        public EnginePlayerDef Player2Def;
+
+        /// <summary>
+        /// Optinal definition of engine used to check moves of second player.
+        /// </summary>
+        public EnginePlayerDef CheckPlayer2Def;
+
+        /// <summary>
+        /// If each move in each game should be output to the log/console.
+        /// </summary>
+        public bool ShowGameMoves = true;
+
+        /// <summary>
+        /// Name PGN or EPD file containing set of starting positions to be used.
+        /// If null then chess start position is used for every game.
+        /// The user setting "DirPGN" is consulted to determine the source directory.
+        /// </summary>
+        public string OpeningsFileName;
+
+        /// <summary>
+        /// Starting position for the games (unless OpeningsFileName is specified).
+        /// Defaults to the chess start position is used for every game.
+        /// </summary>
+        public string StartingFEN = null;
+
+        /// <summary>
+        /// If the order of the openings from the book should be randomized.
+        /// </summary>
+        public bool RandomizeOpenings = false;
+
+        /// <summary>
+        /// If tablebases should be consulted for adjudication purposes.
+        /// </summary>
+        public bool UseTablebasesForAdjudication = true;
+
+        /// <summary>
+        /// Minimum absolute evaluation (in centipawns)
+        /// which must be exceeded by both engines
+        /// for a win to be declared by adjudication.
+        /// </summary>
+        public int AdjudicationThresholdCentipawns = 350;
 
 
-    public TournamentDef Clone()
-    {
-      TournamentDef clone = ObjUtils.DeepClone<TournamentDef>(this);
-      clone.Logger = this.Logger;
-      return clone;
-    }
+        /// <summary>
+        /// Minimum number of moves for which both engines evaluations
+        /// must be more extreme than AdjudicationThresholdCentipawns.
+        /// </summary>
+        public int AdjudicationThresholdNumMoves = 2;
+
+        /// <summary>
+        /// Creation time of tournament (use as a unique ID for generating PGN)
+        /// </summary>
+        public readonly DateTime StartTime;
 
 
-    public void DumpParams()
-    {
-      Console.WriteLine($"TOURNAMENT    {ID}");
-      Console.WriteLine($"  Game Pairs: {NumGamePairs} ");
-      Console.WriteLine($"  Openings  : {OpeningsDescription()}");
-      Console.WriteLine($"  Adjudicate: {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp"
-                     + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}");
-      Console.WriteLine($"  Player 1  : {Player1Def} ");
-      Console.WriteLine($"  Player 2  : {Player2Def} ");
+        public TournamentDef(string id, EnginePlayerDef player1Def, EnginePlayerDef player2Def)
+        {
+            ID = id;
+            Player1Def = player1Def ?? throw new ArgumentNullException(nameof(player1Def));
+            Player2Def = player2Def ?? throw new ArgumentNullException(nameof(player2Def));
+            StartTime = DateTime.Now;
+
+            if (object.ReferenceEquals(player1Def, player2Def))
+            {
+                throw new Exception("player1Def must be different from player2Def");
+            }
+        }
+
+        public TournamentDef(string id, List<EnginePlayerDef> engines)
+        {
+            ID = id;
+            engines.ForEach(engine => Engines.Add(engine));
+            StartTime = DateTime.Now;
+
+            foreach (var engine in Engines)
+            {
+                if (engines.Where(e=>e != engine).Any(e => object.ReferenceEquals(engine,e)))
+                {
+                    throw new Exception("playerDef must be different from each other");
+                }
+            }            
+        }
 
 
-      if (Player1Def.EngineDef is GameEngineDefCeres &&
-        Player2Def.EngineDef is GameEngineDefCeres)
-        (Player1Def.EngineDef as GameEngineDefCeres).DumpComparison(Console.Out, Player2Def.EngineDef as GameEngineDefCeres, true);
-      Console.WriteLine();
+        public TournamentDef Clone()
+        {
+            TournamentDef clone = ObjUtils.DeepClone<TournamentDef>(this);
+            clone.Logger = this.Logger;
+            return clone;
+        }
+
+
+        public void DumpParams()
+        {
+            Console.WriteLine($"TOURNAMENT    {ID}");
+            Console.WriteLine($"  Game Pairs: {NumGamePairs} ");
+            Console.WriteLine($"  Openings  : {OpeningsDescription()}");
+            Console.WriteLine($"  Adjudicate: {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp"
+                           + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}");
+            Console.WriteLine($"  Player 1  : {Player1Def} ");
+            Console.WriteLine($"  Player 2  : {Player2Def} ");
+
+
+            //if (Player1Def.EngineDef is GameEngineDefCeres &&
+            //  Player2Def.EngineDef is GameEngineDefCeres)
+            //    (Player1Def.EngineDef as GameEngineDefCeres).DumpComparison(Console.Out, Player2Def.EngineDef as GameEngineDefCeres, true);
+            Console.WriteLine();
 #if NOT
       ParamsDump.DumpParams(Console.Out, true,
                  UCIEngine1Spec, UCIEngine2Spec,
@@ -158,28 +176,28 @@ namespace Ceres.Features.Tournaments
                  SearchParams1.Execution, SearchParams2.Execution
                  );
 #endif
-    }
+        }
 
-    /// <summary>
-    /// Returns string summary.
-    /// </summary>
-    /// <returns></returns>
-    public override string ToString()
-    {
-      string openingsInfo = OpeningsDescription();
+        /// <summary>
+        /// Returns string summary.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            string openingsInfo = OpeningsDescription();
 
-      return $"<TournamentDef {ID} with {NumGamePairs} game pairs from "
-           + $"{openingsInfo} {(RandomizeOpenings ? " Randomized" : "")} "
-           + $" adjudicate {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp "
-           + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}"
-           + $"{Player1Def} vs {Player2Def}"
-           + ">";
-    }
+            return $"<TournamentDef {ID} with {NumGamePairs} game pairs from "
+                 + $"{openingsInfo} {(RandomizeOpenings ? " Randomized" : "")} "
+                 + $" adjudicate {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp "
+                 + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}"
+                 + $"{Player1Def} vs {Player2Def}"
+                 + ">";
+        }
 
-    private string OpeningsDescription()
-    {
-      string openingsInfo = StartingFEN != null ? StartingFEN : OpeningsFileName;
-      return openingsInfo;
+        private string OpeningsDescription()
+        {
+            string openingsInfo = StartingFEN != null ? StartingFEN : OpeningsFileName;
+            return openingsInfo;
+        }
     }
-  }
 }

--- a/src/Ceres.Features/Tournaments/TournamentDef.cs
+++ b/src/Ceres.Features/Tournaments/TournamentDef.cs
@@ -56,7 +56,7 @@ namespace Ceres.Features.Tournaments
     /// <summary>
     /// List of engines in the tournament
     /// </summary>
-    public List<EnginePlayerDef> Engines { get; set; } = new List<EnginePlayerDef>();
+    public EnginePlayerDef[] Engines { get; set; }
 
     /// <summary>
     /// Definition of the first player engine.
@@ -120,18 +120,18 @@ namespace Ceres.Features.Tournaments
     /// </summary>
     public readonly DateTime StartTime;
 
-    public TournamentDef(string id, List<EnginePlayerDef> engines)
+    public TournamentDef(string id, params EnginePlayerDef[] engines)
     {
-      if (engines.Count < 2)
+      if (engines.Length < 2)
       {
         throw new ArgumentNullException("A tournament must have 2 or more players");
       }
 
       ID = id;
-      engines.ForEach(engine => Engines.Add(engine));
+      Engines = engines;
       StartTime = DateTime.Now;
 
-      foreach (var engine in Engines)
+      foreach (EnginePlayerDef engine in Engines)
       {
         if (engines.Where(e => e != engine).Any(e => object.ReferenceEquals(engine, e)))
         {
@@ -149,7 +149,7 @@ namespace Ceres.Features.Tournaments
 
     public void DumpParams()
     {
-      var refEngine = String.IsNullOrEmpty(ReferenceEngineId) ? "None" : ReferenceEngineId;
+      string refEngine = String.IsNullOrEmpty(ReferenceEngineId) ? "None" : ReferenceEngineId;
       Console.WriteLine($"TOURNAMENT:  {ID}");
       Console.WriteLine($"  Game Pairs : {NumGamePairs} ");
       Console.WriteLine($"  Openings   : {OpeningsDescription()}");
@@ -157,23 +157,23 @@ namespace Ceres.Features.Tournaments
       Console.WriteLine($"  Adjudicate : {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp"
                      + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}");
 
-      for (int i = 0; i < Engines.Count; i++)
+      for (int i = 0; i < Engines.Length; i++)
       {
         Console.WriteLine($"  Player {i + 1} : {Engines[i]}");
       }
 
       //Check if we need to dump comparison info too
-      var ceresEngines =
+      IEnumerable<GameEngineDefCeres> ceresEngines =
           Engines
           .Where(e => e.EngineDef is GameEngineDefCeres)
           .Select(e => e.EngineDef as GameEngineDefCeres);
 
       if (ceresEngines.Count() > 1)
       {
-        var toCompare = ceresEngines.First();
+        GameEngineDefCeres toCompare = ceresEngines.First();
 
         //dump pairs here
-        foreach (var engine in ceresEngines.Skip(1))
+        foreach (GameEngineDefCeres engine in ceresEngines.Skip(1))
         {
           toCompare.DumpComparison(Console.Out, engine, true);
         }

--- a/src/Ceres.Features/Tournaments/TournamentDef.cs
+++ b/src/Ceres.Features/Tournaments/TournamentDef.cs
@@ -26,155 +26,160 @@ using Ceres.Features.Players;
 
 namespace Ceres.Features.Tournaments
 {
+  /// <summary>
+  /// Defines the parameters of a tournament between chess engines.
+  /// </summary>
+  [Serializable]
+  public class TournamentDef
+  {
     /// <summary>
-    /// Defines the parameters of a tournament between chess engines.
+    /// Descriptive identifying string of tournament.
     /// </summary>
-    [Serializable]
-    public class TournamentDef
+    public string ID;
+
+    /// <summary>
+    /// The reference engine used in tournaments
+    /// </summary>
+    public string ReferenceEngineId = null;
+
+    /// <summary>
+    /// Optional number of game pairs to run (opponents play both sides in a pair).
+    /// If not specified, one game pair is run for each specified opening position.
+    /// </summary>
+    public int? NumGamePairs;
+
+    /// <summary>
+    /// Target for logging messages.
+    /// </summary>
+    [NonSerialized] public TextWriter Logger = Console.Out;
+
+    /// <summary>
+    /// List of engines in the tournament
+    /// </summary>
+    public List<EnginePlayerDef> Engines { get; set; } = new List<EnginePlayerDef>();
+
+    /// <summary>
+    /// Definition of the first player engine.
+    /// </summary>
+    public EnginePlayerDef Player1Def;
+
+    /// <summary>
+    /// Definition of the second player engine.
+    /// </summary>
+    public EnginePlayerDef Player2Def;
+
+    /// <summary>
+    /// Optinal definition of engine used to check moves of second player.
+    /// </summary>
+    public EnginePlayerDef CheckPlayer2Def;
+
+    /// <summary>
+    /// If each move in each game should be output to the log/console.
+    /// </summary>
+    public bool ShowGameMoves = true;
+
+    /// <summary>
+    /// Name PGN or EPD file containing set of starting positions to be used.
+    /// If null then chess start position is used for every game.
+    /// The user setting "DirPGN" is consulted to determine the source directory.
+    /// </summary>
+    public string OpeningsFileName;
+
+    /// <summary>
+    /// Starting position for the games (unless OpeningsFileName is specified).
+    /// Defaults to the chess start position is used for every game.
+    /// </summary>
+    public string StartingFEN = null;
+
+    /// <summary>
+    /// If the order of the openings from the book should be randomized.
+    /// </summary>
+    public bool RandomizeOpenings = false;
+
+    /// <summary>
+    /// If tablebases should be consulted for adjudication purposes.
+    /// </summary>
+    public bool UseTablebasesForAdjudication = true;
+
+    /// <summary>
+    /// Minimum absolute evaluation (in centipawns)
+    /// which must be exceeded by both engines
+    /// for a win to be declared by adjudication.
+    /// </summary>
+    public int AdjudicationThresholdCentipawns = 350;
+
+
+    /// <summary>
+    /// Minimum number of moves for which both engines evaluations
+    /// must be more extreme than AdjudicationThresholdCentipawns.
+    /// </summary>
+    public int AdjudicationThresholdNumMoves = 2;
+
+    /// <summary>
+    /// Creation time of tournament (use as a unique ID for generating PGN)
+    /// </summary>
+    public readonly DateTime StartTime;
+
+    public TournamentDef(string id, List<EnginePlayerDef> engines)
     {
-        /// <summary>
-        /// Descriptive identifying string of tournament.
-        /// </summary>
-        public string ID;
+      if (engines.Count < 2)
+      {
+        throw new ArgumentNullException("A tournament must have 2 or more players");
+      }
 
-        /// <summary>
-        /// Optional number of game pairs to run (opponents play both sides in a pair).
-        /// If not specified, one game pair is run for each specified opening position.
-        /// </summary>
-        public int? NumGamePairs;
+      ID = id;
+      engines.ForEach(engine => Engines.Add(engine));
+      StartTime = DateTime.Now;
 
-        /// <summary>
-        /// Target for logging messages.
-        /// </summary>
-        [NonSerialized] public TextWriter Logger = Console.Out;
-
-        public List<EnginePlayerDef> Engines { get; set; } = new List<EnginePlayerDef>();
-
-        /// <summary>
-        /// Definition of the first player engine.
-        /// </summary>
-        public EnginePlayerDef Player1Def;
-
-        /// <summary>
-        /// Definition of the second player engine.
-        /// </summary>
-        public EnginePlayerDef Player2Def;
-
-        /// <summary>
-        /// Optinal definition of engine used to check moves of second player.
-        /// </summary>
-        public EnginePlayerDef CheckPlayer2Def;
-
-        /// <summary>
-        /// If each move in each game should be output to the log/console.
-        /// </summary>
-        public bool ShowGameMoves = true;
-
-        /// <summary>
-        /// Name PGN or EPD file containing set of starting positions to be used.
-        /// If null then chess start position is used for every game.
-        /// The user setting "DirPGN" is consulted to determine the source directory.
-        /// </summary>
-        public string OpeningsFileName;
-
-        /// <summary>
-        /// Starting position for the games (unless OpeningsFileName is specified).
-        /// Defaults to the chess start position is used for every game.
-        /// </summary>
-        public string StartingFEN = null;
-
-        /// <summary>
-        /// If the order of the openings from the book should be randomized.
-        /// </summary>
-        public bool RandomizeOpenings = false;
-
-        /// <summary>
-        /// If tablebases should be consulted for adjudication purposes.
-        /// </summary>
-        public bool UseTablebasesForAdjudication = true;
-
-        /// <summary>
-        /// Minimum absolute evaluation (in centipawns)
-        /// which must be exceeded by both engines
-        /// for a win to be declared by adjudication.
-        /// </summary>
-        public int AdjudicationThresholdCentipawns = 350;
-
-
-        /// <summary>
-        /// Minimum number of moves for which both engines evaluations
-        /// must be more extreme than AdjudicationThresholdCentipawns.
-        /// </summary>
-        public int AdjudicationThresholdNumMoves = 2;
-
-        /// <summary>
-        /// Creation time of tournament (use as a unique ID for generating PGN)
-        /// </summary>
-        public readonly DateTime StartTime;
-
-
-        public TournamentDef(string id, EnginePlayerDef player1Def, EnginePlayerDef player2Def)
+      foreach (var engine in Engines)
+      {
+        if (engines.Where(e => e != engine).Any(e => object.ReferenceEquals(engine, e)))
         {
-            ID = id;
-            Player1Def = player1Def ?? throw new ArgumentNullException(nameof(player1Def));
-            Player2Def = player2Def ?? throw new ArgumentNullException(nameof(player2Def));
-            StartTime = DateTime.Now;
-
-            if (object.ReferenceEquals(player1Def, player2Def))
-            {
-                throw new Exception("player1Def must be different from player2Def");
-            }
+          throw new Exception("playerDef must be different from each other");
         }
+      }
+    }
 
-        public TournamentDef(string id, List<EnginePlayerDef> engines)
+    public TournamentDef Clone()
+    {
+      TournamentDef clone = ObjUtils.DeepClone<TournamentDef>(this);
+      clone.Logger = this.Logger;
+      return clone;
+    }
+
+    public void DumpParams()
+    {
+      var refEngine = String.IsNullOrEmpty(ReferenceEngineId) ? "None" : ReferenceEngineId;
+      Console.WriteLine($"TOURNAMENT:  {ID}");
+      Console.WriteLine($"  Game Pairs : {NumGamePairs} ");
+      Console.WriteLine($"  Openings   : {OpeningsDescription()}");
+      Console.WriteLine($"  Ref engine : {refEngine}");
+      Console.WriteLine($"  Adjudicate : {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp"
+                     + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}");
+
+      for (int i = 0; i < Engines.Count; i++)
+      {
+        Console.WriteLine($"  Player {i + 1} : {Engines[i]}");
+      }
+
+      //Check if we need to dump comparison info too
+      var ceresEngines =
+          Engines
+          .Where(e => e.EngineDef is GameEngineDefCeres)
+          .Select(e => e.EngineDef as GameEngineDefCeres);
+
+      if (ceresEngines.Count() > 1)
+      {
+        var toCompare = ceresEngines.First();
+
+        //dump pairs here
+        foreach (var engine in ceresEngines.Skip(1))
         {
-            ID = id;
-            engines.ForEach(engine => Engines.Add(engine));
-            StartTime = DateTime.Now;
-
-            foreach (var engine in Engines)
-            {
-                if (engines.Where(e => e != engine).Any(e => object.ReferenceEquals(engine, e)))
-                {
-                    throw new Exception("playerDef must be different from each other");
-                }
-            }
+          toCompare.DumpComparison(Console.Out, engine, true);
         }
+      }
 
-
-        public TournamentDef Clone()
-        {
-            TournamentDef clone = ObjUtils.DeepClone<TournamentDef>(this);
-            clone.Logger = this.Logger;
-            return clone;
-        }
-
-
-        public void DumpParams()
-        {
-            Console.WriteLine($"TOURNAMENT:  {ID}");
-            Console.WriteLine($"  Game Pairs: {NumGamePairs} ");
-            Console.WriteLine($"  Openings  : {OpeningsDescription()}");
-            Console.WriteLine($"  Adjudicate: {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp"
-                           + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}");
-            if (Engines.Count > 0)
-            {
-                for (int i = 0; i < Engines.Count; i++)
-                {
-                    Console.WriteLine($"  Player {i + 1} : {Engines[i]}");
-                }
-            }
-            else
-            {
-                Console.WriteLine($"  Player 1  : {Player1Def} ");
-                Console.WriteLine($"  Player 2  : {Player2Def} ");
-            }
-
-
-            //if (Player1Def.EngineDef is GameEngineDefCeres &&
-            //  Player2Def.EngineDef is GameEngineDefCeres)
-            //    (Player1Def.EngineDef as GameEngineDefCeres).DumpComparison(Console.Out, Player2Def.EngineDef as GameEngineDefCeres, true);
-            Console.WriteLine();
+      Console.WriteLine();
 #if NOT
       ParamsDump.DumpParams(Console.Out, true,
                  UCIEngine1Spec, UCIEngine2Spec,
@@ -186,28 +191,28 @@ namespace Ceres.Features.Tournaments
                  SearchParams1.Execution, SearchParams2.Execution
                  );
 #endif
-        }
-
-        /// <summary>
-        /// Returns string summary.
-        /// </summary>
-        /// <returns></returns>
-        public override string ToString()
-        {
-            string openingsInfo = OpeningsDescription();
-
-            return $"<TournamentDef {ID} with {NumGamePairs} game pairs from "
-                 + $"{openingsInfo} {(RandomizeOpenings ? " Randomized" : "")} "
-                 + $" adjudicate {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp "
-                 + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}"
-                 + $"{Player1Def} vs {Player2Def}"
-                 + ">";
-        }
-
-        private string OpeningsDescription()
-        {
-            string openingsInfo = StartingFEN != null ? StartingFEN : OpeningsFileName;
-            return openingsInfo;
-        }
     }
+
+    /// <summary>
+    /// Returns string summary.
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString()
+    {
+      string openingsInfo = OpeningsDescription();
+
+      return $"<TournamentDef {ID} with {NumGamePairs} game pairs from "
+           + $"{openingsInfo} {(RandomizeOpenings ? " Randomized" : "")} "
+           + $" adjudicate {AdjudicationThresholdNumMoves} moves at {AdjudicationThresholdCentipawns}cp "
+           + $"{(UseTablebasesForAdjudication ? " or via tablebases" : "")}"
+           + $"{Player1Def} vs {Player2Def}"
+           + ">";
+    }
+
+    private string OpeningsDescription()
+    {
+      string openingsInfo = StartingFEN != null ? StartingFEN : OpeningsFileName;
+      return openingsInfo;
+    }
+  }
 }

--- a/src/Ceres.Features/Tournaments/TournamentGameRunner.cs
+++ b/src/Ceres.Features/Tournaments/TournamentGameRunner.cs
@@ -57,22 +57,13 @@ namespace Ceres.Features.Tournaments
         /// <param name="def"></param>
         public TournamentGameRunner(TournamentDef def)
         {
-            Def = def;
-
+            Def = def;            
             foreach (var engine in Def.Engines)
             {
                 Engines.Add(engine.EngineDef.CreateEngine());
             }
-
-            //if (Def.Engines.Count > 0)
-            //{
-            //    var first = Def.Engines[0];
-            //    var rest = Def.Engines.Skip(1);
-            //    foreach (var engine in rest)
-            //    {
-
-            //    }                
-            //}
+            
+            Parallel.Invoke(() => Engines.ForEach(e => e.Warmup()));
 
             // Create and warmup both engines (in parallel)
             if (Def.Engines.Count == 0)
@@ -94,8 +85,8 @@ namespace Ceres.Features.Tournaments
         public void CreateAndPrepareEngines(int gameEngine1Index, int gameEngine2Index)
         {
             // Create and warmup both engines (in parallel)
-            Parallel.Invoke(() => { Engine1 = Engines[gameEngine1Index]; Engine1.Warmup(Def.Engines[gameEngine1Index].SearchLimit.KnownMaxNumNodes); },
-                      () => { Engine2 = Engines[gameEngine2Index]; Engine2.Warmup(Def.Engines[gameEngine2Index].SearchLimit.KnownMaxNumNodes); });
+            Parallel.Invoke(() => { Engine1 = Engines[gameEngine1Index]; },
+                      () => { Engine2 = Engines[gameEngine2Index]; });
 
             if (Def.CheckPlayer2Def != null)
             {

--- a/src/Ceres.Features/Tournaments/TournamentGameRunner.cs
+++ b/src/Ceres.Features/Tournaments/TournamentGameRunner.cs
@@ -23,83 +23,73 @@ using Ceres.Chess.GameEngines;
 
 namespace Ceres.Features.Tournaments
 {
+  /// <summary>
+  /// Manages execution of a tournament (match between two players).
+  /// </summary>
+  public class TournamentGameRunner
+  {
     /// <summary>
-    /// Manages execution of a tournament (match between two players).
+    /// Parent tournament definition.
     /// </summary>
-    public class TournamentGameRunner
+    public readonly TournamentDef Def;
+
+    /// <summary>
+    /// Instance of first engine.
+    /// </summary>
+    public GameEngine Engine1;
+
+    /// <summary>
+    /// Instance of second engine.
+    /// </summary>
+    public GameEngine Engine2;
+
+    /// <summary>
+    /// Instance of optional "check" engine against which
+    /// the moves of engine 2 are compared.
+    /// </summary>
+    public GameEngine Engine2CheckEngine;
+
+    /// <summary>
+    /// List of game engines in tournament
+    /// </summary>
+    public List<GameEngine> Engines { get; set; } = new List<GameEngine>();
+
+    /// <summary>
+    /// Constructor from a given tournament defintion.
+    /// </summary>
+    /// <param name="def"></param>
+    public TournamentGameRunner(TournamentDef def)
     {
-        /// <summary>
-        /// Parent tournament definition.
-        /// </summary>
-        public readonly TournamentDef Def;
+      Def = def;
 
-        /// <summary>
-        /// Instance of first engine.
-        /// </summary>
-        public GameEngine Engine1;
+      // Create and warmup both engines (in parallel)            
+      Parallel.Invoke(() => Def.Engines.ForEach(engine => Engines.Add(engine.EngineDef.CreateEngine())));
+      Parallel.Invoke(() => Engines.ForEach(e => e.Warmup()));
+    }
 
-        /// <summary>
-        /// Instance of second engine.
-        /// </summary>
-        public GameEngine Engine2;
 
-        /// <summary>
-        /// Instance of optional "check" engine against which
-        /// the moves of engine 2 are compared.
-        /// </summary>
-        public GameEngine Engine2CheckEngine;
+    /// <summary>
+    /// Pairing engines based on index in Engines list. Useful for Round Robin tournaments
+    /// </summary>
+    /// <param name="gameEngine1Index"></param>
+    /// <param name="gameEngine2Index"></param>
+    public void SetEnginePair(int gameEngine1Index, int gameEngine2Index)
+    {
+      Engine1 = Engines[gameEngine1Index];
+      Engine2 = Engines[gameEngine2Index];
 
-        public List<GameEngine> Engines { get; set; } = new List<GameEngine>();
+      if (Def.CheckPlayer2Def != null)
+      {
+        Engine2CheckEngine = Def.CheckPlayer2Def.EngineDef.CreateEngine();
+        Engine2CheckEngine.Warmup(Def.CheckPlayer2Def.SearchLimit.KnownMaxNumNodes);
+      }
 
-        /// <summary>
-        /// Constructor from a given tournament defintion.
-        /// </summary>
-        /// <param name="def"></param>
-        public TournamentGameRunner(TournamentDef def)
-        {
-            Def = def;            
-            foreach (var engine in Def.Engines)
-            {
-                Engines.Add(engine.EngineDef.CreateEngine());
-            }
-            
-            Parallel.Invoke(() => Engines.ForEach(e => e.Warmup()));
+      Engine1.OpponentEngine = Engine2;
+      Engine2.OpponentEngine = Engine1;
+      Def.Player1Def = Def.Engines[gameEngine1Index];
+      Def.Player2Def = Def.Engines[gameEngine2Index];
 
-            // Create and warmup both engines (in parallel)
-            if (Def.Engines.Count == 0)
-            {
-                Parallel.Invoke(() => { Engine1 = def.Player1Def.EngineDef.CreateEngine(); Engine1.Warmup(def.Player1Def.SearchLimit.KnownMaxNumNodes); },
-                          () => { Engine2 = def.Player2Def.EngineDef.CreateEngine(); Engine2.Warmup(def.Player2Def.SearchLimit.KnownMaxNumNodes); });
-
-                if (def.CheckPlayer2Def != null)
-                {
-                    Engine2CheckEngine = def.CheckPlayer2Def.EngineDef.CreateEngine();
-                    Engine2CheckEngine.Warmup(def.CheckPlayer2Def.SearchLimit.KnownMaxNumNodes);
-                }
-
-                Engine1.OpponentEngine = Engine2;
-                Engine2.OpponentEngine = Engine1;
-            }
-        }
-
-        public void CreateAndPrepareEngines(int gameEngine1Index, int gameEngine2Index)
-        {
-            // Create and warmup both engines (in parallel)
-            Parallel.Invoke(() => { Engine1 = Engines[gameEngine1Index]; },
-                      () => { Engine2 = Engines[gameEngine2Index]; });
-
-            if (Def.CheckPlayer2Def != null)
-            {
-                Engine2CheckEngine = Def.CheckPlayer2Def.EngineDef.CreateEngine();
-                Engine2CheckEngine.Warmup(Def.CheckPlayer2Def.SearchLimit.KnownMaxNumNodes);
-            }
-
-            Engine1.OpponentEngine = Engine2;
-            Engine2.OpponentEngine = Engine1;
-            Def.Player1Def = Def.Engines[gameEngine1Index];
-            Def.Player2Def = Def.Engines[gameEngine2Index];
-
-        }
+    }
 
 #if NOT_USED
     static GameEngine GetEngine(GameEngineUCISpec engineSpec, string suffix, 
@@ -134,5 +124,5 @@ namespace Ceres.Features.Tournaments
     }
 #endif
 
-    }
+  }
 }

--- a/src/Ceres.Features/Tournaments/TournamentGameRunner.cs
+++ b/src/Ceres.Features/Tournaments/TournamentGameRunner.cs
@@ -52,7 +52,7 @@ namespace Ceres.Features.Tournaments
     /// <summary>
     /// List of game engines in tournament
     /// </summary>
-    public List<GameEngine> Engines { get; set; } = new List<GameEngine>();
+    public GameEngine[] Engines { get; set; }
 
     /// <summary>
     /// Constructor from a given tournament defintion.
@@ -62,9 +62,10 @@ namespace Ceres.Features.Tournaments
     {
       Def = def;
 
-      // Create and warmup both engines (in parallel)            
-      Parallel.Invoke(() => Def.Engines.ForEach(engine => Engines.Add(engine.EngineDef.CreateEngine())));
-      Parallel.Invoke(() => Engines.ForEach(e => e.Warmup()));
+      // Create and warmup all engines (in parallel).
+      Engines = new GameEngine[Def.Engines.Length];
+      Parallel.For(0, Def.Engines.Length, i => Engines[i] = Def.Engines[i].EngineDef.CreateEngine());
+      Parallel.ForEach(Engines, e => e.Warmup());
     }
 
 

--- a/src/Ceres.Features/Tournaments/TournamentGameRunner.cs
+++ b/src/Ceres.Features/Tournaments/TournamentGameRunner.cs
@@ -58,7 +58,7 @@ namespace Ceres.Features.Tournaments
         public TournamentGameRunner(TournamentDef def)
         {
             Def = def;
-            
+
             foreach (var engine in Def.Engines)
             {
                 Engines.Add(engine.EngineDef.CreateEngine());
@@ -74,18 +74,21 @@ namespace Ceres.Features.Tournaments
             //    }                
             //}
 
-            //// Create and warmup both engines (in parallel)
-            //Parallel.Invoke(() => { Engine1 = def.Player1Def.EngineDef.CreateEngine(); Engine1.Warmup(def.Player1Def.SearchLimit.KnownMaxNumNodes); },
-            //          () => { Engine2 = def.Player2Def.EngineDef.CreateEngine(); Engine2.Warmup(def.Player2Def.SearchLimit.KnownMaxNumNodes); });
+            // Create and warmup both engines (in parallel)
+            if (Def.Engines.Count == 0)
+            {
+                Parallel.Invoke(() => { Engine1 = def.Player1Def.EngineDef.CreateEngine(); Engine1.Warmup(def.Player1Def.SearchLimit.KnownMaxNumNodes); },
+                          () => { Engine2 = def.Player2Def.EngineDef.CreateEngine(); Engine2.Warmup(def.Player2Def.SearchLimit.KnownMaxNumNodes); });
 
-            //if (def.CheckPlayer2Def != null)
-            //{
-            //    Engine2CheckEngine = def.CheckPlayer2Def.EngineDef.CreateEngine();
-            //    Engine2CheckEngine.Warmup(def.CheckPlayer2Def.SearchLimit.KnownMaxNumNodes);
-            //}
+                if (def.CheckPlayer2Def != null)
+                {
+                    Engine2CheckEngine = def.CheckPlayer2Def.EngineDef.CreateEngine();
+                    Engine2CheckEngine.Warmup(def.CheckPlayer2Def.SearchLimit.KnownMaxNumNodes);
+                }
 
-            //Engine1.OpponentEngine = Engine2;
-            //Engine2.OpponentEngine = Engine1;
+                Engine1.OpponentEngine = Engine2;
+                Engine2.OpponentEngine = Engine1;
+            }
         }
 
         public void CreateAndPrepareEngines(int gameEngine1Index, int gameEngine2Index)
@@ -104,7 +107,7 @@ namespace Ceres.Features.Tournaments
             Engine2.OpponentEngine = Engine1;
             Def.Player1Def = Def.Engines[gameEngine1Index];
             Def.Player2Def = Def.Engines[gameEngine2Index];
-            
+
         }
 
 #if NOT_USED

--- a/src/Ceres.Features/Tournaments/TournamentGameThread.cs
+++ b/src/Ceres.Features/Tournaments/TournamentGameThread.cs
@@ -113,7 +113,7 @@ namespace Ceres.Features.Tournaments
 
       // Create a file name that will be common to all threads in tournament.
       string pgnFileName;
-      if (Run.Engines.Count > 2)
+      if (Run.Engines.Length > 2)
       {
         pgnFileName = Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "match_" + Def.ID + "_"
                                     + "MultiEngine" + "_" + Def.StartTime.Ticks + ".pgn");
@@ -165,7 +165,7 @@ namespace Ceres.Features.Tournaments
 
         if (string.IsNullOrEmpty(Def.ReferenceEngineId))
         {
-          var list = new List<GameEngine>(Run.Engines);
+          List<GameEngine> list = new List<GameEngine>(Run.Engines);
           int engine1Index = 0;
           while (list.Count > 1)
           {
@@ -185,15 +185,17 @@ namespace Ceres.Features.Tournaments
 
         else
         {
-          var refEngine = Run.Engines.FirstOrDefault(e => e.ID == Def.ReferenceEngineId);
+          GameEngine refEngine = Run.Engines.FirstOrDefault(e => e.ID == Def.ReferenceEngineId);
           if (refEngine == null)
             throw new Exception("Error in loading reference engine");
-          var index = Run.Engines.IndexOf(refEngine);
-          for (int i = 0; i < Run.Engines.Count; i++)
+          int index =  Array.IndexOf(Run.Engines, refEngine);
+          for (int i = 0; i < Run.Engines.Length; i++)
           {
             if (index == i)
+            {
               continue;
-            var engineToPair = Run.Engines[i];
+            }
+            GameEngine engineToPair = Run.Engines[i];
             Run.SetEnginePair(index, i);
             TournamentGameInfo gameInfo = RunGame(pgnFileName, engine2White, openingIndex, gameSequenceNum, roundNumber);
             TournamentGameInfo gameReverseInfo = RunGame(pgnFileName, !engine2White, openingIndex, gameSequenceNum + 1, roundNumber);
@@ -203,7 +205,7 @@ namespace Ceres.Features.Tournaments
         }
       }
 
-      foreach (var engine in Run.Engines)
+      foreach (GameEngine engine in Run.Engines)
       {
         engine.Dispose();
         Run.Engine2CheckEngine?.Dispose();
@@ -265,7 +267,7 @@ namespace Ceres.Features.Tournaments
 
       // Add some supplemental tags with round number and also
       // information about Ceres engine configuration.
-      var extraTags = GetSupplementalTags(engine2White);
+      List<(string name, string value)> extraTags = GetSupplementalTags(engine2White);
       extraTags.Add(("Round", roundNumber.ToString()));
 
       PGNWriter pgnWriter = new PGNWriter(null, engine2White ? Run.Engine2.ID : Run.Engine1.ID,
@@ -326,10 +328,10 @@ namespace Ceres.Features.Tournaments
 
     private void OutputGameResultInfo(bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
     {
-      var engineStat = engine2White ?
+      TournamentResultStats engineStat = engine2White ?
                           ParentStats.GetResultsForPlayer(Run.Engine2.ID, Run.Engine1.ID)
                           : ParentStats.GetResultsForPlayer(Run.Engine1.ID, Run.Engine2.ID);
-      var gNumber = NumGames + 1;
+      float gNumber = NumGames + 1;
       (float eloMin, float eloAvg, float eloMax) = EloCalculator.EloConfidenceInterval(engineStat.Player1Wins, engineStat.Draws, engineStat.Player1Losses);
       float eloSD = eloMax - eloAvg;
       float los = EloCalculator.LikelihoodSuperiority(engineStat.Player1Wins, engineStat.Draws, engineStat.Player1Losses);

--- a/src/Ceres.Features/Tournaments/TournamentGameThread.cs
+++ b/src/Ceres.Features/Tournaments/TournamentGameThread.cs
@@ -33,219 +33,220 @@ using System.Linq;
 
 namespace Ceres.Features.Tournaments
 {
+  /// <summary>
+  /// Manage execution of a single thread of a tournament,
+  /// running the main move loop which alternates between players.
+  /// </summary>
+  public class TournamentGameThread
+  {
+    public delegate TournamentGameInfo GamePairRunnerDelegate(string pgnFileName, int gameSequenceNum, int openingIndex, int roundNumber, bool engine2White);
+
     /// <summary>
-    /// Manage execution of a single thread of a tournament,
-    /// running the main move loop which alternates between players.
+    /// Definition of associated parent tournament definition.
     /// </summary>
-    public class TournamentGameThread
+    public readonly TournamentDef Def;
+
+    /// <summary>
+    /// Collection of tournament result statistics.
+    /// </summary>
+    public readonly TournamentResultStats ParentStats;
+
+    // TODO: This is not correct to be static in the case that 
+    //       multiple tournaments are being run simultaneously.
+    static bool havePrintedHeaders = false;
+
+
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="def"></param>
+    /// <param name="parentTestResults"></param>
+    public TournamentGameThread(TournamentDef def, TournamentResultStats parentTestResults)
     {
-        public delegate TournamentGameInfo GamePairRunnerDelegate(string pgnFileName, int gameSequenceNum, int openingIndex, int roundNumber, bool engine2White);
-
-        /// <summary>
-        /// Definition of associated parent tournament definition.
-        /// </summary>
-        public readonly TournamentDef Def;
-
-        /// <summary>
-        /// Collection of tournament result statistics.
-        /// </summary>
-        public readonly TournamentResultStats ParentStats;
-
-        // TODO: This is not correct to be static in the case that 
-        //       multiple tournaments are being run simultaneously.
-        static bool havePrintedHeaders = false;
+      Def = def;
+      ParentStats = parentTestResults;
+    }
 
 
+    static PositionsWithHistory openings = new PositionsWithHistory();
 
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="def"></param>
-        /// <param name="parentTestResults"></param>
-        public TournamentGameThread(TournamentDef def, TournamentResultStats parentTestResults)
+    static object writePGNLock = new();
+
+    public long TotalNodesEngine1 = 0;
+    public long TotalNodesEngine2 = 0;
+    public int TotalMovesEngine1 = 0;
+    public int TotalMovesEngine2 = 0;
+    public float TotalTimeEngine1 = 0;
+    public float TotalTimeEngine2 = 0;
+    public float NumGames;
+
+
+    public TournamentGameRunner Run;
+
+    int numGamePairsLaunched = 0;
+    readonly object lockObj = new();
+
+    /// <summary>
+    /// Method called by threads to get the next available game to be played.
+    /// </summary>
+    /// <returns></returns>
+    int GetNextOpeningIndexForLocalThread(int maxOpenings)
+    {
+      if (Def.RandomizeOpenings) throw new NotImplementedException();
+
+      lock (lockObj)
+      {
+        if (numGamePairsLaunched < maxOpenings)
         {
-            Def = def;
-            ParentStats = parentTestResults;
+          return numGamePairsLaunched++;
         }
+        else
+          return -1;
+      }
+    }
 
+    public void RunGameTests(int runnerIndex, Func<int> getGamePairToProcess,
+                             Action<TournamentGameInfo, TournamentGameInfo> doneGamePairCallback = null)
+    {
+      Run = new TournamentGameRunner(Def);
 
-        static PositionsWithHistory openings = new PositionsWithHistory();
+      // Create a file name that will be common to all threads in tournament.
+      string pgnFileName;
+      if (Run.Engines.Count > 2)
+      {
+        pgnFileName = Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "match_" + Def.ID + "_"
+                                    + "MultiEngine" + "_" + Def.StartTime.Ticks + ".pgn");
+      }
+      else
+      {
+        pgnFileName = Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "match_" + Def.ID + "_"
+                                    + Run.Engines[0].ID + "_" + Run.Engines[1].ID + "_" + Def.StartTime.Ticks + ".pgn");
+      }
+      lock (writePGNLock) File.AppendAllText(pgnFileName, "");
 
-        static object writePGNLock = new();
+      havePrintedHeaders = false;
 
-        public long TotalNodesEngine1 = 0;
-        public long TotalNodesEngine2 = 0;
-        public int TotalMovesEngine1 = 0;
-        public int TotalMovesEngine2 = 0;
-        public float TotalTimeEngine1 = 0;
-        public float TotalTimeEngine2 = 0;
-        public float NumGames;
-        
+      SetOpeningsSource();
 
-        public TournamentGameRunner Run;
+      Random rand = new Random();
 
-        int numGamePairsLaunched = 0;
-        readonly object lockObj = new();
+      // Def.Logger.WriteLine($"Begin {def.NumGames} game test with limit {def.SearchLimitEngine1} {def.SearchLimitEngine2} ID { gameSequenceNum } ");
+      int numPairsProcessed = 0;
 
-        /// <summary>
-        /// Method called by threads to get the next available game to be played.
-        /// </summary>
-        /// <returns></returns>
-        int GetNextOpeningIndexForLocalThread(int maxOpenings)
+      int maxOpenings = Math.Min(Def.NumGamePairs ?? int.MaxValue, openings.Count);
+
+      while (true)
+      {
+        int openingIndex = getGamePairToProcess();
+
+        // Look for sentinel indicating end
+        if (openingIndex < 0)
         {
-            if (Def.RandomizeOpenings) throw new NotImplementedException();
-
-            lock (lockObj)
-            {
-                if (numGamePairsLaunched < maxOpenings)
-                {
-                    return numGamePairsLaunched++;
-                }
-                else
-                    return -1;
-            }
+          break;
         }
-
-        public void RunGameTests(int runnerIndex, Func<int> getGamePairToProcess,
-                                 Action<TournamentGameInfo, TournamentGameInfo> doneGamePairCallback = null)
-        {
-            Run = new TournamentGameRunner(Def);
-
-            // Create a file name that will be common to all threads in tournament.
-            string pgnFileName;
-            if (Run.Engines.Count > 0)
-            {
-                pgnFileName = Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "match_" + Def.ID + "_"
-                                            + "MultiEngine" + "_" + Def.StartTime.Ticks + ".pgn");
-            }
-            else
-            {
-                pgnFileName = Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "match_" + Def.ID + "_"
-                                            + Run.Engine1.ID + "_" + Run.Engine2.ID + "_" + Def.StartTime.Ticks + ".pgn");
-            }
-            lock (writePGNLock) File.AppendAllText(pgnFileName, "");
-
-            havePrintedHeaders = false;
-
-            SetOpeningsSource();
-
-            Random rand = new Random();
-
-            // Def.Logger.WriteLine($"Begin {def.NumGames} game test with limit {def.SearchLimitEngine1} {def.SearchLimitEngine2} ID { gameSequenceNum } ");
-            int numPairsProcessed = 0;
-
-            int maxOpenings = Math.Min(Def.NumGamePairs ?? int.MaxValue, openings.Count);
-
-            while (true)
-            {
-                int openingIndex = getGamePairToProcess();
-
-                // Look for sentinel indicating end
-                if (openingIndex < 0)
-                {
-                    break;
-                }
 #if NOT
         // Some engines such as LZ0 doesn't seem to support "setoption name Clear Hash"
         // Therefore we don't clear cache every time, instead let it stick around unless first game in a set
         bool clearHashTable = isFirstGameOfPossiblePair;
 #endif
 
-                int gameSequenceNum = openingIndex * 2;
+        int gameSequenceNum = openingIndex * 2;
 
-                // The engine going second could possibly benefit 
-                // if REUSE_POSITION_EVALUATIONS_FROM_OTHER_TREE is true.
-                // Therefore we alternate each pair which one goes first.
-                int roundNumber = 1 + gameSequenceNum / 2;
+        // The engine going second could possibly benefit 
+        // if REUSE_POSITION_EVALUATIONS_FROM_OTHER_TREE is true.
+        // Therefore we alternate each pair which one goes first.
+        int roundNumber = 1 + gameSequenceNum / 2;
 
-                // Alternate which side gets white to avoid any clustered imbalance
-                // which could happen if multiple threads are active
-                // (possibly otherwise all first giving white to one particular side).
-                bool engine2White = (numPairsProcessed + runnerIndex) % 2 == 0;
+        // Alternate which side gets white to avoid any clustered imbalance
+        // which could happen if multiple threads are active
+        // (possibly otherwise all first giving white to one particular side).
+        bool engine2White = (numPairsProcessed + runnerIndex) % 2 == 0;
 
-                if (Run.Engines.Count > 0)
-                {
-                    var list = new List<GameEngine>(Run.Engines);
-                    int engine1Index = 0;
-                    while (list.Count > 1)
-                    {
-                        for (int i = 1; i < list.Count; i++)
-                        {
-                            Run.CreateAndPrepareEngines(engine1Index, i + engine1Index);
-
-                            TournamentGameInfo gameInfo = RunGame(pgnFileName, engine2White, openingIndex, gameSequenceNum, roundNumber);
-                            TournamentGameInfo gameReverseInfo = RunGame(pgnFileName, !engine2White, openingIndex, gameSequenceNum + 1, roundNumber);
-                            doneGamePairCallback?.Invoke(gameInfo, gameReverseInfo);
-                        }
-                        list.RemoveAt(0);
-                        engine1Index++;
-                    }
-                    numPairsProcessed++;
-                }
-
-                else
-                {
-
-                    TournamentGameInfo gameInfo = RunGame(pgnFileName, engine2White, openingIndex, gameSequenceNum, roundNumber);
-                    TournamentGameInfo gameReverseInfo = RunGame(pgnFileName, !engine2White, openingIndex, gameSequenceNum + 1, roundNumber);
-                    doneGamePairCallback?.Invoke(gameInfo, gameReverseInfo);
-                    numPairsProcessed++;
-                }
-            }
-
-            if (Run.Engines.Count > 0)
-            {
-                foreach (var engine in Run.Engines)
-                {
-                    engine.Dispose();
-                    Run.Engine2CheckEngine?.Dispose();
-                }
-            }
-            else
-            {
-                Run.Engine1.Dispose();
-                Run.Engine2.Dispose();
-                Run.Engine2CheckEngine?.Dispose();
-            }
-        }
-
-        private void SetOpeningsSource()
+        if (string.IsNullOrEmpty(Def.ReferenceEngineId))
         {
-            if (Def.OpeningsFileName != null)
+          var list = new List<GameEngine>(Run.Engines);
+          int engine1Index = 0;
+          while (list.Count > 1)
+          {
+            for (int i = 1; i < list.Count; i++)
             {
-                openings = PositionsWithHistory.FromEPDOrPGNFile(Def.OpeningsFileName);
+              Run.SetEnginePair(engine1Index, i + engine1Index);
+
+              TournamentGameInfo gameInfo = RunGame(pgnFileName, engine2White, openingIndex, gameSequenceNum, roundNumber);
+              TournamentGameInfo gameReverseInfo = RunGame(pgnFileName, !engine2White, openingIndex, gameSequenceNum + 1, roundNumber);
+              doneGamePairCallback?.Invoke(gameInfo, gameReverseInfo);
             }
-            else if (Def.StartingFEN != null)
-            {
-                openings = PositionsWithHistory.FromFEN(Def.StartingFEN, Def.NumGamePairs ?? 1);
-            }
-            else
-            {
-                openings = PositionsWithHistory.FromFEN(Position.StartPosition.FEN, Def.NumGamePairs ?? 1);
-            }
+            list.RemoveAt(0);
+            engine1Index++;
+          }
+          numPairsProcessed++;
         }
 
-
-        /// <summary>
-        /// Returns list of supplemental name/value tags to be 
-        /// included in the PGN header with helpful ancillary metadata.
-        /// </summary>
-        /// <param name="engine2White"></param>
-        /// <returns></returns>
-        List<(string name, string value)> GetSupplementalTags(bool engine2White)
+        else
         {
-            List<(string name, string value)> tags = new List<(string name, string value)>();
-
-            tags.Add((engine2White ? "BlackEngine" : "WhiteEngine", Def.Player1Def.EngineDef.ToString()));
-            tags.Add((engine2White ? "WhiteEngine" : "BlackEngine", Def.Player2Def.EngineDef.ToString()));
-            tags.Add(("CeresVersion", CeresVersion.VersionString));
-            tags.Add(("CeresGIT", GitInfo.VersionString));
-
-            return tags;
+          var refEngine = Run.Engines.FirstOrDefault(e => e.ID == Def.ReferenceEngineId);
+          if (refEngine == null)
+            throw new Exception("Error in loading reference engine");
+          var index = Run.Engines.IndexOf(refEngine);
+          for (int i = 0; i < Run.Engines.Count; i++)
+          {
+            if (index == i)
+              continue;
+            var engineToPair = Run.Engines[i];
+            Run.SetEnginePair(index, i);
+            TournamentGameInfo gameInfo = RunGame(pgnFileName, engine2White, openingIndex, gameSequenceNum, roundNumber);
+            TournamentGameInfo gameReverseInfo = RunGame(pgnFileName, !engine2White, openingIndex, gameSequenceNum + 1, roundNumber);
+            doneGamePairCallback?.Invoke(gameInfo, gameReverseInfo);
+          }
+          numPairsProcessed++;
         }
+      }
+
+      foreach (var engine in Run.Engines)
+      {
+        engine.Dispose();
+        Run.Engine2CheckEngine?.Dispose();
+      }
+    }
+
+    private void SetOpeningsSource()
+    {
+      if (Def.OpeningsFileName != null)
+      {
+        openings = PositionsWithHistory.FromEPDOrPGNFile(Def.OpeningsFileName);
+      }
+      else if (Def.StartingFEN != null)
+      {
+        openings = PositionsWithHistory.FromFEN(Def.StartingFEN, Def.NumGamePairs ?? 1);
+      }
+      else
+      {
+        openings = PositionsWithHistory.FromFEN(Position.StartPosition.FEN, Def.NumGamePairs ?? 1);
+      }
+    }
 
 
-        HashSet<int> openingsFinishedAtLeastOnce = new();
+    /// <summary>
+    /// Returns list of supplemental name/value tags to be 
+    /// included in the PGN header with helpful ancillary metadata.
+    /// </summary>
+    /// <param name="engine2White"></param>
+    /// <returns></returns>
+    List<(string name, string value)> GetSupplementalTags(bool engine2White)
+    {
+      List<(string name, string value)> tags = new List<(string name, string value)>();
+
+      tags.Add((engine2White ? "BlackEngine" : "WhiteEngine", Def.Player1Def.EngineDef.ToString()));
+      tags.Add((engine2White ? "WhiteEngine" : "BlackEngine", Def.Player2Def.EngineDef.ToString()));
+      tags.Add(("CeresVersion", CeresVersion.VersionString));
+      tags.Add(("CeresGIT", GitInfo.VersionString));
+
+      return tags;
+    }
+
+
+    HashSet<int> openingsFinishedAtLeastOnce = new();
 
 #if NOT
     public record TournamentGameRunRequest
@@ -258,720 +259,635 @@ namespace Ceres.Features.Tournaments
     }
 #endif
 
-        private TournamentGameInfo RunGame(string pgnFileName, bool engine2White, int openingIndex, int gameSequenceNum, int roundNumber)
+    private TournamentGameInfo RunGame(string pgnFileName, bool engine2White, int openingIndex, int gameSequenceNum, int roundNumber)
+    {
+      TournamentGameInfo thisResult;
+
+      // Add some supplemental tags with round number and also
+      // information about Ceres engine configuration.
+      var extraTags = GetSupplementalTags(engine2White);
+      extraTags.Add(("Round", roundNumber.ToString()));
+
+      PGNWriter pgnWriter = new PGNWriter(null, engine2White ? Run.Engine2.ID : Run.Engine1.ID,
+                                  engine2White ? Run.Engine1.ID : Run.Engine2.ID,
+                                  extraTags.ToArray());
+
+
+      TimingStats gameTimingStats = new TimingStats();
+      using (new TimingBlock(gameTimingStats, TimingBlock.LoggingType.None))
+      {
+        // Start new game
+        string gameID = $"{Def.ID}_GAME_SEQ{gameSequenceNum}_OPENING_{openingIndex}";
+        Run.Engine1.ResetGame(gameID);
+        Run.Engine2.ResetGame(gameID);
+        Run.Engine2CheckEngine?.ResetGame(gameID);
+
+        bool checkTablebases = Def.UseTablebasesForAdjudication && CeresUserSettingsManager.Settings.TablebaseDirectory != null;
+        thisResult = DoGameTest(Def.Logger, pgnWriter, gameSequenceNum, openingIndex,
+                                Run.Engine1, Run.Engine2,
+                                Run.Engine2CheckEngine, engine2White,
+                                Def.Player1Def.SearchLimit, Def.Player2Def.SearchLimit,
+                                checkTablebases, Def.ShowGameMoves);
+
+        if (MCTSDiagnostics.TournamentDumpEngine2EndOfGameSummary)
         {
-            TournamentGameInfo thisResult;
-
-            // Add some supplemental tags with round number and also
-            // information about Ceres engine configuration.
-            var extraTags = GetSupplementalTags(engine2White);
-            extraTags.Add(("Round", roundNumber.ToString()));
-
-            PGNWriter pgnWriter = new PGNWriter(null, engine2White ? Run.Engine2.ID : Run.Engine1.ID,
-                                        engine2White ? Run.Engine1.ID : Run.Engine2.ID,
-                                        extraTags.ToArray());
-
-
-            TimingStats gameTimingStats = new TimingStats();
-            using (new TimingBlock(gameTimingStats, TimingBlock.LoggingType.None))
-            {
-                // Start new game
-                string gameID = $"{Def.ID}_GAME_SEQ{gameSequenceNum}_OPENING_{openingIndex}";
-                Run.Engine1.ResetGame(gameID);
-                Run.Engine2.ResetGame(gameID);
-                Run.Engine2CheckEngine?.ResetGame(gameID);
-
-                bool checkTablebases = Def.UseTablebasesForAdjudication && CeresUserSettingsManager.Settings.TablebaseDirectory != null;
-                thisResult = DoGameTest(Def.Logger, pgnWriter, gameSequenceNum, openingIndex,
-                                        Run.Engine1, Run.Engine2,
-                                        Run.Engine2CheckEngine, engine2White,
-                                        Def.Player1Def.SearchLimit, Def.Player2Def.SearchLimit,
-                                        checkTablebases, Def.ShowGameMoves);
-
-                if (MCTSDiagnostics.TournamentDumpEngine2EndOfGameSummary)
-                {
-                    Run.Engine2.DumpFullMoveHistory(thisResult.GameMoveHistory, engine2White);
-                }
-
-                WritePGNResult(engine2White, thisResult, pgnWriter);
-
-                if (pgnFileName != null)
-                {
-                    lock (writePGNLock) File.AppendAllText(pgnFileName, pgnWriter.GetText());
-                }
-
-            }
-
-            UpdateStatsAndOutputSummaryFromGameResult(pgnFileName, engine2White, openingIndex, gameSequenceNum, thisResult);
-
-            return thisResult;
+          Run.Engine2.DumpFullMoveHistory(thisResult.GameMoveHistory, engine2White);
         }
 
-        internal void UpdateStatsAndOutputSummaryFromGameResult(string pgnFileName, bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
+        WritePGNResult(engine2White, thisResult, pgnWriter);
+
+        if (pgnFileName != null)
         {
-            if (Def.Engines.Count > 0)
-            {
-                lock (ParentStats)
-                {
-                    ParentStats.UpdateRRTournamentStats(thisResult, Run.Engine1, Run.Engine2);
-                }
-            }
-
-            else
-            {
-                lock (ParentStats)
-                {
-                    ParentStats.UpdateTournamentStats(thisResult);
-                }
-            }
-
-            // Only show headers first time for first thread
-            if (!havePrintedHeaders)
-            {
-                OutputHeaders(pgnFileName);
-            }
-            if (Def.Engines.Count > 0)
-            {
-                OutputGameResultRRInfo(engine2White, openingIndex, gameSequenceNum, thisResult);
-                return;
-            }
-
-            OutputGameResultInfo(engine2White, openingIndex, gameSequenceNum, thisResult);
+          lock (writePGNLock) File.AppendAllText(pgnFileName, pgnWriter.GetText());
         }
 
-        private void OutputGameResultInfo(bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
-        {
-            (float eloMin, float eloAvg, float eloMax) = EloCalculator.EloConfidenceInterval(ParentStats.Player1Wins, ParentStats.Draws, ParentStats.Player1Losses);
-            float eloSD = eloMax - eloAvg;
-            float los = EloCalculator.LikelihoodSuperiority(ParentStats.Player1Wins, ParentStats.Draws, ParentStats.Player1Losses);
+      }
 
-            string wdlStr = $"{ParentStats.Player1Wins,3} {ParentStats.Draws,3} {ParentStats.Player1Losses,3}";
+      UpdateStatsAndOutputSummaryFromGameResult(pgnFileName, engine2White, openingIndex, gameSequenceNum, thisResult);
 
-            // Show a "." after the opening index if this was the second of the pair of games played.
-            string openingPlayedBothWaysStr = openingsFinishedAtLeastOnce.Contains(openingIndex) ? "." : " ";
-
-            string player1ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine1 ? "f" : " ";
-            string player2ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine2 ? "f" : " ";
-
-            const string TournamentGameResultReasonCodes = "CSTMERVL";
-
-            char resultReasonChar = TournamentGameResultReasonCodes[(int)thisResult.ResultReason];
-
-            static bool EvalInconsistent(TournamentGameResult outcome, float scoreCP, int numMovesBack)
-            {
-                float mult = numMovesBack % 2 == 1 ? 1 : -1; // adjust for side to move perspective
-                float adjustedCP = mult * scoreCP;
-                return (outcome == TournamentGameResult.Win && adjustedCP < 100) ||
-                       (outcome == TournamentGameResult.Draw && MathF.Abs(adjustedCP) > 50) ||
-                       (outcome == TournamentGameResult.Loss && adjustedCP > -100);
-            }
-
-            // Possibly show one or two "?" characters if the evaluations of the final two positions
-            // are very inconsisten with the actual game outcome (as a diagnostic).
-            string questionableFinalCP = "  ";
-            float endingCP = 0;
-            if (thisResult.GameMoveHistory.Count > 0)
-            {
-                bool finalMoveIsPlayer1 = (thisResult.GameMoveHistory[^1].Side == SideType.White) != engine2White;
-                float reverseMult = finalMoveIsPlayer1 ? 1 : -1;
-                endingCP = reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns;
-
-                if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns, 1))
-                {
-                    questionableFinalCP = "? ";
-                }
-
-                if (thisResult.GameMoveHistory.Count > 1)
-                {
-                    if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^2].ScoreCentipawns, 2))
-                    {
-                        questionableFinalCP = questionableFinalCP[0] + "?";
-                    }
-
-                }
-            }
-
-            lock (outputLockObj)
-            {
-                string checkEnginePlyDifferent = thisResult.NumEngine2MovesDifferentFromCheckEngine == 0 ? "   " : $"{thisResult.NumEngine2MovesDifferentFromCheckEngine,3:N0}";
-                if (Def.ShowGameMoves) Def.Logger.WriteLine();
-                Def.Logger.Write($" {TrimmedIfNeeded(Def.Player1Def.ID, 10),-10} {TrimmedIfNeeded(Def.Player2Def.ID, 10),-10}");
-                Def.Logger.Write($"{eloAvg,4:0} {eloSD,4:0} {100.0f * los,5:0}  ");
-                Def.Logger.Write($"{NumGames,5} {DateTime.Now.ToString().Split(" ")[1],10}  {gameSequenceNum,4:F0}  {openingIndex,4:F0}{openingPlayedBothWaysStr}  ");
-                Def.Logger.Write($"{thisResult.TotalTimeEngine1,8:F2}{player1ForfeitChar}{thisResult.RemainingTimeEngine1,7:F2} ");
-                Def.Logger.Write($"{thisResult.TotalTimeEngine2,8:F2}{player2ForfeitChar}{thisResult.RemainingTimeEngine2,7:F2}  ");
-                Def.Logger.Write($"{thisResult.TotalNodesEngine1,16:N0} {thisResult.TotalNodesEngine2,16:N0}   ");
-
-                if (Def.CheckPlayer2Def != null)
-                {
-                    Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {checkEnginePlyDifferent}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
-                }
-                else
-                {
-                    Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
-                }
-
-                Def.Logger.Write($" {resultReasonChar}   {endingCP,5:F0}{questionableFinalCP}");
-                Def.Logger.Write($" {wdlStr}   {thisResult.FEN} ");
-                Def.Logger.WriteLine();
-            }
-
-            UpdateAggregateGameStats(thisResult);
-
-            openingsFinishedAtLeastOnce.Add(openingIndex);
-            NumGames++;
-        }
-
-        private void OutputGameResultRRInfo(bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
-        {
-            var engineStat = ParentStats.GetResultsForPlayer(Run.Engine1.ID, Run.Engine2.ID);
-            var gNumber = NumGames + 1;
-            (float eloMin, float eloAvg, float eloMax) = EloCalculator.EloConfidenceInterval(engineStat.Player1Wins, engineStat.Draws, engineStat.Player1Losses);
-            float eloSD = eloMax - eloAvg;
-            float los = EloCalculator.LikelihoodSuperiority(engineStat.Player1Wins, engineStat.Draws, engineStat.Player1Losses);
-
-            string wdlStr = $"{engineStat.Player1Wins,3} {engineStat.Draws,3} {engineStat.Player1Losses,3}";
-
-            // Show a "." after the opening index if this was the second of the pair of games played.
-            string openingPlayedBothWaysStr = openingsFinishedAtLeastOnce.Contains(openingIndex) ? "." : " ";
-
-            string player1ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine1 ? "f" : " ";
-            string player2ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine2 ? "f" : " ";
-
-            const string TournamentGameResultReasonCodes = "CSTMERVL";
-
-            char resultReasonChar = TournamentGameResultReasonCodes[(int)thisResult.ResultReason];
-
-            static bool EvalInconsistent(TournamentGameResult outcome, float scoreCP, int numMovesBack)
-            {
-                float mult = numMovesBack % 2 == 1 ? 1 : -1; // adjust for side to move perspective
-                float adjustedCP = mult * scoreCP;
-                return (outcome == TournamentGameResult.Win && adjustedCP < 100) ||
-                       (outcome == TournamentGameResult.Draw && MathF.Abs(adjustedCP) > 50) ||
-                       (outcome == TournamentGameResult.Loss && adjustedCP > -100);
-            }
-
-            // Possibly show one or two "?" characters if the evaluations of the final two positions
-            // are very inconsisten with the actual game outcome (as a diagnostic).
-            string questionableFinalCP = "  ";
-            float endingCP = 0;
-            if (thisResult.GameMoveHistory.Count > 0)
-            {
-                bool finalMoveIsPlayer1 = (thisResult.GameMoveHistory[^1].Side == SideType.White) != engine2White;
-                float reverseMult = finalMoveIsPlayer1 ? 1 : -1;
-                endingCP = reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns;
-
-                if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns, 1))
-                {
-                    questionableFinalCP = "? ";
-                }
-
-                if (thisResult.GameMoveHistory.Count > 1)
-                {
-                    if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^2].ScoreCentipawns, 2))
-                    {
-                        questionableFinalCP = questionableFinalCP[0] + "?";
-                    }
-
-                }
-            }
-
-            lock (outputLockObj)
-            {
-                string checkEnginePlyDifferent = thisResult.NumEngine2MovesDifferentFromCheckEngine == 0 ? "   " : $"{thisResult.NumEngine2MovesDifferentFromCheckEngine,3:N0}";
-                if (Def.ShowGameMoves) Def.Logger.WriteLine();
-                Def.Logger.Write($" {TrimmedIfNeeded(Def.Player1Def.ID, 10),-10} {TrimmedIfNeeded(Def.Player2Def.ID, 10),-10}");
-                Def.Logger.Write($"{eloAvg,4:0} {eloSD,4:0} {100.0f * los,5:0}  ");
-                Def.Logger.Write($"{gNumber,5} {DateTime.Now.ToString().Split(" ")[1],10}  {gameSequenceNum,4:F0}  {openingIndex,4:F0}{openingPlayedBothWaysStr}  ");
-                Def.Logger.Write($"{thisResult.TotalTimeEngine1,8:F2}{player1ForfeitChar}{thisResult.RemainingTimeEngine1,7:F2} ");
-                Def.Logger.Write($"{thisResult.TotalTimeEngine2,8:F2}{player2ForfeitChar}{thisResult.RemainingTimeEngine2,7:F2}  ");
-                Def.Logger.Write($"{thisResult.TotalNodesEngine1,16:N0} {thisResult.TotalNodesEngine2,16:N0}   ");
-
-                if (Def.CheckPlayer2Def != null)
-                {
-                    Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {checkEnginePlyDifferent}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
-                }
-                else
-                {
-                    Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
-                }
-
-                Def.Logger.Write($" {resultReasonChar}   {endingCP,5:F0}{questionableFinalCP}");
-                Def.Logger.Write($" {wdlStr}   {thisResult.FEN} ");
-                Def.Logger.WriteLine();
-            }
-
-            UpdateAggregateGameStats(thisResult);
-
-            openingsFinishedAtLeastOnce.Add(openingIndex);
-            NumGames++;
-        }
-
-        private void UpdateAggregateGameStats(TournamentGameInfo thisResult)
-        {
-            TotalNodesEngine1 += thisResult.TotalNodesEngine1;
-            TotalNodesEngine2 += thisResult.TotalNodesEngine2;
-            TotalMovesEngine1 += thisResult.PlyCount;
-            TotalMovesEngine2 += thisResult.PlyCount;
-            TotalTimeEngine1 += thisResult.TotalTimeEngine1;
-            TotalTimeEngine2 += thisResult.TotalTimeEngine2;
-        }
-
-        private static void WritePGNResult(bool engine2White, TournamentGameInfo thisResult, PGNWriter pgnWriter)
-        {
-            switch (thisResult.Result)
-            {
-                case TournamentGameResult.Win:
-                    if (engine2White)
-                    {
-                        pgnWriter.WriteResultBlackWins();
-                    }
-                    else
-                    {
-                        pgnWriter.WriteResultWhiteWins();
-                    }
-                    break;
-
-                case TournamentGameResult.Loss:
-                    if (engine2White)
-                    {
-                        pgnWriter.WriteResultWhiteWins();
-                    }
-                    else
-                    {
-                        pgnWriter.WriteResultBlackWins();
-                    }
-                    break;
-
-                default:
-                    pgnWriter.WriteResultDraw();
-                    break;
-            }
-        }
-
-
-        private void OutputHeaders(string pgnFileName)
-        {
-            Def.Logger.WriteLine();
-            Def.Logger.WriteLine($"Games will be incrementally written to file: {pgnFileName}");
-            Def.Logger.WriteLine("Result codes: C=checkmate S=stalemate T=tablebase M=insufficient material E=excessive moves R=draw by repetition V=evaluation agreement F=time forfeit");
-            Def.Logger.WriteLine();
-
-            if (Def.CheckPlayer2Def != null)
-            {
-                Def.Logger.WriteLine("  Player1    Player2   ELO   +/-  LOS   GAME#     TIME    TH#   OP#      TIME1    REM1    TIME2    REM2        NODES 2       PLY  DIF    RES  R   ENDCP     W   D   L   FEN");
-                Def.Logger.WriteLine(" ---------  ---------  ---   ---  ---   -----  --------   ---   ---     ------  ------   ------  ------   --------------   ----  ---    ---  -   -----     -   -   -   ---------------------------------------------------");
-            }
-            else
-            {
-                Def.Logger.WriteLine("  Player1    Player2   ELO   +/-  LOS   GAME#     TIME    TH#   OP#      TIME1    REM1    TIME2    REM2       NODES 1           NODES 2       PLY    RES  R   ENDCP     W   D   L   FEN");
-                Def.Logger.WriteLine(" ---------  ---------  ---   ---  ---   -----  --------   ---   ---     ------  ------   ------  ------    --------------   --------------   ----    ---  -   -----     -   -   -   ---------------------------------------------------");
-            }
-            havePrintedHeaders = true;
-        }
-
-
-        static readonly object outputLockObj = new();
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="openingIndex"></param>
-        /// <param name="engine1"></param>
-        /// <param name="engine2"></param>
-        /// <param name="engine2IsWhite"></param>
-        /// <param name="searchLimit"></param>
-        /// <returns>GameResult (from the perspective of engine2)</returns>
-        TournamentGameInfo DoGameTest(TextWriter logger, PGNWriter pgnWriter, int gameSequenceNum, int openingIndex,
-                                     GameEngine engine1, GameEngine engine2, GameEngine engineCheckAgainstEngine2,
-                                     bool engine2IsWhite,
-                                     SearchLimit searchLimitEngine1, SearchLimit searchLimitEngine2,
-                                     bool useTablebasesForAdjudication, bool showMoves)
-        {
-            if (openingIndex >= openings.Count)
-            {
-                throw new Exception($"Reached end of openings of size {openings.Count}.");
-            }
-
-            PositionWithHistory curPositionAndMoves = openings.GetAtIndex(openingIndex);
-            string startFEN = curPositionAndMoves.FinalPosition.FEN;
-            bool engine2ToMove = engine2IsWhite == (curPositionAndMoves.FinalPosition.MiscInfo.SideToMove == SideType.White);
-
-            if (showMoves)
-            {
-                logger.WriteLine();
-                logger.WriteLine("NEW GAME from " + curPositionAndMoves);
-                if (engine2ToMove)
-                {
-                    logger.WriteLine((engine2IsWhite ? "White: " : "Black: ") + engine2.ID + " [" + searchLimitEngine2 + "]");
-                    logger.WriteLine((engine2IsWhite ? "Black: " : "White: ") + engine1.ID + " [" + searchLimitEngine1 + "]");
-                }
-                else
-                {
-                    logger.WriteLine((engine2IsWhite ? "Black: " : "White: ") + engine1.ID + " [" + searchLimitEngine1 + "]");
-                    logger.WriteLine((engine2IsWhite ? "White: " : "Black: ") + engine2.ID + " [" + searchLimitEngine2 + "]");
-                }
-            }
-
-            pgnWriter.WriteStartPosition(startFEN);
-
-
-            GameMoveConsoleInfo info = new GameMoveConsoleInfo();
-
-            int plyCount = 1;
-            float timeEngine1Tot = 0;
-            float timeEngine2Tot = 0;
-            long visitsEngine1Tot = 0;
-            long visitsEngine2Tot = 0;
-            long nodesEngine1Tot = 0;
-            long nodesEngine2Tot = 0;
-            int movesEngine1 = 0;
-            int movesEngine2 = 0;
-            bool engine1ShouldHaveForfieted = false;
-            bool engine2ShouldHaveForfieted = false;
-
-            int numEngine2MovesDifferentFromCheckEngine = 0;
-
-            List<float> scoresEngine1 = new List<float>();
-            List<float> scoresEngine2 = new List<float>();
-
-            List<GameMoveStat> gameMoveHistory = new List<GameMoveStat>();
-
-            static float RemainingTime(SearchLimit limit, int numMoves, float timeUsed)
-            {
-                if (limit.Type == SearchLimitType.SecondsForAllMoves)
-                {
-                    return limit.MaxValueAfterMoves(numMoves) - timeUsed;
-                }
-                else
-                {
-                    // TODO: in principle we could do this also for nodes per game limits
-                    return 0;
-                }
-            }
-
-            TournamentGameInfo MakeGameInfo(TournamentGameResult result, TournamentGameResultReason reason)
-            {
-                return new TournamentGameInfo()
-                {
-                    Engine2IsWhite = engine2IsWhite,
-                    GameSequenceNum = gameSequenceNum,
-                    OpeningIndex = openingIndex,
-                    FEN = startFEN,
-                    Result = result, //TournamentGameInfo.InvertedResult(result),
-                    ResultReason = reason,
-                    PlyCount = plyCount,
-                    TotalTimeEngine1 = timeEngine1Tot,
-                    TotalTimeEngine2 = timeEngine2Tot,
-                    TotalNodesEngine1 = nodesEngine1Tot,
-                    TotalNodesEngine2 = nodesEngine2Tot,
-                    RemainingTimeEngine1 = RemainingTime(searchLimitEngine1, movesEngine1, timeEngine1Tot),
-                    RemainingTimeEngine2 = RemainingTime(searchLimitEngine2, movesEngine2, timeEngine2Tot),
-                    ShouldHaveForfeitedOnLimitsEngine1 = engine1ShouldHaveForfieted,
-                    ShouldHaveForfeitedOnLimitsEngine2 = engine2ShouldHaveForfieted,
-                    NumEngine2MovesDifferentFromCheckEngine = numEngine2MovesDifferentFromCheckEngine,
-                    GameMoveHistory = gameMoveHistory
-                };
-
-            }
-
-            // Reset the game state before we begin making moves
-            engine1.CumulativeSearchTimeSeconds = 0;
-            engine1.CumulativeNodes = 0;
-            engine2.CumulativeSearchTimeSeconds = 0;
-            engine2.CumulativeNodes = 0;
-            TournamentGameResult result = TournamentGameResult.None;
-
-            SearchLimit searchLimitWithIncrementsEngine1 = searchLimitEngine1 with { };
-            SearchLimit searchLimitWithIncrementsEngine2 = searchLimitEngine2 with { };
-
-
-            // Keep a list of all positions seen so far in game      
-            List<Position> encounteredPositions = new List<Position>();
-
-            // Repeatedly make moves
-            while (true)
-            {
-                // Add this position to the set of positions encountered
-                Position currentPosition = curPositionAndMoves.FinalPosition;
-                encounteredPositions.Add(currentPosition);
-
-                // If time or node increment was specified for game-level search limit,
-                // adjust the search limit to give credit for this increment
-                if (!engine2ToMove && searchLimitEngine1.ValueIncrement != 0)
-                {
-                    searchLimitWithIncrementsEngine1 = searchLimitWithIncrementsEngine1.WithIncrementApplied();
-                }
-
-                if (engine2ToMove && searchLimitEngine2.ValueIncrement != 0)
-                {
-                    searchLimitWithIncrementsEngine2 = searchLimitWithIncrementsEngine2.WithIncrementApplied();
-                }
-
-                // Check for very bad evaluation for one side (agreed by both sides)
-                if (scoresEngine1.Count > 5)
-                {
-                    result = CheckResultAgreedBothEngines(scoresEngine1, scoresEngine2, result);
-                    if (result != TournamentGameResult.None)
-                    {
-                        return MakeGameInfo(result, TournamentGameResultReason.AdjudicatedEvaluation);
-                    }
-                }
-
-                info.FEN = currentPosition.FEN;
-                info.MoveNum = plyCount / 2;
-
-                // Check for draw by repetition of position (3 times)
-                int countRepetitions = 0;
-                foreach (Position pos in encounteredPositions)
-                {
-                    if (pos.EqualAsRepetition(in currentPosition))
-                    {
-                        countRepetitions++;
-                    }
-                }
-
-                if (countRepetitions >= 3)
-                {
-                    return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.Repetition);
-                }
-
-
-                // Check for draw by insufficient material
-                if (curPositionAndMoves.FinalPosition.CheckDrawBasedOnMaterial == Position.PositionDrawStatus.DrawByInsufficientMaterial)
-                {
-                    return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.AdjudicateMaterial);
-                }
-                else if (curPositionAndMoves.FinalPosition.CheckDrawCanBeClaimed == Position.PositionDrawStatus.DrawCanBeClaimed)
-                {
-                    return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.Repetition);
-                }
-                else if (plyCount >= 500)
-                {
-                    return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.ExcessiveMoves);
-                }
-
-                // Check for terminal result (tablebase or intrinsically terminal)
-                TournamentGameResultReason reason;
-                result = TournamentUtils.TryGetGameResultIfTerminal(curPositionAndMoves, !engine2IsWhite, useTablebasesForAdjudication, out reason);
-                if (result != TournamentGameResult.None)
-                {
-                    return MakeGameInfo(result, reason);
-                }
-
-                plyCount++;
-
-                int numPieces = Position.FromFEN(info.FEN).PieceCount;
-
-                // Make player's move
-                GameMoveStat moveStat;
-                if (engine2ToMove)
-                {
-                    info = DoMove(engine2, engineCheckAgainstEngine2,
-                                  gameMoveHistory, searchLimitWithIncrementsEngine2, scoresEngine2,
-                                  ref nodesEngine2Tot, ref visitsEngine2Tot, ref timeEngine2Tot);
-                    movesEngine2++;
-
-                    if (engine2IsWhite)
-                    {
-                        engine2ShouldHaveForfieted |= info.WhiteShouldHaveForfeitedOnLimit;
-                        moveStat = new GameMoveStat(plyCount, SideType.White, info.WhiteScoreQ, info.WhiteScoreCentipawns, engine2.CumulativeSearchTimeSeconds, numPieces, info.WhiteMAvg, info.WhiteFinalN, info.WhiteNumNodesComputed, info.WhiteSearchLimitPre, info.WhiteMoveTimeUsed);
-                    }
-                    else
-                    {
-                        engine2ShouldHaveForfieted |= info.BlackShouldHaveForfeitedOnLimit;
-                        moveStat = new GameMoveStat(plyCount, SideType.Black, info.BlackScoreQ, info.BlackScoreCentipawns, engine2.CumulativeSearchTimeSeconds, numPieces, info.BlackMAvg, info.BlackFinalN, info.BlackNumNodesComputed, info.BlackSearchLimitPre, info.BlackMoveTimeUsed);
-                    }
-                }
-                else
-                {
-                    info = DoMove(engine1, null,
-                                  gameMoveHistory, searchLimitWithIncrementsEngine1, scoresEngine1,
-                                  ref nodesEngine1Tot, ref visitsEngine1Tot, ref timeEngine1Tot);
-                    movesEngine1++;
-                    if (engine2IsWhite)
-                    {
-                        engine1ShouldHaveForfieted |= info.BlackShouldHaveForfeitedOnLimit;
-                        moveStat = new GameMoveStat(plyCount, SideType.Black, info.BlackScoreQ, info.BlackScoreCentipawns, engine1.CumulativeSearchTimeSeconds, numPieces, info.BlackMAvg, info.BlackFinalN, info.BlackNumNodesComputed, info.BlackSearchLimitPre, info.BlackMoveTimeUsed);
-                    }
-                    else
-                    {
-                        engine1ShouldHaveForfieted |= info.WhiteShouldHaveForfeitedOnLimit;
-                        moveStat = new GameMoveStat(plyCount, SideType.White, info.WhiteScoreQ, info.WhiteScoreCentipawns, engine1.CumulativeSearchTimeSeconds, numPieces, info.WhiteMAvg, info.WhiteFinalN, info.WhiteNumNodesComputed, info.WhiteSearchLimitPre, info.WhiteMoveTimeUsed);
-                    }
-                }
-
-
-                gameMoveHistory.Add(moveStat);
-
-                engine2ToMove = !engine2ToMove;
-                if (plyCount % 2 == 1)
-                {
-                    info = new GameMoveConsoleInfo();
-                    if (showMoves) logger.WriteLine();
-                }
-            }
-
-
-            GameMoveConsoleInfo DoMove(GameEngine engine, GameEngine checkMoveEngine,
-                                       List<GameMoveStat> gameMoveHistory,
-                                       SearchLimit searchLimit, List<float> scoresCP,
-                                        ref long totalNodesUsed, ref long totalVisitsUsed, ref float totalTimeUsed)
-            {
-                SearchLimit thisMoveSearchLimit = searchLimit.Type switch
-                {
-                    SearchLimitType.SecondsPerMove => searchLimit,
-                    SearchLimitType.NodesPerMove => searchLimit,
-                    SearchLimitType.NodesForAllMoves => new SearchLimit(SearchLimitType.NodesForAllMoves,
-                                                                        Math.Max(0, searchLimit.Value - totalVisitsUsed),
-                                                                        searchLimit.SearchCanBeExpanded,
-                                                                        searchLimit.ValueIncrement,
-                                                                        searchLimit.MaxMovesToGo),
-                    SearchLimitType.SecondsForAllMoves => new SearchLimit(SearchLimitType.SecondsForAllMoves,
-                                                                          MathF.Max(0, searchLimit.Value - totalTimeUsed),
-                                                                          searchLimit.SearchCanBeExpanded,
-                                                                          searchLimit.ValueIncrement,
-                                                                          searchLimit.MaxMovesToGo),
-                    _ => throw new Exception($"Internal error, unknown SearchLimit.LimitType {searchLimit.Type}")
-                };
-
-                GameEngineSearchResult engineMove = engine.Search(curPositionAndMoves, thisMoveSearchLimit, gameMoveHistory);
-                float engineTime = (float)engineMove.TimingStats.ElapsedTimeSecs;
-
-                // Check for time forfeit
-                bool shouldHaveForfeited = false;
-                if (thisMoveSearchLimit.IsTimeLimit)
-                {
-                    const float GRACE_FRACTION = 0.02f; // Allow up to 2% over
-                    float GRACE_SECONDS = searchLimit.Value * GRACE_FRACTION;
-                    float timeExcess = engineTime - thisMoveSearchLimit.Value;
-                    if (gameMoveHistory.Count >= 2 && timeExcess > GRACE_SECONDS)
-                    {
-                        shouldHaveForfeited = true;
-
-                        // TODO: (a) remove the "Count > 2" restriction above,
-                        //       (b) reconsider the GRACE_FRACTION above
-                        //       (b) log this
-                        //throw new Exception($"Time forfeit, allotted {thisMoveSearchLimit.Value} used {engineTime} for engine {engine}");
-                    }
-                }
-
-                GameEngineSearchResult checkSearch = default;
-                string checkMove = "";
-                if (checkMoveEngine != null)
-                {
-                    checkSearch = checkMoveEngine.Search(curPositionAndMoves, searchLimit);
-                    checkMove = checkSearch.MoveString;
-                    if (engineMove.MoveString != checkMove)
-                    {
-                        numEngine2MovesDifferentFromCheckEngine++;
-                    }
-                }
-
-                // Verify the engine's move was legal by trying to make it.
-                try
-                {
-                    Position positionAfterMoveTest = curPositionAndMoves.FinalPosition.AfterMove(Move.FromUCI(engineMove.MoveString));
-                }
-                catch (Exception exc)
-                {
-                    throw new Exception($"Engine {engine.ID} made illegal move {engineMove.MoveString} in position {curPositionAndMoves.FinalPosition.FEN}");
-                }
-
-                PositionWithHistory newPosition = new PositionWithHistory(curPositionAndMoves);
-                newPosition.AppendMove(engineMove.MoveString);
-
-                // Output position to PGN
-                pgnWriter.WriteMove(newPosition.Moves[^1], curPositionAndMoves.FinalPosition, engineTime, engineMove.Depth, engineMove.ScoreCentipawns);
-
-                scoresCP.Add(engineMove.ScoreCentipawns);
-
-                totalNodesUsed += engineMove.FinalN;
-                totalVisitsUsed += engineMove.Visits;
-                totalTimeUsed += engineTime;
-                if (curPositionAndMoves.FinalPosition.MiscInfo.SideToMove == SideType.White)
-                {
-                    info.WhiteMoveStr = engineMove.MoveString;
-                    info.WhiteScoreQ = engineMove.ScoreQ;
-                    info.WhiteScoreCentipawns = engineMove.ScoreCentipawns;
-                    info.WhiteSearchLimitPre = thisMoveSearchLimit;
-                    info.WhiteSearchLimitPost = engineMove.Limit;
-                    info.WhiteMoveTimeUsed = engineTime;
-                    info.WhiteTimeAllMoves = totalTimeUsed;
-                    info.WhiteNodesAllMoves = totalNodesUsed;
-                    info.WhiteStartN = engineMove.StartingN;
-                    info.WhiteFinalN = engineMove.FinalN;
-                    info.WhiteMAvg = engineMove.MAvg;
-                    info.WhiteCheckMoveStr = checkMove;
-                    info.WhiteShouldHaveForfeitedOnLimit = shouldHaveForfeited;
-                }
-                else
-                {
-                    info.BlackMoveStr = engineMove.MoveString;
-                    info.BlackScoreQ = engineMove.ScoreQ;
-                    info.BlackScoreCentipawns = engineMove.ScoreCentipawns;
-                    info.BlackSearchLimitPre = thisMoveSearchLimit;
-                    info.BlackSearchLimitPost = engineMove.Limit;
-                    info.BlackMoveTimeUsed = engineTime;
-                    info.BlackTimeAllMoves = totalTimeUsed;
-                    info.BlackNodesAllMoves = totalNodesUsed;
-                    info.BlackStartN = engineMove.StartingN;
-                    info.BlackFinalN = engineMove.FinalN;
-                    info.BlackMAvg = engineMove.MAvg;
-                    info.BlackCheckMoveStr = checkMove;
-                    info.BlackShouldHaveForfeitedOnLimit = shouldHaveForfeited;
-                }
-
-                if (showMoves) info.PutStr();
-
-                // Advance to next move
-                curPositionAndMoves = newPosition;
-
-                return info;
-            }
-        }
-
-
-        static float MinLastN(List<float> vals, int count)
-        {
-            float min = float.MaxValue;
-            for (int i = 1; i <= count; i++)
-                if (vals[^i] < min)
-                    min = vals[^i];
-            return min;
-        }
-
-        static float MaxLastN(List<float> vals, int count)
-        {
-            float max = float.MinValue;
-            for (int i = 1; i <= count; i++)
-                if (vals[^i] > max)
-                    max = vals[^i];
-            return max;
-        }
-
-        TournamentGameResult CheckResultAgreedBothEngines(List<float> scoresCPEngine1, List<float> scoresCPEngine2, TournamentGameResult result)
-        {
-            int WIN_THRESHOLD = Run.Def.AdjudicationThresholdCentipawns;
-            int NUM_MOVES = Run.Def.AdjudicationThresholdNumMoves;
-
-            // Return if insufficient moves in history to make determination.
-            if (scoresCPEngine2.Count < NUM_MOVES || scoresCPEngine1.Count < NUM_MOVES)
-                return result;
-
-            if (MinLastN(scoresCPEngine2, NUM_MOVES) > WIN_THRESHOLD && MaxLastN(scoresCPEngine1, NUM_MOVES) < -WIN_THRESHOLD)
-            {
-                return TournamentGameResult.Loss;
-            }
-            else if (MinLastN(scoresCPEngine1, NUM_MOVES) > WIN_THRESHOLD && MaxLastN(scoresCPEngine2, NUM_MOVES) < -WIN_THRESHOLD)
-            {
-                return TournamentGameResult.Win;
-            }
-            else
-            {
-                return result;
-            }
-        }
-
+      return thisResult;
     }
+
+    internal void UpdateStatsAndOutputSummaryFromGameResult(string pgnFileName, bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
+    {
+      lock (ParentStats)
+      {
+        ParentStats.UpdateTournamentStats(thisResult, Run.Engine1);
+      }
+
+      // Only show headers first time for first thread
+      if (!havePrintedHeaders)
+      {
+        OutputHeaders(pgnFileName);
+      }
+
+      OutputGameResultInfo(engine2White, openingIndex, gameSequenceNum, thisResult);
+    }
+
+    private void OutputGameResultInfo(bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
+    {
+      var engineStat = engine2White ?
+                          ParentStats.GetResultsForPlayer(Run.Engine2.ID, Run.Engine1.ID)
+                          : ParentStats.GetResultsForPlayer(Run.Engine1.ID, Run.Engine2.ID);
+      var gNumber = NumGames + 1;
+      (float eloMin, float eloAvg, float eloMax) = EloCalculator.EloConfidenceInterval(engineStat.Player1Wins, engineStat.Draws, engineStat.Player1Losses);
+      float eloSD = eloMax - eloAvg;
+      float los = EloCalculator.LikelihoodSuperiority(engineStat.Player1Wins, engineStat.Draws, engineStat.Player1Losses);
+
+      string wdlStr = $"{engineStat.Player1Wins,3} {engineStat.Draws,3} {engineStat.Player1Losses,3}";
+
+      // Show a "." after the opening index if this was the second of the pair of games played.
+      string openingPlayedBothWaysStr = gameSequenceNum % 2 == 1 && openingsFinishedAtLeastOnce.Contains(openingIndex) ? "." : " ";
+
+      string player1ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine1 ? "f" : " ";
+      string player2ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine2 ? "f" : " ";
+
+      const string TournamentGameResultReasonCodes = "CSTMERVL";
+
+      char resultReasonChar = TournamentGameResultReasonCodes[(int)thisResult.ResultReason];
+
+      static bool EvalInconsistent(TournamentGameResult outcome, float scoreCP, int numMovesBack)
+      {
+        float mult = numMovesBack % 2 == 1 ? 1 : -1; // adjust for side to move perspective
+        float adjustedCP = mult * scoreCP;
+        return (outcome == TournamentGameResult.Win && adjustedCP < 100) ||
+               (outcome == TournamentGameResult.Draw && MathF.Abs(adjustedCP) > 50) ||
+               (outcome == TournamentGameResult.Loss && adjustedCP > -100);
+      }
+
+      // Possibly show one or two "?" characters if the evaluations of the final two positions
+      // are very inconsisten with the actual game outcome (as a diagnostic).
+      string questionableFinalCP = "  ";
+      float endingCP = 0;
+      if (thisResult.GameMoveHistory.Count > 0)
+      {
+        bool finalMoveIsPlayer1 = (thisResult.GameMoveHistory[^1].Side == SideType.White) != engine2White;
+        float reverseMult = finalMoveIsPlayer1 ? 1 : -1;
+        endingCP = reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns;
+
+        if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns, 1))
+        {
+          questionableFinalCP = "? ";
+        }
+
+        if (thisResult.GameMoveHistory.Count > 1)
+        {
+          if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^2].ScoreCentipawns, 2))
+          {
+            questionableFinalCP = questionableFinalCP[0] + "?";
+          }
+
+        }
+      }
+
+      lock (outputLockObj)
+      {
+        string checkEnginePlyDifferent = thisResult.NumEngine2MovesDifferentFromCheckEngine == 0 ? "   " : $"{thisResult.NumEngine2MovesDifferentFromCheckEngine,3:N0}";
+        if (Def.ShowGameMoves) Def.Logger.WriteLine();
+        if (engine2White)
+          Def.Logger.Write($" {TrimmedIfNeeded(Def.Player2Def.ID, 10),-10} {TrimmedIfNeeded(Def.Player1Def.ID, 10),-10}");
+        else
+          Def.Logger.Write($" {TrimmedIfNeeded(Def.Player1Def.ID, 10),-10} {TrimmedIfNeeded(Def.Player2Def.ID, 10),-10}");
+        Def.Logger.Write($"{eloAvg,4:0} {eloSD,4:0} {100.0f * los,5:0}  ");
+        Def.Logger.Write($"{gNumber,5} {DateTime.Now.ToString().Split(" ")[1],10}  {gameSequenceNum,4:F0}  {openingIndex,4:F0}{openingPlayedBothWaysStr}  ");
+        if (engine2White)
+        {
+          Def.Logger.Write($"{thisResult.TotalTimeEngine2,8:F2}{player2ForfeitChar}{thisResult.RemainingTimeEngine2,7:F2} ");
+          Def.Logger.Write($"{thisResult.TotalTimeEngine1,8:F2}{player1ForfeitChar}{thisResult.RemainingTimeEngine1,7:F2}  ");
+          Def.Logger.Write($"{thisResult.TotalNodesEngine2,16:N0} {thisResult.TotalNodesEngine1,16:N0}   ");
+        }
+        else
+        {
+          Def.Logger.Write($"{thisResult.TotalTimeEngine1,8:F2}{player1ForfeitChar}{thisResult.RemainingTimeEngine1,7:F2} ");
+          Def.Logger.Write($"{thisResult.TotalTimeEngine2,8:F2}{player2ForfeitChar}{thisResult.RemainingTimeEngine2,7:F2}  ");
+          Def.Logger.Write($"{thisResult.TotalNodesEngine1,16:N0} {thisResult.TotalNodesEngine2,16:N0}   ");
+        }
+
+        if (Def.CheckPlayer2Def != null)
+        {
+          Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {checkEnginePlyDifferent}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
+        }
+        else
+        {
+          Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
+        }
+
+        Def.Logger.Write($" {resultReasonChar}   {endingCP,5:F0}{questionableFinalCP}");
+        Def.Logger.Write($" {wdlStr}   {thisResult.FEN} ");
+        Def.Logger.WriteLine();
+      }
+
+      UpdateAggregateGameStats(thisResult);
+
+      openingsFinishedAtLeastOnce.Add(openingIndex);
+      NumGames++;
+    }
+
+    private void UpdateAggregateGameStats(TournamentGameInfo thisResult)
+    {
+      TotalNodesEngine1 += thisResult.TotalNodesEngine1;
+      TotalNodesEngine2 += thisResult.TotalNodesEngine2;
+      TotalMovesEngine1 += thisResult.PlyCount;
+      TotalMovesEngine2 += thisResult.PlyCount;
+      TotalTimeEngine1 += thisResult.TotalTimeEngine1;
+      TotalTimeEngine2 += thisResult.TotalTimeEngine2;
+    }
+
+    private static void WritePGNResult(bool engine2White, TournamentGameInfo thisResult, PGNWriter pgnWriter)
+    {
+      switch (thisResult.Result)
+      {
+        case TournamentGameResult.Win:
+          if (engine2White)
+          {
+            pgnWriter.WriteResultBlackWins();
+          }
+          else
+          {
+            pgnWriter.WriteResultWhiteWins();
+          }
+          break;
+
+        case TournamentGameResult.Loss:
+          if (engine2White)
+          {
+            pgnWriter.WriteResultWhiteWins();
+          }
+          else
+          {
+            pgnWriter.WriteResultBlackWins();
+          }
+          break;
+
+        default:
+          pgnWriter.WriteResultDraw();
+          break;
+      }
+    }
+
+
+    private void OutputHeaders(string pgnFileName)
+    {
+      Def.Logger.WriteLine();
+      Def.Logger.WriteLine($"Games will be incrementally written to file: {pgnFileName}");
+      Def.Logger.WriteLine("Result codes: C=checkmate S=stalemate T=tablebase M=insufficient material E=excessive moves R=draw by repetition V=evaluation agreement F=time forfeit");
+      Def.Logger.WriteLine();
+
+      if (Def.CheckPlayer2Def != null)
+      {
+        Def.Logger.WriteLine("  Player1    Player2   ELO   +/-  LOS   GAME#     TIME    TH#   OP#      TIME1    REM1    TIME2    REM2        NODES 2       PLY  DIF    RES  R   ENDCP     W   D   L   FEN");
+        Def.Logger.WriteLine(" ---------  ---------  ---   ---  ---   -----  --------   ---   ---     ------  ------   ------  ------   --------------   ----  ---    ---  -   -----     -   -   -   ---------------------------------------------------");
+      }
+      else
+      {
+        Def.Logger.WriteLine("  Player1    Player2   ELO   +/-  LOS   GAME#     TIME    TH#   OP#      TIME1    REM1    TIME2    REM2       NODES 1           NODES 2       PLY    RES  R   ENDCP     W   D   L   FEN");
+        Def.Logger.WriteLine(" ---------  ---------  ---   ---  ---   -----  --------   ---   ---     ------  ------   ------  ------    --------------   --------------   ----    ---  -   -----     -   -   -   ---------------------------------------------------");
+      }
+      havePrintedHeaders = true;
+    }
+
+
+    static readonly object outputLockObj = new();
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="openingIndex"></param>
+    /// <param name="engine1"></param>
+    /// <param name="engine2"></param>
+    /// <param name="engine2IsWhite"></param>
+    /// <param name="searchLimit"></param>
+    /// <returns>GameResult (from the perspective of engine2)</returns>
+    TournamentGameInfo DoGameTest(TextWriter logger, PGNWriter pgnWriter, int gameSequenceNum, int openingIndex,
+                                 GameEngine engine1, GameEngine engine2, GameEngine engineCheckAgainstEngine2,
+                                 bool engine2IsWhite,
+                                 SearchLimit searchLimitEngine1, SearchLimit searchLimitEngine2,
+                                 bool useTablebasesForAdjudication, bool showMoves)
+    {
+      if (openingIndex >= openings.Count)
+      {
+        throw new Exception($"Reached end of openings of size {openings.Count}.");
+      }
+
+      PositionWithHistory curPositionAndMoves = openings.GetAtIndex(openingIndex);
+      string startFEN = curPositionAndMoves.FinalPosition.FEN;
+      bool engine2ToMove = engine2IsWhite == (curPositionAndMoves.FinalPosition.MiscInfo.SideToMove == SideType.White);
+
+      if (showMoves)
+      {
+        logger.WriteLine();
+        logger.WriteLine("NEW GAME from " + curPositionAndMoves);
+        if (engine2ToMove)
+        {
+          logger.WriteLine((engine2IsWhite ? "White: " : "Black: ") + engine2.ID + " [" + searchLimitEngine2 + "]");
+          logger.WriteLine((engine2IsWhite ? "Black: " : "White: ") + engine1.ID + " [" + searchLimitEngine1 + "]");
+        }
+        else
+        {
+          logger.WriteLine((engine2IsWhite ? "Black: " : "White: ") + engine1.ID + " [" + searchLimitEngine1 + "]");
+          logger.WriteLine((engine2IsWhite ? "White: " : "Black: ") + engine2.ID + " [" + searchLimitEngine2 + "]");
+        }
+      }
+
+      pgnWriter.WriteStartPosition(startFEN);
+
+
+      GameMoveConsoleInfo info = new GameMoveConsoleInfo();
+
+      int plyCount = 1;
+      float timeEngine1Tot = 0;
+      float timeEngine2Tot = 0;
+      long visitsEngine1Tot = 0;
+      long visitsEngine2Tot = 0;
+      long nodesEngine1Tot = 0;
+      long nodesEngine2Tot = 0;
+      int movesEngine1 = 0;
+      int movesEngine2 = 0;
+      bool engine1ShouldHaveForfieted = false;
+      bool engine2ShouldHaveForfieted = false;
+
+      int numEngine2MovesDifferentFromCheckEngine = 0;
+
+      List<float> scoresEngine1 = new List<float>();
+      List<float> scoresEngine2 = new List<float>();
+
+      List<GameMoveStat> gameMoveHistory = new List<GameMoveStat>();
+
+      static float RemainingTime(SearchLimit limit, int numMoves, float timeUsed)
+      {
+        if (limit.Type == SearchLimitType.SecondsForAllMoves)
+        {
+          return limit.MaxValueAfterMoves(numMoves) - timeUsed;
+        }
+        else
+        {
+          // TODO: in principle we could do this also for nodes per game limits
+          return 0;
+        }
+      }
+
+      TournamentGameInfo MakeGameInfo(TournamentGameResult result, TournamentGameResultReason reason)
+      {
+        return new TournamentGameInfo()
+        {
+          Engine2IsWhite = engine2IsWhite,
+          GameSequenceNum = gameSequenceNum,
+          OpeningIndex = openingIndex,
+          FEN = startFEN,
+          Result = result, //TournamentGameInfo.InvertedResult(result),
+          ResultReason = reason,
+          PlyCount = plyCount,
+          TotalTimeEngine1 = timeEngine1Tot,
+          TotalTimeEngine2 = timeEngine2Tot,
+          TotalNodesEngine1 = nodesEngine1Tot,
+          TotalNodesEngine2 = nodesEngine2Tot,
+          RemainingTimeEngine1 = RemainingTime(searchLimitEngine1, movesEngine1, timeEngine1Tot),
+          RemainingTimeEngine2 = RemainingTime(searchLimitEngine2, movesEngine2, timeEngine2Tot),
+          ShouldHaveForfeitedOnLimitsEngine1 = engine1ShouldHaveForfieted,
+          ShouldHaveForfeitedOnLimitsEngine2 = engine2ShouldHaveForfieted,
+          NumEngine2MovesDifferentFromCheckEngine = numEngine2MovesDifferentFromCheckEngine,
+          GameMoveHistory = gameMoveHistory
+        };
+
+      }
+
+      // Reset the game state before we begin making moves
+      engine1.CumulativeSearchTimeSeconds = 0;
+      engine1.CumulativeNodes = 0;
+      engine2.CumulativeSearchTimeSeconds = 0;
+      engine2.CumulativeNodes = 0;
+      TournamentGameResult result = TournamentGameResult.None;
+
+      SearchLimit searchLimitWithIncrementsEngine1 = searchLimitEngine1 with { };
+      SearchLimit searchLimitWithIncrementsEngine2 = searchLimitEngine2 with { };
+
+
+      // Keep a list of all positions seen so far in game      
+      List<Position> encounteredPositions = new List<Position>();
+
+      // Repeatedly make moves
+      while (true)
+      {
+        // Add this position to the set of positions encountered
+        Position currentPosition = curPositionAndMoves.FinalPosition;
+        encounteredPositions.Add(currentPosition);
+
+        // If time or node increment was specified for game-level search limit,
+        // adjust the search limit to give credit for this increment
+        if (!engine2ToMove && searchLimitEngine1.ValueIncrement != 0)
+        {
+          searchLimitWithIncrementsEngine1 = searchLimitWithIncrementsEngine1.WithIncrementApplied();
+        }
+
+        if (engine2ToMove && searchLimitEngine2.ValueIncrement != 0)
+        {
+          searchLimitWithIncrementsEngine2 = searchLimitWithIncrementsEngine2.WithIncrementApplied();
+        }
+
+        // Check for very bad evaluation for one side (agreed by both sides)
+        if (scoresEngine1.Count > 5)
+        {
+          result = CheckResultAgreedBothEngines(scoresEngine1, scoresEngine2, result);
+          if (result != TournamentGameResult.None)
+          {
+            return MakeGameInfo(result, TournamentGameResultReason.AdjudicatedEvaluation);
+          }
+        }
+
+        info.FEN = currentPosition.FEN;
+        info.MoveNum = plyCount / 2;
+
+        // Check for draw by repetition of position (3 times)
+        int countRepetitions = 0;
+        foreach (Position pos in encounteredPositions)
+        {
+          if (pos.EqualAsRepetition(in currentPosition))
+          {
+            countRepetitions++;
+          }
+        }
+
+        if (countRepetitions >= 3)
+        {
+          return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.Repetition);
+        }
+
+
+        // Check for draw by insufficient material
+        if (curPositionAndMoves.FinalPosition.CheckDrawBasedOnMaterial == Position.PositionDrawStatus.DrawByInsufficientMaterial)
+        {
+          return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.AdjudicateMaterial);
+        }
+        else if (curPositionAndMoves.FinalPosition.CheckDrawCanBeClaimed == Position.PositionDrawStatus.DrawCanBeClaimed)
+        {
+          return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.Repetition);
+        }
+        else if (plyCount >= 500)
+        {
+          return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.ExcessiveMoves);
+        }
+
+        // Check for terminal result (tablebase or intrinsically terminal)
+        TournamentGameResultReason reason;
+        result = TournamentUtils.TryGetGameResultIfTerminal(curPositionAndMoves, !engine2IsWhite, useTablebasesForAdjudication, out reason);
+        if (result != TournamentGameResult.None)
+        {
+          return MakeGameInfo(result, reason);
+        }
+
+        plyCount++;
+
+        int numPieces = Position.FromFEN(info.FEN).PieceCount;
+
+        // Make player's move
+        GameMoveStat moveStat;
+        if (engine2ToMove)
+        {
+          info = DoMove(engine2, engineCheckAgainstEngine2,
+                        gameMoveHistory, searchLimitWithIncrementsEngine2, scoresEngine2,
+                        ref nodesEngine2Tot, ref visitsEngine2Tot, ref timeEngine2Tot);
+          movesEngine2++;
+
+          if (engine2IsWhite)
+          {
+            engine2ShouldHaveForfieted |= info.WhiteShouldHaveForfeitedOnLimit;
+            moveStat = new GameMoveStat(plyCount, SideType.White, info.WhiteScoreQ, info.WhiteScoreCentipawns, engine2.CumulativeSearchTimeSeconds, numPieces, info.WhiteMAvg, info.WhiteFinalN, info.WhiteNumNodesComputed, info.WhiteSearchLimitPre, info.WhiteMoveTimeUsed);
+          }
+          else
+          {
+            engine2ShouldHaveForfieted |= info.BlackShouldHaveForfeitedOnLimit;
+            moveStat = new GameMoveStat(plyCount, SideType.Black, info.BlackScoreQ, info.BlackScoreCentipawns, engine2.CumulativeSearchTimeSeconds, numPieces, info.BlackMAvg, info.BlackFinalN, info.BlackNumNodesComputed, info.BlackSearchLimitPre, info.BlackMoveTimeUsed);
+          }
+        }
+        else
+        {
+          info = DoMove(engine1, null,
+                        gameMoveHistory, searchLimitWithIncrementsEngine1, scoresEngine1,
+                        ref nodesEngine1Tot, ref visitsEngine1Tot, ref timeEngine1Tot);
+          movesEngine1++;
+          if (engine2IsWhite)
+          {
+            engine1ShouldHaveForfieted |= info.BlackShouldHaveForfeitedOnLimit;
+            moveStat = new GameMoveStat(plyCount, SideType.Black, info.BlackScoreQ, info.BlackScoreCentipawns, engine1.CumulativeSearchTimeSeconds, numPieces, info.BlackMAvg, info.BlackFinalN, info.BlackNumNodesComputed, info.BlackSearchLimitPre, info.BlackMoveTimeUsed);
+          }
+          else
+          {
+            engine1ShouldHaveForfieted |= info.WhiteShouldHaveForfeitedOnLimit;
+            moveStat = new GameMoveStat(plyCount, SideType.White, info.WhiteScoreQ, info.WhiteScoreCentipawns, engine1.CumulativeSearchTimeSeconds, numPieces, info.WhiteMAvg, info.WhiteFinalN, info.WhiteNumNodesComputed, info.WhiteSearchLimitPre, info.WhiteMoveTimeUsed);
+          }
+        }
+
+
+        gameMoveHistory.Add(moveStat);
+
+        engine2ToMove = !engine2ToMove;
+        if (plyCount % 2 == 1)
+        {
+          info = new GameMoveConsoleInfo();
+          if (showMoves) logger.WriteLine();
+        }
+      }
+
+
+      GameMoveConsoleInfo DoMove(GameEngine engine, GameEngine checkMoveEngine,
+                                 List<GameMoveStat> gameMoveHistory,
+                                 SearchLimit searchLimit, List<float> scoresCP,
+                                  ref long totalNodesUsed, ref long totalVisitsUsed, ref float totalTimeUsed)
+      {
+        SearchLimit thisMoveSearchLimit = searchLimit.Type switch
+        {
+          SearchLimitType.SecondsPerMove => searchLimit,
+          SearchLimitType.NodesPerMove => searchLimit,
+          SearchLimitType.NodesForAllMoves => new SearchLimit(SearchLimitType.NodesForAllMoves,
+                                                              Math.Max(0, searchLimit.Value - totalVisitsUsed),
+                                                              searchLimit.SearchCanBeExpanded,
+                                                              searchLimit.ValueIncrement,
+                                                              searchLimit.MaxMovesToGo),
+          SearchLimitType.SecondsForAllMoves => new SearchLimit(SearchLimitType.SecondsForAllMoves,
+                                                                MathF.Max(0, searchLimit.Value - totalTimeUsed),
+                                                                searchLimit.SearchCanBeExpanded,
+                                                                searchLimit.ValueIncrement,
+                                                                searchLimit.MaxMovesToGo),
+          _ => throw new Exception($"Internal error, unknown SearchLimit.LimitType {searchLimit.Type}")
+        };
+
+        GameEngineSearchResult engineMove = engine.Search(curPositionAndMoves, thisMoveSearchLimit, gameMoveHistory);
+        float engineTime = (float)engineMove.TimingStats.ElapsedTimeSecs;
+
+        // Check for time forfeit
+        bool shouldHaveForfeited = false;
+        if (thisMoveSearchLimit.IsTimeLimit)
+        {
+          const float GRACE_FRACTION = 0.02f; // Allow up to 2% over
+          float GRACE_SECONDS = searchLimit.Value * GRACE_FRACTION;
+          float timeExcess = engineTime - thisMoveSearchLimit.Value;
+          if (gameMoveHistory.Count >= 2 && timeExcess > GRACE_SECONDS)
+          {
+            shouldHaveForfeited = true;
+
+            // TODO: (a) remove the "Count > 2" restriction above,
+            //       (b) reconsider the GRACE_FRACTION above
+            //       (b) log this
+            //throw new Exception($"Time forfeit, allotted {thisMoveSearchLimit.Value} used {engineTime} for engine {engine}");
+          }
+        }
+
+        GameEngineSearchResult checkSearch = default;
+        string checkMove = "";
+        if (checkMoveEngine != null)
+        {
+          checkSearch = checkMoveEngine.Search(curPositionAndMoves, searchLimit);
+          checkMove = checkSearch.MoveString;
+          if (engineMove.MoveString != checkMove)
+          {
+            numEngine2MovesDifferentFromCheckEngine++;
+          }
+        }
+
+        // Verify the engine's move was legal by trying to make it.
+        try
+        {
+          Position positionAfterMoveTest = curPositionAndMoves.FinalPosition.AfterMove(Move.FromUCI(engineMove.MoveString));
+        }
+        catch (Exception exc)
+        {
+          throw new Exception($"Engine {engine.ID} made illegal move {engineMove.MoveString} in position {curPositionAndMoves.FinalPosition.FEN}");
+        }
+
+        PositionWithHistory newPosition = new PositionWithHistory(curPositionAndMoves);
+        newPosition.AppendMove(engineMove.MoveString);
+
+        // Output position to PGN
+        pgnWriter.WriteMove(newPosition.Moves[^1], curPositionAndMoves.FinalPosition, engineTime, engineMove.Depth, engineMove.ScoreCentipawns);
+
+        scoresCP.Add(engineMove.ScoreCentipawns);
+
+        totalNodesUsed += engineMove.FinalN;
+        totalVisitsUsed += engineMove.Visits;
+        totalTimeUsed += engineTime;
+        if (curPositionAndMoves.FinalPosition.MiscInfo.SideToMove == SideType.White)
+        {
+          info.WhiteMoveStr = engineMove.MoveString;
+          info.WhiteScoreQ = engineMove.ScoreQ;
+          info.WhiteScoreCentipawns = engineMove.ScoreCentipawns;
+          info.WhiteSearchLimitPre = thisMoveSearchLimit;
+          info.WhiteSearchLimitPost = engineMove.Limit;
+          info.WhiteMoveTimeUsed = engineTime;
+          info.WhiteTimeAllMoves = totalTimeUsed;
+          info.WhiteNodesAllMoves = totalNodesUsed;
+          info.WhiteStartN = engineMove.StartingN;
+          info.WhiteFinalN = engineMove.FinalN;
+          info.WhiteMAvg = engineMove.MAvg;
+          info.WhiteCheckMoveStr = checkMove;
+          info.WhiteShouldHaveForfeitedOnLimit = shouldHaveForfeited;
+        }
+        else
+        {
+          info.BlackMoveStr = engineMove.MoveString;
+          info.BlackScoreQ = engineMove.ScoreQ;
+          info.BlackScoreCentipawns = engineMove.ScoreCentipawns;
+          info.BlackSearchLimitPre = thisMoveSearchLimit;
+          info.BlackSearchLimitPost = engineMove.Limit;
+          info.BlackMoveTimeUsed = engineTime;
+          info.BlackTimeAllMoves = totalTimeUsed;
+          info.BlackNodesAllMoves = totalNodesUsed;
+          info.BlackStartN = engineMove.StartingN;
+          info.BlackFinalN = engineMove.FinalN;
+          info.BlackMAvg = engineMove.MAvg;
+          info.BlackCheckMoveStr = checkMove;
+          info.BlackShouldHaveForfeitedOnLimit = shouldHaveForfeited;
+        }
+
+        if (showMoves) info.PutStr();
+
+        // Advance to next move
+        curPositionAndMoves = newPosition;
+
+        return info;
+      }
+    }
+
+
+    static float MinLastN(List<float> vals, int count)
+    {
+      float min = float.MaxValue;
+      for (int i = 1; i <= count; i++)
+        if (vals[^i] < min)
+          min = vals[^i];
+      return min;
+    }
+
+    static float MaxLastN(List<float> vals, int count)
+    {
+      float max = float.MinValue;
+      for (int i = 1; i <= count; i++)
+        if (vals[^i] > max)
+          max = vals[^i];
+      return max;
+    }
+
+    TournamentGameResult CheckResultAgreedBothEngines(List<float> scoresCPEngine1, List<float> scoresCPEngine2, TournamentGameResult result)
+    {
+      int WIN_THRESHOLD = Run.Def.AdjudicationThresholdCentipawns;
+      int NUM_MOVES = Run.Def.AdjudicationThresholdNumMoves;
+
+      // Return if insufficient moves in history to make determination.
+      if (scoresCPEngine2.Count < NUM_MOVES || scoresCPEngine1.Count < NUM_MOVES)
+        return result;
+
+      if (MinLastN(scoresCPEngine2, NUM_MOVES) > WIN_THRESHOLD && MaxLastN(scoresCPEngine1, NUM_MOVES) < -WIN_THRESHOLD)
+      {
+        return TournamentGameResult.Loss;
+      }
+      else if (MinLastN(scoresCPEngine1, NUM_MOVES) > WIN_THRESHOLD && MaxLastN(scoresCPEngine2, NUM_MOVES) < -WIN_THRESHOLD)
+      {
+        return TournamentGameResult.Win;
+      }
+      else
+      {
+        return result;
+      }
+    }
+
+  }
 }

--- a/src/Ceres.Features/Tournaments/TournamentGameThread.cs
+++ b/src/Ceres.Features/Tournaments/TournamentGameThread.cs
@@ -27,181 +27,224 @@ using Chess.Ceres.PlayEvaluation;
 using Ceres.Chess.GameEngines;
 using Ceres.Chess.UserSettings;
 using Ceres.MCTS.Iteration;
+using System.Linq;
 
 #endregion
 
 namespace Ceres.Features.Tournaments
 {
-  /// <summary>
-  /// Manage execution of a single thread of a tournament,
-  /// running the main move loop which alternates between players.
-  /// </summary>
-  public class TournamentGameThread
-  {
-    public delegate TournamentGameInfo GamePairRunnerDelegate(string pgnFileName, int gameSequenceNum, int openingIndex, int roundNumber, bool engine2White);
-
     /// <summary>
-    /// Definition of associated parent tournament definition.
+    /// Manage execution of a single thread of a tournament,
+    /// running the main move loop which alternates between players.
     /// </summary>
-    public readonly TournamentDef Def;
-
-    /// <summary>
-    /// Collection of tournament result statistics.
-    /// </summary>
-    public readonly TournamentResultStats ParentStats;
-
-    // TODO: This is not correct to be static in the case that 
-    //       multiple tournaments are being run simultaneously.
-    static bool havePrintedHeaders = false;
-
-
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    /// <param name="def"></param>
-    /// <param name="parentTestResults"></param>
-    public TournamentGameThread(TournamentDef def, TournamentResultStats parentTestResults)
+    public class TournamentGameThread
     {
-      Def = def;
-      ParentStats = parentTestResults;
-    }
+        public delegate TournamentGameInfo GamePairRunnerDelegate(string pgnFileName, int gameSequenceNum, int openingIndex, int roundNumber, bool engine2White);
+
+        /// <summary>
+        /// Definition of associated parent tournament definition.
+        /// </summary>
+        public readonly TournamentDef Def;
+
+        /// <summary>
+        /// Collection of tournament result statistics.
+        /// </summary>
+        public readonly TournamentResultStats ParentStats;
+
+        // TODO: This is not correct to be static in the case that 
+        //       multiple tournaments are being run simultaneously.
+        static bool havePrintedHeaders = false;
 
 
-    static PositionsWithHistory openings = new PositionsWithHistory();
 
-    static object writePGNLock = new();
-
-    public long TotalNodesEngine1 = 0;
-    public long TotalNodesEngine2 = 0;
-    public int TotalMovesEngine1 = 0;
-    public int TotalMovesEngine2 = 0;
-    public float TotalTimeEngine1 = 0;
-    public float TotalTimeEngine2 = 0;
-    public float NumGames;
-
-    public TournamentGameRunner Run;
-
-    int numGamePairsLaunched = 0;
-    readonly object lockObj = new();
-
-    /// <summary>
-    /// Method called by threads to get the next available game to be played.
-    /// </summary>
-    /// <returns></returns>
-    int GetNextOpeningIndexForLocalThread(int maxOpenings)
-    {
-      if (Def.RandomizeOpenings) throw new NotImplementedException();
-
-      lock (lockObj)
-      {
-        if (numGamePairsLaunched < maxOpenings)
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="def"></param>
+        /// <param name="parentTestResults"></param>
+        public TournamentGameThread(TournamentDef def, TournamentResultStats parentTestResults)
         {
-          return numGamePairsLaunched++;
+            Def = def;
+            ParentStats = parentTestResults;
         }
-        else
-          return -1;
-      }
-    }
 
-    public void RunGameTests(int runnerIndex, Func<int> getGamePairToProcess,
-                             Action<TournamentGameInfo, TournamentGameInfo> doneGamePairCallback = null)     
-    {
-      Run = new TournamentGameRunner(Def);
 
-      // Create a file name that will be common to all threads in tournament.
-      string pgnFileName = Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "match_" + Def.ID + "_"
-                                      + Run.Engine1.ID + "_" + Run.Engine2.ID + "_" + Def.StartTime.Ticks + ".pgn");
-      lock (writePGNLock) File.AppendAllText(pgnFileName, "");
+        static PositionsWithHistory openings = new PositionsWithHistory();
 
-      havePrintedHeaders = false;
+        static object writePGNLock = new();
 
-      SetOpeningsSource();
+        public long TotalNodesEngine1 = 0;
+        public long TotalNodesEngine2 = 0;
+        public int TotalMovesEngine1 = 0;
+        public int TotalMovesEngine2 = 0;
+        public float TotalTimeEngine1 = 0;
+        public float TotalTimeEngine2 = 0;
+        public float NumGames;
 
-      Random rand = new Random();
+        public TournamentGameRunner Run;
 
-      // Def.Logger.WriteLine($"Begin {def.NumGames} game test with limit {def.SearchLimitEngine1} {def.SearchLimitEngine2} ID { gameSequenceNum } ");
-      int numPairsProcessed = 0;
+        int numGamePairsLaunched = 0;
+        readonly object lockObj = new();
 
-      int maxOpenings = Math.Min(Def.NumGamePairs ?? int.MaxValue, openings.Count);
-
-      while (true)
-      {
-        int openingIndex = getGamePairToProcess();
-
-        // Look for sentinel indicating end
-        if (openingIndex < 0)
+        /// <summary>
+        /// Method called by threads to get the next available game to be played.
+        /// </summary>
+        /// <returns></returns>
+        int GetNextOpeningIndexForLocalThread(int maxOpenings)
         {
-          break;
+            if (Def.RandomizeOpenings) throw new NotImplementedException();
+
+            lock (lockObj)
+            {
+                if (numGamePairsLaunched < maxOpenings)
+                {
+                    return numGamePairsLaunched++;
+                }
+                else
+                    return -1;
+            }
         }
+
+        public void RunGameTests(int runnerIndex, Func<int> getGamePairToProcess,
+                                 Action<TournamentGameInfo, TournamentGameInfo> doneGamePairCallback = null)
+        {
+            Run = new TournamentGameRunner(Def);
+
+            // Create a file name that will be common to all threads in tournament.
+            string pgnFileName;
+            if (Run.Engines.Count > 0)
+            {
+                pgnFileName = Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "match_" + Def.ID + "_"
+                                            + "MultiEngine" + "_" + Def.StartTime.Ticks + ".pgn");
+            }
+            else
+            {
+                pgnFileName = Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "match_" + Def.ID + "_"
+                                            + Run.Engine1.ID + "_" + Run.Engine2.ID + "_" + Def.StartTime.Ticks + ".pgn");
+            }
+            lock (writePGNLock) File.AppendAllText(pgnFileName, "");
+
+            havePrintedHeaders = false;
+
+            SetOpeningsSource();
+
+            Random rand = new Random();
+
+            // Def.Logger.WriteLine($"Begin {def.NumGames} game test with limit {def.SearchLimitEngine1} {def.SearchLimitEngine2} ID { gameSequenceNum } ");
+            int numPairsProcessed = 0;
+
+            int maxOpenings = Math.Min(Def.NumGamePairs ?? int.MaxValue, openings.Count);
+
+            while (true)
+            {
+                int openingIndex = getGamePairToProcess();
+
+                // Look for sentinel indicating end
+                if (openingIndex < 0)
+                {
+                    break;
+                }
 #if NOT
         // Some engines such as LZ0 doesn't seem to support "setoption name Clear Hash"
         // Therefore we don't clear cache every time, instead let it stick around unless first game in a set
         bool clearHashTable = isFirstGameOfPossiblePair;
 #endif
 
-        int gameSequenceNum = openingIndex * 2;
+                int gameSequenceNum = openingIndex * 2;
 
-        // The engine going second could possibly benefit 
-        // if REUSE_POSITION_EVALUATIONS_FROM_OTHER_TREE is true.
-        // Therefore we alternate each pair which one goes first.
-        int roundNumber = 1 + gameSequenceNum / 2;
+                // The engine going second could possibly benefit 
+                // if REUSE_POSITION_EVALUATIONS_FROM_OTHER_TREE is true.
+                // Therefore we alternate each pair which one goes first.
+                int roundNumber = 1 + gameSequenceNum / 2;
 
-        // Alternate which side gets white to avoid any clustered imbalance
-        // which could happen if multiple threads are active
-        // (possibly otherwise all first giving white to one particular side).
-        bool engine2White = (numPairsProcessed + runnerIndex) % 2 == 0;
+                // Alternate which side gets white to avoid any clustered imbalance
+                // which could happen if multiple threads are active
+                // (possibly otherwise all first giving white to one particular side).
+                bool engine2White = (numPairsProcessed + runnerIndex) % 2 == 0;
+                
+                if (Run.Engines.Count > 0)
+                {
+                    var list = new List<GameEngine>(Run.Engines);
+                    int engine1Index = 0;
+                    while (list.Count > 1)
+                    {
+                        for (int i = 1; i < list.Count; i++)
+                        {
+                            Run.CreateAndPrepareEngines(engine1Index, i+engine1Index);
 
-        TournamentGameInfo gameInfo        = RunGame(pgnFileName, engine2White, openingIndex, gameSequenceNum, roundNumber);
-        TournamentGameInfo gameReverseInfo = RunGame(pgnFileName, !engine2White, openingIndex, gameSequenceNum + 1, roundNumber);
+                            TournamentGameInfo gameInfo = RunGame(pgnFileName, engine2White, openingIndex, gameSequenceNum, roundNumber);
+                            TournamentGameInfo gameReverseInfo = RunGame(pgnFileName, !engine2White, openingIndex, gameSequenceNum + 1, roundNumber);
+                            doneGamePairCallback?.Invoke(gameInfo, gameReverseInfo);
+                        }
+                        list.RemoveAt(0);
+                        engine1Index++;
+                    }
+                    numPairsProcessed++;
+                }
 
-        doneGamePairCallback?.Invoke(gameInfo, gameReverseInfo);
+                else
+                {
 
-        numPairsProcessed++;
-      }
+                    TournamentGameInfo gameInfo = RunGame(pgnFileName, engine2White, openingIndex, gameSequenceNum, roundNumber);
+                    TournamentGameInfo gameReverseInfo = RunGame(pgnFileName, !engine2White, openingIndex, gameSequenceNum + 1, roundNumber);
+                    doneGamePairCallback?.Invoke(gameInfo, gameReverseInfo);
+                    numPairsProcessed++;
+                }
+            }
 
-      Run.Engine1.Dispose();
-      Run.Engine2.Dispose();
-      Run.Engine2CheckEngine?.Dispose();
-    }
+            if (Run.Engines.Count > 0)
+            {
+                foreach (var engine in Run.Engines)
+                {
+                    engine.Dispose();                    
+                    Run.Engine2CheckEngine?.Dispose();
+                }
+            }
+            else
+            {
+                Run.Engine1.Dispose();
+                Run.Engine2.Dispose();
+                Run.Engine2CheckEngine?.Dispose();
+            }
+        }
 
-    private void SetOpeningsSource()
-    {
-      if (Def.OpeningsFileName != null)
-      {
-        openings = PositionsWithHistory.FromEPDOrPGNFile(Def.OpeningsFileName);
-      }
-      else if (Def.StartingFEN != null)
-      {
-        openings = PositionsWithHistory.FromFEN(Def.StartingFEN, Def.NumGamePairs ?? 1);
-      }
-      else
-      {
-        openings = PositionsWithHistory.FromFEN(Position.StartPosition.FEN, Def.NumGamePairs ?? 1);
-      }
-    }
-
-
-    /// <summary>
-    /// Returns list of supplemental name/value tags to be 
-    /// included in the PGN header with helpful ancillary metadata.
-    /// </summary>
-    /// <param name="engine2White"></param>
-    /// <returns></returns>
-    List<(string name, string value)> GetSupplementalTags(bool engine2White)
-    {
-      List<(string name, string value)> tags = new List<(string name, string value)>();
-
-      tags.Add((engine2White ? "BlackEngine" : "WhiteEngine", Def.Player1Def.EngineDef.ToString()));
-      tags.Add((engine2White ? "WhiteEngine" : "BlackEngine", Def.Player2Def.EngineDef.ToString()));
-      tags.Add(("CeresVersion", CeresVersion.VersionString));
-      tags.Add(("CeresGIT", GitInfo.VersionString));
-
-      return tags;   
-    }
+        private void SetOpeningsSource()
+        {
+            if (Def.OpeningsFileName != null)
+            {
+                openings = PositionsWithHistory.FromEPDOrPGNFile(Def.OpeningsFileName);
+            }
+            else if (Def.StartingFEN != null)
+            {
+                openings = PositionsWithHistory.FromFEN(Def.StartingFEN, Def.NumGamePairs ?? 1);
+            }
+            else
+            {
+                openings = PositionsWithHistory.FromFEN(Position.StartPosition.FEN, Def.NumGamePairs ?? 1);
+            }
+        }
 
 
-    HashSet<int> openingsFinishedAtLeastOnce = new();
+        /// <summary>
+        /// Returns list of supplemental name/value tags to be 
+        /// included in the PGN header with helpful ancillary metadata.
+        /// </summary>
+        /// <param name="engine2White"></param>
+        /// <returns></returns>
+        List<(string name, string value)> GetSupplementalTags(bool engine2White)
+        {
+            List<(string name, string value)> tags = new List<(string name, string value)>();
+
+            tags.Add((engine2White ? "BlackEngine" : "WhiteEngine", Def.Player1Def.EngineDef.ToString()));
+            tags.Add((engine2White ? "WhiteEngine" : "BlackEngine", Def.Player2Def.EngineDef.ToString()));
+            tags.Add(("CeresVersion", CeresVersion.VersionString));
+            tags.Add(("CeresGIT", GitInfo.VersionString));
+
+            return tags;
+        }
+
+
+        HashSet<int> openingsFinishedAtLeastOnce = new();
 
 #if NOT
     public record TournamentGameRunRequest
@@ -214,619 +257,619 @@ namespace Ceres.Features.Tournaments
     }
 #endif
 
-    private TournamentGameInfo RunGame(string pgnFileName, bool engine2White, int openingIndex, int gameSequenceNum, int roundNumber)
-    {
-      TournamentGameInfo thisResult;
-
-      // Add some supplemental tags with round number and also
-      // information about Ceres engine configuration.
-      var extraTags = GetSupplementalTags(engine2White);
-      extraTags.Add(("Round", roundNumber.ToString()));
-
-      PGNWriter pgnWriter = new PGNWriter(null, engine2White ? Run.Engine2.ID : Run.Engine1.ID,
-                                  engine2White ? Run.Engine1.ID : Run.Engine2.ID,
-                                  extraTags.ToArray());
-
-
-      TimingStats gameTimingStats = new TimingStats();
-      using (new TimingBlock(gameTimingStats, TimingBlock.LoggingType.None))
-      {
-        // Start new game
-        string gameID = $"{Def.ID}_GAME_SEQ{gameSequenceNum}_OPENING_{openingIndex}";
-        Run.Engine1.ResetGame(gameID);
-        Run.Engine2.ResetGame(gameID);
-        Run.Engine2CheckEngine?.ResetGame(gameID);
-
-        bool checkTablebases = Def.UseTablebasesForAdjudication && CeresUserSettingsManager.Settings.TablebaseDirectory != null;
-        thisResult = DoGameTest(Def.Logger, pgnWriter, gameSequenceNum, openingIndex,
-                                Run.Engine1, Run.Engine2,
-                                Run.Engine2CheckEngine, engine2White,
-                                Def.Player1Def.SearchLimit, Def.Player2Def.SearchLimit,
-                                checkTablebases, Def.ShowGameMoves);
-
-        if (MCTSDiagnostics.TournamentDumpEngine2EndOfGameSummary)
+        private TournamentGameInfo RunGame(string pgnFileName, bool engine2White, int openingIndex, int gameSequenceNum, int roundNumber)
         {
-          Run.Engine2.DumpFullMoveHistory(thisResult.GameMoveHistory, engine2White);
+            TournamentGameInfo thisResult;
+
+            // Add some supplemental tags with round number and also
+            // information about Ceres engine configuration.
+            var extraTags = GetSupplementalTags(engine2White);
+            extraTags.Add(("Round", roundNumber.ToString()));
+
+            PGNWriter pgnWriter = new PGNWriter(null, engine2White ? Run.Engine2.ID : Run.Engine1.ID,
+                                        engine2White ? Run.Engine1.ID : Run.Engine2.ID,
+                                        extraTags.ToArray());
+
+
+            TimingStats gameTimingStats = new TimingStats();
+            using (new TimingBlock(gameTimingStats, TimingBlock.LoggingType.None))
+            {
+                // Start new game
+                string gameID = $"{Def.ID}_GAME_SEQ{gameSequenceNum}_OPENING_{openingIndex}";
+                Run.Engine1.ResetGame(gameID);
+                Run.Engine2.ResetGame(gameID);
+                Run.Engine2CheckEngine?.ResetGame(gameID);
+
+                bool checkTablebases = Def.UseTablebasesForAdjudication && CeresUserSettingsManager.Settings.TablebaseDirectory != null;
+                thisResult = DoGameTest(Def.Logger, pgnWriter, gameSequenceNum, openingIndex,
+                                        Run.Engine1, Run.Engine2,
+                                        Run.Engine2CheckEngine, engine2White,
+                                        Def.Player1Def.SearchLimit, Def.Player2Def.SearchLimit,
+                                        checkTablebases, Def.ShowGameMoves);
+
+                if (MCTSDiagnostics.TournamentDumpEngine2EndOfGameSummary)
+                {
+                    Run.Engine2.DumpFullMoveHistory(thisResult.GameMoveHistory, engine2White);
+                }
+
+                WritePGNResult(engine2White, thisResult, pgnWriter);
+
+                if (pgnFileName != null)
+                {
+                    lock (writePGNLock) File.AppendAllText(pgnFileName, pgnWriter.GetText());
+                }
+
+            }
+
+            UpdateStatsAndOutputSummaryFromGameResult(pgnFileName, engine2White, openingIndex, gameSequenceNum, thisResult);
+
+            return thisResult;
         }
 
-        WritePGNResult(engine2White, thisResult, pgnWriter);
-
-        if (pgnFileName != null)
+        internal void UpdateStatsAndOutputSummaryFromGameResult(string pgnFileName, bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
         {
-          lock (writePGNLock) File.AppendAllText(pgnFileName, pgnWriter.GetText());
+            lock (ParentStats)
+            {
+                ParentStats.UpdateTournamentStats(thisResult);
+            }
+
+            // Only show headers first time for first thread
+            if (!havePrintedHeaders)
+            {
+                OutputHeaders(pgnFileName);
+            }
+
+            OutputGameResultInfo(engine2White, openingIndex, gameSequenceNum, thisResult);
         }
 
-      }
+        private void OutputGameResultInfo(bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
+        {
+            (float eloMin, float eloAvg, float eloMax) = EloCalculator.EloConfidenceInterval(ParentStats.Player1Wins, ParentStats.Draws, ParentStats.Player1Losses);
+            float eloSD = eloMax - eloAvg;
+            float los = EloCalculator.LikelihoodSuperiority(ParentStats.Player1Wins, ParentStats.Draws, ParentStats.Player1Losses);
 
-      UpdateStatsAndOutputSummaryFromGameResult(pgnFileName, engine2White, openingIndex, gameSequenceNum, thisResult);
+            string wdlStr = $"{ParentStats.Player1Wins,3} {ParentStats.Draws,3} {ParentStats.Player1Losses,3}";
 
-      return thisResult;
+            // Show a "." after the opening index if this was the second of the pair of games played.
+            string openingPlayedBothWaysStr = openingsFinishedAtLeastOnce.Contains(openingIndex) ? "." : " ";
+
+            string player1ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine1 ? "f" : " ";
+            string player2ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine2 ? "f" : " ";
+
+            const string TournamentGameResultReasonCodes = "CSTMERVL";
+
+            char resultReasonChar = TournamentGameResultReasonCodes[(int)thisResult.ResultReason];
+
+            static bool EvalInconsistent(TournamentGameResult outcome, float scoreCP, int numMovesBack)
+            {
+                float mult = numMovesBack % 2 == 1 ? 1 : -1; // adjust for side to move perspective
+                float adjustedCP = mult * scoreCP;
+                return (outcome == TournamentGameResult.Win && adjustedCP < 100) ||
+                       (outcome == TournamentGameResult.Draw && MathF.Abs(adjustedCP) > 50) ||
+                       (outcome == TournamentGameResult.Loss && adjustedCP > -100);
+            }
+
+            // Possibly show one or two "?" characters if the evaluations of the final two positions
+            // are very inconsisten with the actual game outcome (as a diagnostic).
+            string questionableFinalCP = "  ";
+            float endingCP = 0;
+            if (thisResult.GameMoveHistory.Count > 0)
+            {
+                bool finalMoveIsPlayer1 = (thisResult.GameMoveHistory[^1].Side == SideType.White) != engine2White;
+                float reverseMult = finalMoveIsPlayer1 ? 1 : -1;
+                endingCP = reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns;
+
+                if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns, 1))
+                {
+                    questionableFinalCP = "? ";
+                }
+
+                if (thisResult.GameMoveHistory.Count > 1)
+                {
+                    if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^2].ScoreCentipawns, 2))
+                    {
+                        questionableFinalCP = questionableFinalCP[0] + "?";
+                    }
+
+                }
+            }
+
+            lock (outputLockObj)
+            {
+                string checkEnginePlyDifferent = thisResult.NumEngine2MovesDifferentFromCheckEngine == 0 ? "   " : $"{thisResult.NumEngine2MovesDifferentFromCheckEngine,3:N0}";
+                if (Def.ShowGameMoves) Def.Logger.WriteLine();
+                Def.Logger.Write($" {TrimmedIfNeeded(Def.Player1Def.ID, 10),-10} {TrimmedIfNeeded(Def.Player2Def.ID, 10),-10}");
+                Def.Logger.Write($"{eloAvg,4:0} {eloSD,4:0} {100.0f * los,5:0}  ");
+                Def.Logger.Write($"{ParentStats.NumGames,5} {DateTime.Now.ToString().Split(" ")[1],10}  {gameSequenceNum,4:F0}  {openingIndex,4:F0}{openingPlayedBothWaysStr}  ");
+                Def.Logger.Write($"{thisResult.TotalTimeEngine1,8:F2}{player1ForfeitChar}{thisResult.RemainingTimeEngine1,7:F2} ");
+                Def.Logger.Write($"{thisResult.TotalTimeEngine2,8:F2}{player2ForfeitChar}{thisResult.RemainingTimeEngine2,7:F2}  ");
+                Def.Logger.Write($"{thisResult.TotalNodesEngine1,16:N0} {thisResult.TotalNodesEngine2,16:N0}   ");
+
+                if (Def.CheckPlayer2Def != null)
+                {
+                    Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {checkEnginePlyDifferent}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
+                }
+                else
+                {
+                    Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
+                }
+
+                Def.Logger.Write($" {resultReasonChar}   {endingCP,5:F0}{questionableFinalCP}");
+                Def.Logger.Write($" {wdlStr}   {thisResult.FEN} ");
+                Def.Logger.WriteLine();
+            }
+
+            UpdateAggregateGameStats(thisResult);
+
+            openingsFinishedAtLeastOnce.Add(openingIndex);
+            NumGames++;
+        }
+
+        private void UpdateAggregateGameStats(TournamentGameInfo thisResult)
+        {
+            TotalNodesEngine1 += thisResult.TotalNodesEngine1;
+            TotalNodesEngine2 += thisResult.TotalNodesEngine2;
+            TotalMovesEngine1 += thisResult.PlyCount;
+            TotalMovesEngine2 += thisResult.PlyCount;
+            TotalTimeEngine1 += thisResult.TotalTimeEngine1;
+            TotalTimeEngine2 += thisResult.TotalTimeEngine2;
+        }
+
+        private static void WritePGNResult(bool engine2White, TournamentGameInfo thisResult, PGNWriter pgnWriter)
+        {
+            switch (thisResult.Result)
+            {
+                case TournamentGameResult.Win:
+                    if (engine2White)
+                    {
+                        pgnWriter.WriteResultBlackWins();
+                    }
+                    else
+                    {
+                        pgnWriter.WriteResultWhiteWins();
+                    }
+                    break;
+
+                case TournamentGameResult.Loss:
+                    if (engine2White)
+                    {
+                        pgnWriter.WriteResultWhiteWins();
+                    }
+                    else
+                    {
+                        pgnWriter.WriteResultBlackWins();
+                    }
+                    break;
+
+                default:
+                    pgnWriter.WriteResultDraw();
+                    break;
+            }
+        }
+
+
+        private void OutputHeaders(string pgnFileName)
+        {
+            Def.Logger.WriteLine();
+            Def.Logger.WriteLine($"Games will be incrementally written to file: {pgnFileName}");
+            Def.Logger.WriteLine("Result codes: C=checkmate S=stalemate T=tablebase M=insufficient material E=excessive moves R=draw by repetition V=evaluation agreement F=time forfeit");
+            Def.Logger.WriteLine();
+
+            if (Def.CheckPlayer2Def != null)
+            {
+                Def.Logger.WriteLine("  Player1    Player2   ELO   +/-  LOS   GAME#     TIME    TH#   OP#      TIME1    REM1    TIME2    REM2        NODES 2       PLY  DIF    RES  R   ENDCP     W   D   L   FEN");
+                Def.Logger.WriteLine(" ---------  ---------  ---   ---  ---   -----  --------   ---   ---     ------  ------   ------  ------   --------------   ----  ---    ---  -   -----     -   -   -   ---------------------------------------------------");
+            }
+            else
+            {
+                Def.Logger.WriteLine("  Player1    Player2   ELO   +/-  LOS   GAME#     TIME    TH#   OP#      TIME1    REM1    TIME2    REM2       NODES 1           NODES 2       PLY    RES  R   ENDCP     W   D   L   FEN");
+                Def.Logger.WriteLine(" ---------  ---------  ---   ---  ---   -----  --------   ---   ---     ------  ------   ------  ------    --------------   --------------   ----    ---  -   -----     -   -   -   ---------------------------------------------------");
+            }
+            havePrintedHeaders = true;
+        }
+
+
+        static readonly object outputLockObj = new();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="openingIndex"></param>
+        /// <param name="engine1"></param>
+        /// <param name="engine2"></param>
+        /// <param name="engine2IsWhite"></param>
+        /// <param name="searchLimit"></param>
+        /// <returns>GameResult (from the perspective of engine2)</returns>
+        TournamentGameInfo DoGameTest(TextWriter logger, PGNWriter pgnWriter, int gameSequenceNum, int openingIndex,
+                                     GameEngine engine1, GameEngine engine2, GameEngine engineCheckAgainstEngine2,
+                                     bool engine2IsWhite,
+                                     SearchLimit searchLimitEngine1, SearchLimit searchLimitEngine2,
+                                     bool useTablebasesForAdjudication, bool showMoves)
+        {
+            if (openingIndex >= openings.Count)
+            {
+                throw new Exception($"Reached end of openings of size {openings.Count}.");
+            }
+
+            PositionWithHistory curPositionAndMoves = openings.GetAtIndex(openingIndex);
+            string startFEN = curPositionAndMoves.FinalPosition.FEN;
+            bool engine2ToMove = engine2IsWhite == (curPositionAndMoves.FinalPosition.MiscInfo.SideToMove == SideType.White);
+
+            if (showMoves)
+            {
+                logger.WriteLine();
+                logger.WriteLine("NEW GAME from " + curPositionAndMoves);
+                if (engine2ToMove)
+                {
+                    logger.WriteLine((engine2IsWhite ? "White: " : "Black: ") + engine2.ID + " [" + searchLimitEngine2 + "]");
+                    logger.WriteLine((engine2IsWhite ? "Black: " : "White: ") + engine1.ID + " [" + searchLimitEngine1 + "]");
+                }
+                else
+                {
+                    logger.WriteLine((engine2IsWhite ? "Black: " : "White: ") + engine1.ID + " [" + searchLimitEngine1 + "]");
+                    logger.WriteLine((engine2IsWhite ? "White: " : "Black: ") + engine2.ID + " [" + searchLimitEngine2 + "]");
+                }
+            }
+
+            pgnWriter.WriteStartPosition(startFEN);
+
+
+            GameMoveConsoleInfo info = new GameMoveConsoleInfo();
+
+            int plyCount = 1;
+            float timeEngine1Tot = 0;
+            float timeEngine2Tot = 0;
+            long visitsEngine1Tot = 0;
+            long visitsEngine2Tot = 0;
+            long nodesEngine1Tot = 0;
+            long nodesEngine2Tot = 0;
+            int movesEngine1 = 0;
+            int movesEngine2 = 0;
+            bool engine1ShouldHaveForfieted = false;
+            bool engine2ShouldHaveForfieted = false;
+
+            int numEngine2MovesDifferentFromCheckEngine = 0;
+
+            List<float> scoresEngine1 = new List<float>();
+            List<float> scoresEngine2 = new List<float>();
+
+            List<GameMoveStat> gameMoveHistory = new List<GameMoveStat>();
+
+            static float RemainingTime(SearchLimit limit, int numMoves, float timeUsed)
+            {
+                if (limit.Type == SearchLimitType.SecondsForAllMoves)
+                {
+                    return limit.MaxValueAfterMoves(numMoves) - timeUsed;
+                }
+                else
+                {
+                    // TODO: in principle we could do this also for nodes per game limits
+                    return 0;
+                }
+            }
+
+            TournamentGameInfo MakeGameInfo(TournamentGameResult result, TournamentGameResultReason reason)
+            {
+                return new TournamentGameInfo()
+                {
+                    Engine2IsWhite = engine2IsWhite,
+                    GameSequenceNum = gameSequenceNum,
+                    OpeningIndex = openingIndex,
+                    FEN = startFEN,
+                    Result = result, //TournamentGameInfo.InvertedResult(result),
+                    ResultReason = reason,
+                    PlyCount = plyCount,
+                    TotalTimeEngine1 = timeEngine1Tot,
+                    TotalTimeEngine2 = timeEngine2Tot,
+                    TotalNodesEngine1 = nodesEngine1Tot,
+                    TotalNodesEngine2 = nodesEngine2Tot,
+                    RemainingTimeEngine1 = RemainingTime(searchLimitEngine1, movesEngine1, timeEngine1Tot),
+                    RemainingTimeEngine2 = RemainingTime(searchLimitEngine2, movesEngine2, timeEngine2Tot),
+                    ShouldHaveForfeitedOnLimitsEngine1 = engine1ShouldHaveForfieted,
+                    ShouldHaveForfeitedOnLimitsEngine2 = engine2ShouldHaveForfieted,
+                    NumEngine2MovesDifferentFromCheckEngine = numEngine2MovesDifferentFromCheckEngine,
+                    GameMoveHistory = gameMoveHistory
+                };
+
+            }
+
+            // Reset the game state before we begin making moves
+            engine1.CumulativeSearchTimeSeconds = 0;
+            engine1.CumulativeNodes = 0;
+            engine2.CumulativeSearchTimeSeconds = 0;
+            engine2.CumulativeNodes = 0;
+            TournamentGameResult result = TournamentGameResult.None;
+
+            SearchLimit searchLimitWithIncrementsEngine1 = searchLimitEngine1 with { };
+            SearchLimit searchLimitWithIncrementsEngine2 = searchLimitEngine2 with { };
+
+
+            // Keep a list of all positions seen so far in game      
+            List<Position> encounteredPositions = new List<Position>();
+
+            // Repeatedly make moves
+            while (true)
+            {
+                // Add this position to the set of positions encountered
+                Position currentPosition = curPositionAndMoves.FinalPosition;
+                encounteredPositions.Add(currentPosition);
+
+                // If time or node increment was specified for game-level search limit,
+                // adjust the search limit to give credit for this increment
+                if (!engine2ToMove && searchLimitEngine1.ValueIncrement != 0)
+                {
+                    searchLimitWithIncrementsEngine1 = searchLimitWithIncrementsEngine1.WithIncrementApplied();
+                }
+
+                if (engine2ToMove && searchLimitEngine2.ValueIncrement != 0)
+                {
+                    searchLimitWithIncrementsEngine2 = searchLimitWithIncrementsEngine2.WithIncrementApplied();
+                }
+
+                // Check for very bad evaluation for one side (agreed by both sides)
+                if (scoresEngine1.Count > 5)
+                {
+                    result = CheckResultAgreedBothEngines(scoresEngine1, scoresEngine2, result);
+                    if (result != TournamentGameResult.None)
+                    {
+                        return MakeGameInfo(result, TournamentGameResultReason.AdjudicatedEvaluation);
+                    }
+                }
+
+                info.FEN = currentPosition.FEN;
+                info.MoveNum = plyCount / 2;
+
+                // Check for draw by repetition of position (3 times)
+                int countRepetitions = 0;
+                foreach (Position pos in encounteredPositions)
+                {
+                    if (pos.EqualAsRepetition(in currentPosition))
+                    {
+                        countRepetitions++;
+                    }
+                }
+
+                if (countRepetitions >= 3)
+                {
+                    return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.Repetition);
+                }
+
+
+                // Check for draw by insufficient material
+                if (curPositionAndMoves.FinalPosition.CheckDrawBasedOnMaterial == Position.PositionDrawStatus.DrawByInsufficientMaterial)
+                {
+                    return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.AdjudicateMaterial);
+                }
+                else if (curPositionAndMoves.FinalPosition.CheckDrawCanBeClaimed == Position.PositionDrawStatus.DrawCanBeClaimed)
+                {
+                    return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.Repetition);
+                }
+                else if (plyCount >= 500)
+                {
+                    return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.ExcessiveMoves);
+                }
+
+                // Check for terminal result (tablebase or intrinsically terminal)
+                TournamentGameResultReason reason;
+                result = TournamentUtils.TryGetGameResultIfTerminal(curPositionAndMoves, !engine2IsWhite, useTablebasesForAdjudication, out reason);
+                if (result != TournamentGameResult.None)
+                {
+                    return MakeGameInfo(result, reason);
+                }
+
+                plyCount++;
+
+                int numPieces = Position.FromFEN(info.FEN).PieceCount;
+
+                // Make player's move
+                GameMoveStat moveStat;
+                if (engine2ToMove)
+                {
+                    info = DoMove(engine2, engineCheckAgainstEngine2,
+                                  gameMoveHistory, searchLimitWithIncrementsEngine2, scoresEngine2,
+                                  ref nodesEngine2Tot, ref visitsEngine2Tot, ref timeEngine2Tot);
+                    movesEngine2++;
+
+                    if (engine2IsWhite)
+                    {
+                        engine2ShouldHaveForfieted |= info.WhiteShouldHaveForfeitedOnLimit;
+                        moveStat = new GameMoveStat(plyCount, SideType.White, info.WhiteScoreQ, info.WhiteScoreCentipawns, engine2.CumulativeSearchTimeSeconds, numPieces, info.WhiteMAvg, info.WhiteFinalN, info.WhiteNumNodesComputed, info.WhiteSearchLimitPre, info.WhiteMoveTimeUsed);
+                    }
+                    else
+                    {
+                        engine2ShouldHaveForfieted |= info.BlackShouldHaveForfeitedOnLimit;
+                        moveStat = new GameMoveStat(plyCount, SideType.Black, info.BlackScoreQ, info.BlackScoreCentipawns, engine2.CumulativeSearchTimeSeconds, numPieces, info.BlackMAvg, info.BlackFinalN, info.BlackNumNodesComputed, info.BlackSearchLimitPre, info.BlackMoveTimeUsed);
+                    }
+                }
+                else
+                {
+                    info = DoMove(engine1, null,
+                                  gameMoveHistory, searchLimitWithIncrementsEngine1, scoresEngine1,
+                                  ref nodesEngine1Tot, ref visitsEngine1Tot, ref timeEngine1Tot);
+                    movesEngine1++;
+                    if (engine2IsWhite)
+                    {
+                        engine1ShouldHaveForfieted |= info.BlackShouldHaveForfeitedOnLimit;
+                        moveStat = new GameMoveStat(plyCount, SideType.Black, info.BlackScoreQ, info.BlackScoreCentipawns, engine1.CumulativeSearchTimeSeconds, numPieces, info.BlackMAvg, info.BlackFinalN, info.BlackNumNodesComputed, info.BlackSearchLimitPre, info.BlackMoveTimeUsed);
+                    }
+                    else
+                    {
+                        engine1ShouldHaveForfieted |= info.WhiteShouldHaveForfeitedOnLimit;
+                        moveStat = new GameMoveStat(plyCount, SideType.White, info.WhiteScoreQ, info.WhiteScoreCentipawns, engine1.CumulativeSearchTimeSeconds, numPieces, info.WhiteMAvg, info.WhiteFinalN, info.WhiteNumNodesComputed, info.WhiteSearchLimitPre, info.WhiteMoveTimeUsed);
+                    }
+                }
+
+
+                gameMoveHistory.Add(moveStat);
+
+                engine2ToMove = !engine2ToMove;
+                if (plyCount % 2 == 1)
+                {
+                    info = new GameMoveConsoleInfo();
+                    if (showMoves) logger.WriteLine();
+                }
+            }
+
+
+            GameMoveConsoleInfo DoMove(GameEngine engine, GameEngine checkMoveEngine,
+                                       List<GameMoveStat> gameMoveHistory,
+                                       SearchLimit searchLimit, List<float> scoresCP,
+                                        ref long totalNodesUsed, ref long totalVisitsUsed, ref float totalTimeUsed)
+            {
+                SearchLimit thisMoveSearchLimit = searchLimit.Type switch
+                {
+                    SearchLimitType.SecondsPerMove => searchLimit,
+                    SearchLimitType.NodesPerMove => searchLimit,
+                    SearchLimitType.NodesForAllMoves => new SearchLimit(SearchLimitType.NodesForAllMoves,
+                                                                        Math.Max(0, searchLimit.Value - totalVisitsUsed),
+                                                                        searchLimit.SearchCanBeExpanded,
+                                                                        searchLimit.ValueIncrement,
+                                                                        searchLimit.MaxMovesToGo),
+                    SearchLimitType.SecondsForAllMoves => new SearchLimit(SearchLimitType.SecondsForAllMoves,
+                                                                          MathF.Max(0, searchLimit.Value - totalTimeUsed),
+                                                                          searchLimit.SearchCanBeExpanded,
+                                                                          searchLimit.ValueIncrement,
+                                                                          searchLimit.MaxMovesToGo),
+                    _ => throw new Exception($"Internal error, unknown SearchLimit.LimitType {searchLimit.Type}")
+                };
+
+                GameEngineSearchResult engineMove = engine.Search(curPositionAndMoves, thisMoveSearchLimit, gameMoveHistory);
+                float engineTime = (float)engineMove.TimingStats.ElapsedTimeSecs;
+
+                // Check for time forfeit
+                bool shouldHaveForfeited = false;
+                if (thisMoveSearchLimit.IsTimeLimit)
+                {
+                    const float GRACE_FRACTION = 0.02f; // Allow up to 2% over
+                    float GRACE_SECONDS = searchLimit.Value * GRACE_FRACTION;
+                    float timeExcess = engineTime - thisMoveSearchLimit.Value;
+                    if (gameMoveHistory.Count >= 2 && timeExcess > GRACE_SECONDS)
+                    {
+                        shouldHaveForfeited = true;
+
+                        // TODO: (a) remove the "Count > 2" restriction above,
+                        //       (b) reconsider the GRACE_FRACTION above
+                        //       (b) log this
+                        //throw new Exception($"Time forfeit, allotted {thisMoveSearchLimit.Value} used {engineTime} for engine {engine}");
+                    }
+                }
+
+                GameEngineSearchResult checkSearch = default;
+                string checkMove = "";
+                if (checkMoveEngine != null)
+                {
+                    checkSearch = checkMoveEngine.Search(curPositionAndMoves, searchLimit);
+                    checkMove = checkSearch.MoveString;
+                    if (engineMove.MoveString != checkMove)
+                    {
+                        numEngine2MovesDifferentFromCheckEngine++;
+                    }
+                }
+
+                // Verify the engine's move was legal by trying to make it.
+                try
+                {
+                    Position positionAfterMoveTest = curPositionAndMoves.FinalPosition.AfterMove(Move.FromUCI(engineMove.MoveString));
+                }
+                catch (Exception exc)
+                {
+                    throw new Exception($"Engine {engine.ID} made illegal move {engineMove.MoveString} in position {curPositionAndMoves.FinalPosition.FEN}");
+                }
+
+                PositionWithHistory newPosition = new PositionWithHistory(curPositionAndMoves);
+                newPosition.AppendMove(engineMove.MoveString);
+
+                // Output position to PGN
+                pgnWriter.WriteMove(newPosition.Moves[^1], curPositionAndMoves.FinalPosition, engineTime, engineMove.Depth, engineMove.ScoreCentipawns);
+
+                scoresCP.Add(engineMove.ScoreCentipawns);
+
+                totalNodesUsed += engineMove.FinalN;
+                totalVisitsUsed += engineMove.Visits;
+                totalTimeUsed += engineTime;
+                if (curPositionAndMoves.FinalPosition.MiscInfo.SideToMove == SideType.White)
+                {
+                    info.WhiteMoveStr = engineMove.MoveString;
+                    info.WhiteScoreQ = engineMove.ScoreQ;
+                    info.WhiteScoreCentipawns = engineMove.ScoreCentipawns;
+                    info.WhiteSearchLimitPre = thisMoveSearchLimit;
+                    info.WhiteSearchLimitPost = engineMove.Limit;
+                    info.WhiteMoveTimeUsed = engineTime;
+                    info.WhiteTimeAllMoves = totalTimeUsed;
+                    info.WhiteNodesAllMoves = totalNodesUsed;
+                    info.WhiteStartN = engineMove.StartingN;
+                    info.WhiteFinalN = engineMove.FinalN;
+                    info.WhiteMAvg = engineMove.MAvg;
+                    info.WhiteCheckMoveStr = checkMove;
+                    info.WhiteShouldHaveForfeitedOnLimit = shouldHaveForfeited;
+                }
+                else
+                {
+                    info.BlackMoveStr = engineMove.MoveString;
+                    info.BlackScoreQ = engineMove.ScoreQ;
+                    info.BlackScoreCentipawns = engineMove.ScoreCentipawns;
+                    info.BlackSearchLimitPre = thisMoveSearchLimit;
+                    info.BlackSearchLimitPost = engineMove.Limit;
+                    info.BlackMoveTimeUsed = engineTime;
+                    info.BlackTimeAllMoves = totalTimeUsed;
+                    info.BlackNodesAllMoves = totalNodesUsed;
+                    info.BlackStartN = engineMove.StartingN;
+                    info.BlackFinalN = engineMove.FinalN;
+                    info.BlackMAvg = engineMove.MAvg;
+                    info.BlackCheckMoveStr = checkMove;
+                    info.BlackShouldHaveForfeitedOnLimit = shouldHaveForfeited;
+                }
+
+                if (showMoves) info.PutStr();
+
+                // Advance to next move
+                curPositionAndMoves = newPosition;
+
+                return info;
+            }
+        }
+
+
+        static float MinLastN(List<float> vals, int count)
+        {
+            float min = float.MaxValue;
+            for (int i = 1; i <= count; i++)
+                if (vals[^i] < min)
+                    min = vals[^i];
+            return min;
+        }
+
+        static float MaxLastN(List<float> vals, int count)
+        {
+            float max = float.MinValue;
+            for (int i = 1; i <= count; i++)
+                if (vals[^i] > max)
+                    max = vals[^i];
+            return max;
+        }
+
+        TournamentGameResult CheckResultAgreedBothEngines(List<float> scoresCPEngine1, List<float> scoresCPEngine2, TournamentGameResult result)
+        {
+            int WIN_THRESHOLD = Run.Def.AdjudicationThresholdCentipawns;
+            int NUM_MOVES = Run.Def.AdjudicationThresholdNumMoves;
+
+            // Return if insufficient moves in history to make determination.
+            if (scoresCPEngine2.Count < NUM_MOVES || scoresCPEngine1.Count < NUM_MOVES)
+                return result;
+
+            if (MinLastN(scoresCPEngine2, NUM_MOVES) > WIN_THRESHOLD && MaxLastN(scoresCPEngine1, NUM_MOVES) < -WIN_THRESHOLD)
+            {
+                return TournamentGameResult.Loss;
+            }
+            else if (MinLastN(scoresCPEngine1, NUM_MOVES) > WIN_THRESHOLD && MaxLastN(scoresCPEngine2, NUM_MOVES) < -WIN_THRESHOLD)
+            {
+                return TournamentGameResult.Win;
+            }
+            else
+            {
+                return result;
+            }
+        }
+
     }
-
-    internal void UpdateStatsAndOutputSummaryFromGameResult(string pgnFileName, bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
-    {
-      lock (ParentStats)
-      {
-        ParentStats.UpdateTournamentStats(thisResult);
-      }
-
-      // Only show headers first time for first thread
-      if (!havePrintedHeaders)
-      {
-        OutputHeaders(pgnFileName);
-      }
-
-      OutputGameResultInfo(engine2White, openingIndex, gameSequenceNum, thisResult);
-    }
-
-    private void OutputGameResultInfo(bool engine2White, int openingIndex, int gameSequenceNum, TournamentGameInfo thisResult)
-    {
-      (float eloMin, float eloAvg, float eloMax) = EloCalculator.EloConfidenceInterval(ParentStats.Player1Wins, ParentStats.Draws, ParentStats.Player1Losses);
-      float eloSD = eloMax - eloAvg;
-      float los = EloCalculator.LikelihoodSuperiority(ParentStats.Player1Wins, ParentStats.Draws, ParentStats.Player1Losses);
-
-      string wdlStr = $"{ParentStats.Player1Wins,3} {ParentStats.Draws,3} {ParentStats.Player1Losses,3}";
-
-      // Show a "." after the opening index if this was the second of the pair of games played.
-      string openingPlayedBothWaysStr = openingsFinishedAtLeastOnce.Contains(openingIndex) ? "." : " ";
-
-      string player1ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine1 ? "f" : " ";
-      string player2ForfeitChar = thisResult.ShouldHaveForfeitedOnLimitsEngine2 ? "f" : " ";
-
-      const string TournamentGameResultReasonCodes = "CSTMERVL";
-
-      char resultReasonChar = TournamentGameResultReasonCodes[(int)thisResult.ResultReason];
-
-      static bool EvalInconsistent(TournamentGameResult outcome, float scoreCP, int numMovesBack)
-      {
-        float mult = numMovesBack % 2 == 1 ? 1 : -1; // adjust for side to move perspective
-        float adjustedCP = mult * scoreCP;
-        return (outcome == TournamentGameResult.Win && adjustedCP < 100) ||
-               (outcome == TournamentGameResult.Draw && MathF.Abs(adjustedCP) > 50) ||
-               (outcome == TournamentGameResult.Loss && adjustedCP > -100);
-      }
-
-      // Possibly show one or two "?" characters if the evaluations of the final two positions
-      // are very inconsisten with the actual game outcome (as a diagnostic).
-      string questionableFinalCP = "  ";
-      float endingCP = 0;
-      if (thisResult.GameMoveHistory.Count > 0)
-      {
-        bool finalMoveIsPlayer1 = (thisResult.GameMoveHistory[^1].Side == SideType.White) != engine2White;
-        float reverseMult = finalMoveIsPlayer1 ? 1 : -1;
-        endingCP = reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns;
-
-        if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^1].ScoreCentipawns, 1))
-        {
-          questionableFinalCP = "? ";
-        }
-
-        if (thisResult.GameMoveHistory.Count > 1)
-        {
-          if (EvalInconsistent(thisResult.Result, reverseMult * thisResult.GameMoveHistory[^2].ScoreCentipawns, 2))
-          {
-            questionableFinalCP = questionableFinalCP[0] + "?";
-          }
-
-        }
-      }
-
-      lock (outputLockObj)
-      {
-        string checkEnginePlyDifferent = thisResult.NumEngine2MovesDifferentFromCheckEngine == 0 ? "   " : $"{thisResult.NumEngine2MovesDifferentFromCheckEngine,3:N0}";
-        if (Def.ShowGameMoves) Def.Logger.WriteLine();
-        Def.Logger.Write($" {TrimmedIfNeeded(Def.Player1Def.ID, 10),-10} {TrimmedIfNeeded(Def.Player2Def.ID, 10),-10}");
-        Def.Logger.Write($"{eloAvg,4:0} {eloSD,4:0} {100.0f * los,5:0}  ");
-        Def.Logger.Write($"{ParentStats.NumGames,5} {DateTime.Now.ToString().Split(" ")[1],10}  {gameSequenceNum,4:F0}  {openingIndex,4:F0}{openingPlayedBothWaysStr}  ");
-        Def.Logger.Write($"{thisResult.TotalTimeEngine1,8:F2}{player1ForfeitChar}{thisResult.RemainingTimeEngine1,7:F2} ");
-        Def.Logger.Write($"{thisResult.TotalTimeEngine2,8:F2}{player2ForfeitChar}{thisResult.RemainingTimeEngine2,7:F2}  ");
-        Def.Logger.Write($"{thisResult.TotalNodesEngine1,16:N0} {thisResult.TotalNodesEngine2,16:N0}   ");
-
-        if (Def.CheckPlayer2Def != null)
-        {
-          Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {checkEnginePlyDifferent}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
-        }
-        else
-        {
-          Def.Logger.Write($"{thisResult.PlyCount,4:F0}  {TournamentUtils.ResultStr(thisResult.Result, !engine2White),4}  ");
-        }
-
-        Def.Logger.Write($" {resultReasonChar}   {endingCP,5:F0}{questionableFinalCP}");
-        Def.Logger.Write($" {wdlStr}   {thisResult.FEN} ");
-        Def.Logger.WriteLine();
-      }
-
-      UpdateAggregateGameStats(thisResult);
-
-      openingsFinishedAtLeastOnce.Add(openingIndex);
-      NumGames++;
-    }
-
-    private void UpdateAggregateGameStats(TournamentGameInfo thisResult)
-    {
-      TotalNodesEngine1 += thisResult.TotalNodesEngine1;
-      TotalNodesEngine2 += thisResult.TotalNodesEngine2;
-      TotalMovesEngine1 += thisResult.PlyCount;
-      TotalMovesEngine2 += thisResult.PlyCount;
-      TotalTimeEngine1 += thisResult.TotalTimeEngine1;
-      TotalTimeEngine2 += thisResult.TotalTimeEngine2;
-    }
-
-    private static void WritePGNResult(bool engine2White, TournamentGameInfo thisResult, PGNWriter pgnWriter)
-    {
-      switch (thisResult.Result)
-      {
-        case TournamentGameResult.Win:
-          if (engine2White)
-          {
-            pgnWriter.WriteResultBlackWins();
-          }
-          else
-          {
-            pgnWriter.WriteResultWhiteWins();
-          }
-          break;
-
-        case TournamentGameResult.Loss:
-          if (engine2White)
-          {
-            pgnWriter.WriteResultWhiteWins();
-          }
-          else
-          {
-            pgnWriter.WriteResultBlackWins();
-          }
-          break;
-
-        default:
-          pgnWriter.WriteResultDraw();
-          break;
-      }
-    }
-
-
-    private void OutputHeaders(string pgnFileName)
-    {
-      Def.Logger.WriteLine();
-      Def.Logger.WriteLine($"Games will be incrementally written to file: {pgnFileName}");
-      Def.Logger.WriteLine("Result codes: C=checkmate S=stalemate T=tablebase M=insufficient material E=excessive moves R=draw by repetition V=evaluation agreement F=time forfeit");
-      Def.Logger.WriteLine();
-
-      if (Def.CheckPlayer2Def != null)
-      {
-        Def.Logger.WriteLine("  Player1    Player2   ELO   +/-  LOS   GAME#     TIME    TH#   OP#      TIME1    REM1    TIME2    REM2        NODES 2       PLY  DIF    RES  R   ENDCP     W   D   L   FEN");
-        Def.Logger.WriteLine(" ---------  ---------  ---   ---  ---   -----  --------   ---   ---     ------  ------   ------  ------   --------------   ----  ---    ---  -   -----     -   -   -   ---------------------------------------------------");
-      }
-      else
-      {
-        Def.Logger.WriteLine("  Player1    Player2   ELO   +/-  LOS   GAME#     TIME    TH#   OP#      TIME1    REM1    TIME2    REM2       NODES 1           NODES 2       PLY    RES  R   ENDCP     W   D   L   FEN");
-        Def.Logger.WriteLine(" ---------  ---------  ---   ---  ---   -----  --------   ---   ---     ------  ------   ------  ------    --------------   --------------   ----    ---  -   -----     -   -   -   ---------------------------------------------------");
-      }
-      havePrintedHeaders = true;
-    }
-
-
-    static readonly object outputLockObj = new();
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="openingIndex"></param>
-    /// <param name="engine1"></param>
-    /// <param name="engine2"></param>
-    /// <param name="engine2IsWhite"></param>
-    /// <param name="searchLimit"></param>
-    /// <returns>GameResult (from the perspective of engine2)</returns>
-    TournamentGameInfo DoGameTest(TextWriter logger, PGNWriter pgnWriter, int gameSequenceNum, int openingIndex,
-                                 GameEngine engine1, GameEngine engine2, GameEngine engineCheckAgainstEngine2,
-                                 bool engine2IsWhite,
-                                 SearchLimit searchLimitEngine1, SearchLimit searchLimitEngine2,
-                                 bool useTablebasesForAdjudication, bool showMoves)
-    {
-      if (openingIndex >= openings.Count)
-      {
-        throw new Exception($"Reached end of openings of size {openings.Count}.");
-      }
-
-      PositionWithHistory curPositionAndMoves = openings.GetAtIndex(openingIndex);
-      string startFEN = curPositionAndMoves.FinalPosition.FEN;
-      bool engine2ToMove = engine2IsWhite == (curPositionAndMoves.FinalPosition.MiscInfo.SideToMove == SideType.White);
-
-      if (showMoves)
-      {
-        logger.WriteLine();
-        logger.WriteLine("NEW GAME from " + curPositionAndMoves);
-        if (engine2ToMove)
-        {
-          logger.WriteLine((engine2IsWhite ? "White: " : "Black: ") + engine2.ID + " [" + searchLimitEngine2 + "]");
-          logger.WriteLine((engine2IsWhite ? "Black: " : "White: ") + engine1.ID + " [" + searchLimitEngine1 + "]");
-        }
-        else
-        {
-          logger.WriteLine((engine2IsWhite ? "Black: " : "White: ") + engine1.ID + " [" + searchLimitEngine1 + "]");
-          logger.WriteLine((engine2IsWhite ? "White: " : "Black: ") + engine2.ID + " [" + searchLimitEngine2 + "]");
-        }
-      }
-
-      pgnWriter.WriteStartPosition(startFEN);
-
-
-      GameMoveConsoleInfo info = new GameMoveConsoleInfo();
-
-      int plyCount = 1;
-      float timeEngine1Tot = 0;
-      float timeEngine2Tot = 0;
-      long visitsEngine1Tot = 0;
-      long visitsEngine2Tot = 0;
-      long nodesEngine1Tot = 0;
-      long nodesEngine2Tot = 0;
-      int movesEngine1 = 0;
-      int movesEngine2 = 0;
-      bool engine1ShouldHaveForfieted = false;
-      bool engine2ShouldHaveForfieted = false;
-
-      int numEngine2MovesDifferentFromCheckEngine = 0;
-
-      List<float> scoresEngine1 = new List<float>();
-      List<float> scoresEngine2 = new List<float>();
-
-      List<GameMoveStat> gameMoveHistory = new List<GameMoveStat>();
-
-      static float RemainingTime(SearchLimit limit, int numMoves, float timeUsed)
-      {
-        if (limit.Type == SearchLimitType.SecondsForAllMoves)
-        {
-          return limit.MaxValueAfterMoves(numMoves) - timeUsed;
-        }
-        else
-        {
-          // TODO: in principle we could do this also for nodes per game limits
-          return 0;
-        }
-      }
-
-      TournamentGameInfo MakeGameInfo(TournamentGameResult result, TournamentGameResultReason reason)
-      {
-        return new TournamentGameInfo()
-        {
-          Engine2IsWhite = engine2IsWhite,
-          GameSequenceNum = gameSequenceNum,
-          OpeningIndex = openingIndex,
-          FEN = startFEN,
-          Result = result, //TournamentGameInfo.InvertedResult(result),
-          ResultReason = reason,
-          PlyCount = plyCount,
-          TotalTimeEngine1 = timeEngine1Tot,
-          TotalTimeEngine2 = timeEngine2Tot,
-          TotalNodesEngine1 = nodesEngine1Tot,
-          TotalNodesEngine2 = nodesEngine2Tot,
-          RemainingTimeEngine1 = RemainingTime(searchLimitEngine1, movesEngine1, timeEngine1Tot),
-          RemainingTimeEngine2 = RemainingTime(searchLimitEngine2, movesEngine2, timeEngine2Tot),
-          ShouldHaveForfeitedOnLimitsEngine1 = engine1ShouldHaveForfieted,
-          ShouldHaveForfeitedOnLimitsEngine2 = engine2ShouldHaveForfieted,
-          NumEngine2MovesDifferentFromCheckEngine = numEngine2MovesDifferentFromCheckEngine,
-          GameMoveHistory = gameMoveHistory
-        };
-
-      }
-
-      // Reset the game state before we begin making moves
-      engine1.CumulativeSearchTimeSeconds = 0;
-      engine1.CumulativeNodes = 0;
-      engine2.CumulativeSearchTimeSeconds = 0;
-      engine2.CumulativeNodes = 0;
-      TournamentGameResult result = TournamentGameResult.None;
-
-      SearchLimit searchLimitWithIncrementsEngine1 = searchLimitEngine1 with { };
-      SearchLimit searchLimitWithIncrementsEngine2 = searchLimitEngine2 with { };
-
-
-      // Keep a list of all positions seen so far in game      
-      List<Position> encounteredPositions = new List<Position>();
-
-      // Repeatedly make moves
-      while (true)
-      {
-        // Add this position to the set of positions encountered
-        Position currentPosition = curPositionAndMoves.FinalPosition;
-        encounteredPositions.Add(currentPosition);
-
-        // If time or node increment was specified for game-level search limit,
-        // adjust the search limit to give credit for this increment
-        if (!engine2ToMove && searchLimitEngine1.ValueIncrement != 0)
-        {
-          searchLimitWithIncrementsEngine1 = searchLimitWithIncrementsEngine1.WithIncrementApplied();
-        }
-
-        if (engine2ToMove && searchLimitEngine2.ValueIncrement != 0)
-        {
-          searchLimitWithIncrementsEngine2 = searchLimitWithIncrementsEngine2.WithIncrementApplied();
-        }
-
-        // Check for very bad evaluation for one side (agreed by both sides)
-        if (scoresEngine1.Count > 5)
-        {
-          result = CheckResultAgreedBothEngines(scoresEngine1, scoresEngine2, result);
-          if (result != TournamentGameResult.None)
-          {
-            return MakeGameInfo(result, TournamentGameResultReason.AdjudicatedEvaluation);
-          }
-        }
-
-        info.FEN = currentPosition.FEN;
-        info.MoveNum = plyCount / 2;
-
-        // Check for draw by repetition of position (3 times)
-        int countRepetitions = 0;
-        foreach (Position pos in encounteredPositions)
-        {
-          if (pos.EqualAsRepetition(in currentPosition))
-          {
-            countRepetitions++;
-          }
-        }
-
-        if (countRepetitions >= 3)
-        {
-          return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.Repetition);
-        }
-
-
-        // Check for draw by insufficient material
-        if (curPositionAndMoves.FinalPosition.CheckDrawBasedOnMaterial == Position.PositionDrawStatus.DrawByInsufficientMaterial)
-        {
-          return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.AdjudicateMaterial);
-        }
-        else if( curPositionAndMoves.FinalPosition.CheckDrawCanBeClaimed == Position.PositionDrawStatus.DrawCanBeClaimed)
-        {
-          return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.Repetition);
-        }
-        else if (plyCount >= 500)
-        {
-          return MakeGameInfo(TournamentGameResult.Draw, TournamentGameResultReason.ExcessiveMoves);
-        }
-
-        // Check for terminal result (tablebase or intrinsically terminal)
-        TournamentGameResultReason reason;
-        result = TournamentUtils.TryGetGameResultIfTerminal(curPositionAndMoves, !engine2IsWhite, useTablebasesForAdjudication, out reason);
-        if (result != TournamentGameResult.None)
-        {
-          return MakeGameInfo(result, reason);
-        }
-
-        plyCount++;
-
-        int numPieces = Position.FromFEN(info.FEN).PieceCount;
-
-        // Make player's move
-        GameMoveStat moveStat;
-        if (engine2ToMove)
-        {
-          info = DoMove(engine2, engineCheckAgainstEngine2,
-                        gameMoveHistory, searchLimitWithIncrementsEngine2, scoresEngine2,
-                        ref nodesEngine2Tot, ref visitsEngine2Tot, ref timeEngine2Tot);
-          movesEngine2++;
-
-          if (engine2IsWhite)
-          {
-            engine2ShouldHaveForfieted |= info.WhiteShouldHaveForfeitedOnLimit;
-            moveStat = new GameMoveStat(plyCount, SideType.White, info.WhiteScoreQ, info.WhiteScoreCentipawns, engine2.CumulativeSearchTimeSeconds, numPieces, info.WhiteMAvg, info.WhiteFinalN, info.WhiteNumNodesComputed, info.WhiteSearchLimitPre, info.WhiteMoveTimeUsed);
-          }
-          else
-          {
-            engine2ShouldHaveForfieted |= info.BlackShouldHaveForfeitedOnLimit;
-            moveStat = new GameMoveStat(plyCount, SideType.Black, info.BlackScoreQ, info.BlackScoreCentipawns, engine2.CumulativeSearchTimeSeconds, numPieces, info.BlackMAvg, info.BlackFinalN, info.BlackNumNodesComputed, info.BlackSearchLimitPre, info.BlackMoveTimeUsed);
-          }
-        }
-        else
-        {
-          info = DoMove(engine1, null,
-                        gameMoveHistory, searchLimitWithIncrementsEngine1, scoresEngine1,
-                        ref nodesEngine1Tot, ref visitsEngine1Tot, ref timeEngine1Tot);
-          movesEngine1++;
-          if (engine2IsWhite)
-          {
-            engine1ShouldHaveForfieted |= info.BlackShouldHaveForfeitedOnLimit;
-            moveStat = new GameMoveStat(plyCount, SideType.Black, info.BlackScoreQ, info.BlackScoreCentipawns, engine1.CumulativeSearchTimeSeconds, numPieces, info.BlackMAvg, info.BlackFinalN, info.BlackNumNodesComputed, info.BlackSearchLimitPre, info.BlackMoveTimeUsed);
-          }
-          else
-          {
-            engine1ShouldHaveForfieted |= info.WhiteShouldHaveForfeitedOnLimit;
-            moveStat = new GameMoveStat(plyCount, SideType.White, info.WhiteScoreQ, info.WhiteScoreCentipawns, engine1.CumulativeSearchTimeSeconds, numPieces, info.WhiteMAvg, info.WhiteFinalN, info.WhiteNumNodesComputed, info.WhiteSearchLimitPre, info.WhiteMoveTimeUsed);
-          }
-        }
-        
-
-        gameMoveHistory.Add(moveStat);
-
-        engine2ToMove = !engine2ToMove;
-        if (plyCount % 2 == 1)
-        {
-          info = new GameMoveConsoleInfo();
-          if (showMoves) logger.WriteLine();
-        }
-      }
-
-
-      GameMoveConsoleInfo DoMove(GameEngine engine, GameEngine checkMoveEngine,
-                                 List<GameMoveStat> gameMoveHistory,
-                                 SearchLimit searchLimit, List<float> scoresCP,
-                                  ref long totalNodesUsed, ref long totalVisitsUsed, ref float totalTimeUsed)
-      {
-        SearchLimit thisMoveSearchLimit = searchLimit.Type switch
-        {
-          SearchLimitType.SecondsPerMove => searchLimit,
-          SearchLimitType.NodesPerMove => searchLimit,
-          SearchLimitType.NodesForAllMoves => new SearchLimit(SearchLimitType.NodesForAllMoves,
-                                                              Math.Max(0, searchLimit.Value - totalVisitsUsed),
-                                                              searchLimit.SearchCanBeExpanded, 
-                                                              searchLimit.ValueIncrement,
-                                                              searchLimit.MaxMovesToGo),
-          SearchLimitType.SecondsForAllMoves => new SearchLimit(SearchLimitType.SecondsForAllMoves,
-                                                                MathF.Max(0, searchLimit.Value - totalTimeUsed),
-                                                                searchLimit.SearchCanBeExpanded, 
-                                                                searchLimit.ValueIncrement,
-                                                                searchLimit.MaxMovesToGo),
-          _ => throw new Exception($"Internal error, unknown SearchLimit.LimitType {searchLimit.Type}")
-        };
-
-        GameEngineSearchResult engineMove = engine.Search(curPositionAndMoves, thisMoveSearchLimit, gameMoveHistory);
-        float engineTime = (float)engineMove.TimingStats.ElapsedTimeSecs;
-
-        // Check for time forfeit
-        bool shouldHaveForfeited = false;
-        if (thisMoveSearchLimit.IsTimeLimit)
-        {
-          const float GRACE_FRACTION = 0.02f; // Allow up to 2% over
-          float GRACE_SECONDS = searchLimit.Value * GRACE_FRACTION;
-          float timeExcess = engineTime - thisMoveSearchLimit.Value;
-          if (gameMoveHistory.Count >= 2 && timeExcess > GRACE_SECONDS)
-          {
-            shouldHaveForfeited = true;
-
-            // TODO: (a) remove the "Count > 2" restriction above,
-            //       (b) reconsider the GRACE_FRACTION above
-            //       (b) log this
-            //throw new Exception($"Time forfeit, allotted {thisMoveSearchLimit.Value} used {engineTime} for engine {engine}");
-          }
-        }
-
-        GameEngineSearchResult checkSearch = default;
-        string checkMove = "";
-        if (checkMoveEngine != null)
-        {
-          checkSearch = checkMoveEngine.Search(curPositionAndMoves, searchLimit);
-          checkMove = checkSearch.MoveString;
-          if (engineMove.MoveString != checkMove)
-          {
-            numEngine2MovesDifferentFromCheckEngine++;
-          }
-        }
-
-        // Verify the engine's move was legal by trying to make it.
-        try
-        {
-          Position positionAfterMoveTest = curPositionAndMoves.FinalPosition.AfterMove(Move.FromUCI(engineMove.MoveString));
-        }
-        catch (Exception exc)
-        {
-          throw new Exception($"Engine {engine.ID} made illegal move {engineMove.MoveString} in position {curPositionAndMoves.FinalPosition.FEN}");
-        }
-
-        PositionWithHistory newPosition = new PositionWithHistory(curPositionAndMoves);
-        newPosition.AppendMove(engineMove.MoveString);
-
-        // Output position to PGN
-        pgnWriter.WriteMove(newPosition.Moves[^1], curPositionAndMoves.FinalPosition, engineTime, engineMove.Depth, engineMove.ScoreCentipawns);
-
-        scoresCP.Add(engineMove.ScoreCentipawns);
-
-        totalNodesUsed += engineMove.FinalN;
-        totalVisitsUsed += engineMove.Visits;
-        totalTimeUsed += engineTime;
-        if (curPositionAndMoves.FinalPosition.MiscInfo.SideToMove == SideType.White)
-        {
-          info.WhiteMoveStr = engineMove.MoveString;
-          info.WhiteScoreQ = engineMove.ScoreQ;
-          info.WhiteScoreCentipawns = engineMove.ScoreCentipawns;
-          info.WhiteSearchLimitPre = thisMoveSearchLimit;
-          info.WhiteSearchLimitPost = engineMove.Limit;
-          info.WhiteMoveTimeUsed = engineTime;
-          info.WhiteTimeAllMoves = totalTimeUsed;
-          info.WhiteNodesAllMoves = totalNodesUsed;
-          info.WhiteStartN = engineMove.StartingN;
-          info.WhiteFinalN = engineMove.FinalN;
-          info.WhiteMAvg = engineMove.MAvg;
-          info.WhiteCheckMoveStr = checkMove;
-          info.WhiteShouldHaveForfeitedOnLimit = shouldHaveForfeited;
-        }
-        else
-        {
-          info.BlackMoveStr = engineMove.MoveString;
-          info.BlackScoreQ = engineMove.ScoreQ;
-          info.BlackScoreCentipawns = engineMove.ScoreCentipawns;
-          info.BlackSearchLimitPre = thisMoveSearchLimit;
-          info.BlackSearchLimitPost = engineMove.Limit;
-          info.BlackMoveTimeUsed = engineTime;
-          info.BlackTimeAllMoves = totalTimeUsed;
-          info.BlackNodesAllMoves = totalNodesUsed;
-          info.BlackStartN = engineMove.StartingN;
-          info.BlackFinalN = engineMove.FinalN;
-          info.BlackMAvg = engineMove.MAvg;
-          info.BlackCheckMoveStr = checkMove;
-          info.BlackShouldHaveForfeitedOnLimit = shouldHaveForfeited;
-        }
-
-        if (showMoves) info.PutStr();
-
-        // Advance to next move
-        curPositionAndMoves = newPosition;
-
-        return info;
-      }
-    }
-
-
-    static float MinLastN(List<float> vals, int count)
-    {
-      float min = float.MaxValue;
-      for (int i = 1; i <= count; i++)
-        if (vals[^i] < min)
-          min = vals[^i];
-      return min;
-    }
-
-    static float MaxLastN(List<float> vals, int count)
-    {
-      float max = float.MinValue;
-      for (int i = 1; i <= count; i++)
-        if (vals[^i] > max)
-          max = vals[^i];
-      return max;
-    }
-
-    TournamentGameResult CheckResultAgreedBothEngines(List<float> scoresCPEngine1, List<float> scoresCPEngine2, TournamentGameResult result)
-    {
-      int WIN_THRESHOLD = Run.Def.AdjudicationThresholdCentipawns;
-      int NUM_MOVES = Run.Def.AdjudicationThresholdNumMoves;
-
-      // Return if insufficient moves in history to make determination.
-      if (scoresCPEngine2.Count < NUM_MOVES || scoresCPEngine1.Count < NUM_MOVES)
-        return result;
-
-      if (MinLastN(scoresCPEngine2, NUM_MOVES) > WIN_THRESHOLD && MaxLastN(scoresCPEngine1, NUM_MOVES) < -WIN_THRESHOLD)
-      {
-        return TournamentGameResult.Loss;
-      }
-      else if (MinLastN(scoresCPEngine1, NUM_MOVES) > WIN_THRESHOLD && MaxLastN(scoresCPEngine2, NUM_MOVES) < -WIN_THRESHOLD)
-      {
-        return TournamentGameResult.Win;
-      }
-      else
-      {
-        return result;
-      }
-    }
-
-  }
 }

--- a/src/Ceres.Features/Tournaments/TournamentManager.cs
+++ b/src/Ceres.Features/Tournaments/TournamentManager.cs
@@ -27,47 +27,47 @@ using Ceres.Chess;
 
 namespace Ceres.Features.Tournaments
 {
+  /// <summary>
+  /// Manages execution of a tournament (match) of games
+  /// of one engine against another, possibly multithreaded.
+  /// </summary>
+  public partial class TournamentManager
+  {
     /// <summary>
-    /// Manages execution of a tournament (match) of games
-    /// of one engine against another, possibly multithreaded.
+    /// Number of touranment games to play in parallel.
     /// </summary>
-    public partial class TournamentManager
+    public readonly int NumConcurrent = 1;
+
+    /// <summary>
+    /// Definition of parameters of the tournament.
+    /// </summary>
+    public TournamentDef Def;
+
+
+    /// <summary>
+    /// Optionally a queue manager object which is used when running
+    /// distributed model (running either as a coordinator or worker process).
+    /// </summary>
+    public TournamentGameQueueManager QueueManager;
+
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="def"></param>
+    /// <param name="numParallel"></param>
+    /// <param name="separateGPUs"></param>
+    public TournamentManager(TournamentDef def, int numParallel = 1)
     {
-        /// <summary>
-        /// Number of touranment games to play in parallel.
-        /// </summary>
-        public readonly int NumConcurrent = 1;
+      Def = def;
+      NumConcurrent = Math.Min(numParallel, def.NumGamePairs ?? int.MaxValue);
 
-        /// <summary>
-        /// Definition of parameters of the tournament.
-        /// </summary>
-        public TournamentDef Def;
-
-
-        /// <summary>
-        /// Optionally a queue manager object which is used when running
-        /// distributed model (running either as a coordinator or worker process).
-        /// </summary>
-        public TournamentGameQueueManager QueueManager;
-
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="def"></param>
-        /// <param name="numParallel"></param>
-        /// <param name="separateGPUs"></param>
-        public TournamentManager(TournamentDef def, int numParallel = 1)
-        {
-            Def = def;
-            NumConcurrent = Math.Min(numParallel, def.NumGamePairs ?? int.MaxValue);
-
-            // Turn off showing game moves if running parallel,
-            // since the moves of various games would be intermixed.
-            if (numParallel > 1)
-            {
-                def.ShowGameMoves = false;
-            }
+      // Turn off showing game moves if running parallel,
+      // since the moves of various games would be intermixed.
+      if (numParallel > 1)
+      {
+        def.ShowGameMoves = false;
+      }
 
 #if NOT
       if (def.EvaluatorDef2.DeviceCombo == NNEvaluators.Defs.NNEvaluatorDeviceComboType.Pooled)
@@ -76,210 +76,194 @@ namespace Ceres.Features.Tournaments
         SeparateGPUs = false;
       }
 #endif
-        }
-
-        int numGamePairsLaunched = 0;
-        readonly object lockObj = new();
-
-
-        /// <summary>
-        /// Method called by threads to get the next available game to be played.
-        /// </summary>
-        /// <returns></returns>
-        int GetNextOpeningIndexForLocalThread(int maxOpenings)
-        {
-            if (Def.RandomizeOpenings) throw new NotImplementedException();
-
-            lock (lockObj)
-            {
-                if (numGamePairsLaunched < maxOpenings)
-                {
-                    return numGamePairsLaunched++;
-                }
-                else
-                    return -1;
-            }
-        }
-
-
-        /// <summary>
-        /// If running multiple match threads then we need to make sure the 
-        /// neural network evaluators are suitable for parallel execution, either by:
-        ///   - being of type Pooled, so that all evaluator definitions reference
-        ///     the same underlying evaluator which will pool positions from many
-        ///     threads into one batch, or
-        ///   - each thread being assigned to a different GPU
-        ///   
-        /// This method handles the latter case, if the evaluators are not pooled
-        /// then it will sequentially apply them to GPUs with successive indices.
-        /// 
-        /// TODO: detect error condition where the number of threads exceeds number of GPUs.
-        /// </summary>
-        /// <param name="def"></param>
-        /// <param name="relativeDeviceIndex"></param>
-        static void TrySetRelativeDeviceIDIfNotPooled(TournamentDef def, int relativeDeviceIndex)
-        {
-            def.Player1Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
-            def.Player2Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
-        }
-
-        void VerifyEnginesCompatible()
-        {
-            if (Def.Engines.Count > 0)
-            {
-                foreach (var engine in Def.Engines)
-                {
-                    if (engine.SearchLimit.Type == SearchLimitType.NodesForAllMoves
-                        && !engine.EngineDef.SupportsNodesPerGameMode)
-                    {
-                        throw new Exception($"Requested NodesPerGame mode is not supported by engine: {engine.EngineDef.ID}");
-                    }
-                }
-            }
-
-            else
-            {
-                if (Def.Player1Def.SearchLimit.Type == SearchLimitType.NodesForAllMoves
-                 && !Def.Player1Def.EngineDef.SupportsNodesPerGameMode)
-                {
-                    throw new Exception($"Requested NodesPerGame mode is not supported by engine 1: {Def.Player1Def.EngineDef.ID}");
-                }
-
-                if (Def.Player2Def.SearchLimit.Type == SearchLimitType.NodesForAllMoves
-                 && !Def.Player2Def.EngineDef.SupportsNodesPerGameMode)
-                {
-                    throw new Exception($"Requested NodesPerGame mode is not supported by engine 2: {Def.Player2Def.EngineDef.ID}");
-                }
-            }
-        }
-
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="queueManager">optional associated queue manager if running in distributed mode</param>
-        /// <returns></returns>
-        public TournamentResultStats RunTournament(TournamentGameQueueManager queueManager = null)
-        {
-            if (Def.Engines.Count > 0)
-            {
-                foreach (var engine in Def.Engines)
-                {
-                    if (engine == null) throw new ArgumentNullException("engine is null)");
-                }
-            }
-            else
-            {
-                if (Def.Player1Def == null) throw new ArgumentNullException("Def.Player1Def is null)");
-                if (Def.Player2Def == null) throw new ArgumentNullException("Def.Player2Def is null)");
-            }
-
-
-            VerifyEnginesCompatible();
-
-            QueueManager = queueManager;
-            TournamentResultStats parentTest;
-
-            if (Def.Engines.Count > 0)
-            {
-                parentTest = new(Def.Engines.Select(e => e.ID));
-            }
-
-            else
-            {
-                parentTest = new(Def.Player1Def.ID, Def.Player2Def.ID);
-            }
-
-            // Show differences between engine 1 and engine 2
-            Def.DumpParams();
-
-            // Prepare to create a set of task threads to run games
-            List<Task> tasks = new List<Task>();
-            List<TournamentGameThread> gameThreads = new List<TournamentGameThread>();
-
-            Directory.CreateDirectory(CeresUserSettingsManager.Settings.DirCeresOutput);
-
-            // If we are a worker process then run only a single game thread.
-            int numConcurrent = queueManager != null && !queueManager.IsCoordinator ? 1 : NumConcurrent;
-
-            for (int i = 0; i < numConcurrent; i++)
-            {
-                TournamentDef tournamentDefClone = Def.Clone();
-
-                // Make sure the threads will use either different or pooled evaluators
-                if (NumConcurrent > 1)
-                {
-                    TrySetRelativeDeviceIDIfNotPooled(tournamentDefClone, i);
-                }
-
-                //if (Def.Player1Def is GameEngineDefCeres
-                // && Def.Player2Def is GameEngineDefCeres
-                // && Def.Player1Def.SearchLimit.IsNodesLimit
-                // && Def.Player2Def.SearchLimit.IsNodesLimit)
-                //{
-                //    GameEngineDefCeres thisDefCeres1 = Def.Player1Def.EngineDef as GameEngineDefCeres;
-                //    GameEngineDefCeres thisDefCeres2 = Def.Player2Def.EngineDef as GameEngineDefCeres;
-
-                //    // TODO: possibly add optimization here which will share trees
-                //    //       with ReusePositionEvaluationsFromOtherTree.
-                //    //       See the suite manager for an example of how this is done.
-                //}
-
-                TournamentGameThread gameTest = new TournamentGameThread(tournamentDefClone, parentTest);
-                gameThreads.Add(gameTest);
-
-                Action action;
-                if (QueueManager == null)
-                {
-                    // Everything happens locally, data structures updated as part of processing.
-                    action = () => ThreadProcLocalWorker(i, gameTest);
-                }
-                else if (QueueManager.IsCoordinator)
-                {
-                    // We are coordinator. Repeatedly enqueue request to play game pairs and retireve/show results.
-                    action = () => ThreadProcCoordinator(i, gameTest);
-                }
-                else
-                {
-                    // Worker method (which will forward result data structure back to coordinator).
-                    action = () => ThreadProcDistributedWorker(i, gameTest);
-                }
-
-
-                Task thisTask = new Task(action);
-                tasks.Add(thisTask);
-                thisTask.Start();
-            }
-            Task.WaitAll(tasks.ToArray());
-
-            // Calculate and write summary line
-            long totalNodesEngine1 = gameThreads.Sum(g => g.TotalNodesEngine1);
-            long totalNodesEngine2 = gameThreads.Sum(g => g.TotalNodesEngine2);
-            int totalMovesEngine1 = gameThreads.Sum(g => g.TotalMovesEngine1);
-            int totalMovesEngine2 = gameThreads.Sum(g => g.TotalMovesEngine2);
-            float totalTimeEngine1 = gameThreads.Sum(g => g.TotalTimeEngine1);
-            float totalTimeEngine2 = gameThreads.Sum(g => g.TotalTimeEngine2);
-            float numGames = gameThreads.Sum(g => g.NumGames);
-
-            Def.Logger.Write("	      	                    			           ");
-            Def.Logger.WriteLine("     ------   ------     --------------   --------------   ----");
-            Def.Logger.Write("                                                ");
-            Def.Logger.Write("                     ");
-            Def.Logger.Write($"{totalTimeEngine1,9:F2}{totalTimeEngine2,9:F2}");
-            Def.Logger.Write($"{totalNodesEngine1,19:N0}{totalNodesEngine2,17:N0}   ");
-            Def.Logger.Write($"{Math.Round(totalMovesEngine1 / numGames, 0),4:F0}");
-
-            Def.Logger.WriteLine();
-            if (Def.Engines.Count > 0)
-            {
-                parentTest.DumpRoundRobin();
-            }
-            else
-            {
-                parentTest.Dump();
-            }
-            return parentTest;
-        }
-
     }
+
+    int numGamePairsLaunched = 0;
+    readonly object lockObj = new();
+
+
+    /// <summary>
+    /// Method called by threads to get the next available game to be played.
+    /// </summary>
+    /// <returns></returns>
+    int GetNextOpeningIndexForLocalThread(int maxOpenings)
+    {
+      if (Def.RandomizeOpenings) throw new NotImplementedException();
+
+      lock (lockObj)
+      {
+        if (numGamePairsLaunched < maxOpenings)
+        {
+          return numGamePairsLaunched++;
+        }
+        else
+          return -1;
+      }
+    }
+
+
+    /// <summary>
+    /// If running multiple match threads then we need to make sure the 
+    /// neural network evaluators are suitable for parallel execution, either by:
+    ///   - being of type Pooled, so that all evaluator definitions reference
+    ///     the same underlying evaluator which will pool positions from many
+    ///     threads into one batch, or
+    ///   - each thread being assigned to a different GPU
+    ///   
+    /// This method handles the latter case, if the evaluators are not pooled
+    /// then it will sequentially apply them to GPUs with successive indices.
+    /// 
+    /// TODO: detect error condition where the number of threads exceeds number of GPUs.
+    /// </summary>
+    /// <param name="def"></param>
+    /// <param name="relativeDeviceIndex"></param>
+    static void TrySetRelativeDeviceIDIfNotPooled(TournamentDef def, int relativeDeviceIndex)
+    {
+      def.Player1Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
+      def.Player2Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
+    }
+
+    void VerifyEnginesCompatible()
+    {
+      if (Def.Engines.Count > 0)
+      {
+        foreach (var engine in Def.Engines)
+        {
+          if (engine.SearchLimit.Type == SearchLimitType.NodesForAllMoves
+              && !engine.EngineDef.SupportsNodesPerGameMode)
+          {
+            throw new Exception($"Requested NodesPerGame mode is not supported by engine: {engine.EngineDef.ID}");
+          }
+        }
+      }
+
+      else
+      {
+        if (Def.Player1Def.SearchLimit.Type == SearchLimitType.NodesForAllMoves
+         && !Def.Player1Def.EngineDef.SupportsNodesPerGameMode)
+        {
+          throw new Exception($"Requested NodesPerGame mode is not supported by engine 1: {Def.Player1Def.EngineDef.ID}");
+        }
+
+        if (Def.Player2Def.SearchLimit.Type == SearchLimitType.NodesForAllMoves
+         && !Def.Player2Def.EngineDef.SupportsNodesPerGameMode)
+        {
+          throw new Exception($"Requested NodesPerGame mode is not supported by engine 2: {Def.Player2Def.EngineDef.ID}");
+        }
+      }
+    }
+
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="queueManager">optional associated queue manager if running in distributed mode</param>
+    /// <returns></returns>
+    public TournamentResultStats RunTournament(TournamentGameQueueManager queueManager = null)
+    {
+      if (Def.Engines.Count > 0)
+      {
+        foreach (var engine in Def.Engines)
+        {
+          if (engine == null) throw new ArgumentNullException("engine is null)");
+        }
+      }
+      else
+      {
+        if (Def.Player1Def == null) throw new ArgumentNullException("Def.Player1Def is null)");
+        if (Def.Player2Def == null) throw new ArgumentNullException("Def.Player2Def is null)");
+      }
+
+
+      VerifyEnginesCompatible();
+
+      QueueManager = queueManager;
+      TournamentResultStats parentTest = new();
+
+
+      // Show differences between engine 1 and engine 2
+      Def.DumpParams();
+
+      // Prepare to create a set of task threads to run games
+      List<Task> tasks = new List<Task>();
+      List<TournamentGameThread> gameThreads = new List<TournamentGameThread>();
+
+      Directory.CreateDirectory(CeresUserSettingsManager.Settings.DirCeresOutput);
+
+      // If we are a worker process then run only a single game thread.
+      int numConcurrent = queueManager != null && !queueManager.IsCoordinator ? 1 : NumConcurrent;
+
+      for (int i = 0; i < numConcurrent; i++)
+      {
+        TournamentDef tournamentDefClone = Def.Clone();
+
+        // Make sure the threads will use either different or pooled evaluators
+        if (NumConcurrent > 1)
+        {
+          TrySetRelativeDeviceIDIfNotPooled(tournamentDefClone, i);
+        }
+
+        //if (Def.Player1Def is GameEngineDefCeres
+        // && Def.Player2Def is GameEngineDefCeres
+        // && Def.Player1Def.SearchLimit.IsNodesLimit
+        // && Def.Player2Def.SearchLimit.IsNodesLimit)
+        //{
+        //    GameEngineDefCeres thisDefCeres1 = Def.Player1Def.EngineDef as GameEngineDefCeres;
+        //    GameEngineDefCeres thisDefCeres2 = Def.Player2Def.EngineDef as GameEngineDefCeres;
+
+        //    // TODO: possibly add optimization here which will share trees
+        //    //       with ReusePositionEvaluationsFromOtherTree.
+        //    //       See the suite manager for an example of how this is done.
+        //}
+
+        TournamentGameThread gameTest = new TournamentGameThread(tournamentDefClone, parentTest);
+        gameThreads.Add(gameTest);
+
+        Action action;
+        if (QueueManager == null)
+        {
+          // Everything happens locally, data structures updated as part of processing.
+          action = () => ThreadProcLocalWorker(i, gameTest);
+        }
+        else if (QueueManager.IsCoordinator)
+        {
+          // We are coordinator. Repeatedly enqueue request to play game pairs and retireve/show results.
+          action = () => ThreadProcCoordinator(i, gameTest);
+        }
+        else
+        {
+          // Worker method (which will forward result data structure back to coordinator).
+          action = () => ThreadProcDistributedWorker(i, gameTest);
+        }
+
+
+        Task thisTask = new Task(action);
+        tasks.Add(thisTask);
+        thisTask.Start();
+      }
+      Task.WaitAll(tasks.ToArray());
+
+      // Calculate and write summary line
+      long totalNodesEngine1 = gameThreads.Sum(g => g.TotalNodesEngine1);
+      long totalNodesEngine2 = gameThreads.Sum(g => g.TotalNodesEngine2);
+      int totalMovesEngine1 = gameThreads.Sum(g => g.TotalMovesEngine1);
+      int totalMovesEngine2 = gameThreads.Sum(g => g.TotalMovesEngine2);
+      float totalTimeEngine1 = gameThreads.Sum(g => g.TotalTimeEngine1);
+      float totalTimeEngine2 = gameThreads.Sum(g => g.TotalTimeEngine2);
+      float numGames = gameThreads.Sum(g => g.NumGames);
+
+      Def.Logger.Write("	      	                    			           ");
+      Def.Logger.WriteLine("     ------   ------     --------------   --------------   ----");
+      Def.Logger.Write("                                                ");
+      Def.Logger.Write("                     ");
+      Def.Logger.Write($"{totalTimeEngine1,9:F2}{totalTimeEngine2,9:F2}");
+      Def.Logger.Write($"{totalNodesEngine1,19:N0}{totalNodesEngine2,17:N0}   ");
+      Def.Logger.Write($"{Math.Round(totalMovesEngine1 / numGames, 0),4:F0}");
+      Def.Logger.WriteLine();
+
+      parentTest.DumpTournamentSummary(Def.ReferenceEngineId);
+      return parentTest;
+    }
+
+  }
 }

--- a/src/Ceres.Features/Tournaments/TournamentManager.cs
+++ b/src/Ceres.Features/Tournaments/TournamentManager.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using Ceres.Chess.UserSettings;
 using Ceres.Features.GameEngines;
 using Ceres.Chess;
+using Ceres.Features.Players;
 
 #endregion
 
@@ -119,15 +120,25 @@ namespace Ceres.Features.Tournaments
     /// <param name="relativeDeviceIndex"></param>
     static void TrySetRelativeDeviceIDIfNotPooled(TournamentDef def, int relativeDeviceIndex)
     {
-      def.Player1Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
-      def.Player2Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
+      if (def.Engines != null)
+      {
+        foreach (EnginePlayerDef engine in def.Engines)
+        {
+          engine.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
+        }
+      }
+      else
+      {
+        def.Player1Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
+        def.Player2Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
+      }
     }
 
     void VerifyEnginesCompatible()
     {
-      if (Def.Engines.Count > 0)
+      if (Def.Engines != null)
       {
-        foreach (var engine in Def.Engines)
+        foreach (EnginePlayerDef engine in Def.Engines)
         {
           if (engine.SearchLimit.Type == SearchLimitType.NodesForAllMoves
               && !engine.EngineDef.SupportsNodesPerGameMode)
@@ -161,9 +172,9 @@ namespace Ceres.Features.Tournaments
     /// <returns></returns>
     public TournamentResultStats RunTournament(TournamentGameQueueManager queueManager = null)
     {
-      if (Def.Engines.Count > 0)
+      if (Def.Engines.Length > 0)
       {
-        foreach (var engine in Def.Engines)
+        foreach (EnginePlayerDef engine in Def.Engines)
         {
           if (engine == null) throw new ArgumentNullException("engine is null)");
         }

--- a/src/Ceres.Features/Tournaments/TournamentManager.cs
+++ b/src/Ceres.Features/Tournaments/TournamentManager.cs
@@ -27,47 +27,47 @@ using Ceres.Chess;
 
 namespace Ceres.Features.Tournaments
 {
-  /// <summary>
-  /// Manages execution of a tournament (match) of games
-  /// of one engine against another, possibly multithreaded.
-  /// </summary>
-  public partial class TournamentManager
-  {
     /// <summary>
-    /// Number of touranment games to play in parallel.
+    /// Manages execution of a tournament (match) of games
+    /// of one engine against another, possibly multithreaded.
     /// </summary>
-    public readonly int NumConcurrent = 1;
-
-    /// <summary>
-    /// Definition of parameters of the tournament.
-    /// </summary>
-    public TournamentDef Def;
-
-
-    /// <summary>
-    /// Optionally a queue manager object which is used when running
-    /// distributed model (running either as a coordinator or worker process).
-    /// </summary>
-    public TournamentGameQueueManager QueueManager;
-
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    /// <param name="def"></param>
-    /// <param name="numParallel"></param>
-    /// <param name="separateGPUs"></param>
-    public TournamentManager(TournamentDef def, int numParallel = 1)
+    public partial class TournamentManager
     {
-      Def = def;
-      NumConcurrent = Math.Min(numParallel, def.NumGamePairs ?? int.MaxValue);
+        /// <summary>
+        /// Number of touranment games to play in parallel.
+        /// </summary>
+        public readonly int NumConcurrent = 1;
 
-      // Turn off showing game moves if running parallel,
-      // since the moves of various games would be intermixed.
-      if (numParallel > 1)
-      {
-        def.ShowGameMoves = false;
-      }
+        /// <summary>
+        /// Definition of parameters of the tournament.
+        /// </summary>
+        public TournamentDef Def;
+
+
+        /// <summary>
+        /// Optionally a queue manager object which is used when running
+        /// distributed model (running either as a coordinator or worker process).
+        /// </summary>
+        public TournamentGameQueueManager QueueManager;
+
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="def"></param>
+        /// <param name="numParallel"></param>
+        /// <param name="separateGPUs"></param>
+        public TournamentManager(TournamentDef def, int numParallel = 1)
+        {
+            Def = def;
+            NumConcurrent = Math.Min(numParallel, def.NumGamePairs ?? int.MaxValue);
+
+            // Turn off showing game moves if running parallel,
+            // since the moves of various games would be intermixed.
+            if (numParallel > 1)
+            {
+                def.ShowGameMoves = false;
+            }
 
 #if NOT
       if (def.EvaluatorDef2.DeviceCombo == NNEvaluators.Defs.NNEvaluatorDeviceComboType.Pooled)
@@ -76,168 +76,203 @@ namespace Ceres.Features.Tournaments
         SeparateGPUs = false;
       }
 #endif
+        }
+
+        int numGamePairsLaunched = 0;
+        readonly object lockObj = new();
+
+
+        /// <summary>
+        /// Method called by threads to get the next available game to be played.
+        /// </summary>
+        /// <returns></returns>
+        int GetNextOpeningIndexForLocalThread(int maxOpenings)
+        {
+            if (Def.RandomizeOpenings) throw new NotImplementedException();
+
+            lock (lockObj)
+            {
+                if (numGamePairsLaunched < maxOpenings)
+                {
+                    return numGamePairsLaunched++;
+                }
+                else
+                    return -1;
+            }
+        }
+
+
+        /// <summary>
+        /// If running multiple match threads then we need to make sure the 
+        /// neural network evaluators are suitable for parallel execution, either by:
+        ///   - being of type Pooled, so that all evaluator definitions reference
+        ///     the same underlying evaluator which will pool positions from many
+        ///     threads into one batch, or
+        ///   - each thread being assigned to a different GPU
+        ///   
+        /// This method handles the latter case, if the evaluators are not pooled
+        /// then it will sequentially apply them to GPUs with successive indices.
+        /// 
+        /// TODO: detect error condition where the number of threads exceeds number of GPUs.
+        /// </summary>
+        /// <param name="def"></param>
+        /// <param name="relativeDeviceIndex"></param>
+        static void TrySetRelativeDeviceIDIfNotPooled(TournamentDef def, int relativeDeviceIndex)
+        {
+            def.Player1Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
+            def.Player2Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
+        }
+
+        void VerifyEnginesCompatible()
+        {
+            if (Def.Engines.Count > 0)
+            {
+                foreach (var engine in Def.Engines)
+                {
+                    if (engine.SearchLimit.Type == SearchLimitType.NodesForAllMoves
+                        && !engine.EngineDef.SupportsNodesPerGameMode)
+                    {
+                        throw new Exception($"Requested NodesPerGame mode is not supported by engine: {engine.EngineDef.ID}");
+                    }
+                }
+            }
+
+            else
+            {
+                if (Def.Player1Def.SearchLimit.Type == SearchLimitType.NodesForAllMoves
+                 && !Def.Player1Def.EngineDef.SupportsNodesPerGameMode)
+                {
+                    throw new Exception($"Requested NodesPerGame mode is not supported by engine 1: {Def.Player1Def.EngineDef.ID}");
+                }
+
+                if (Def.Player2Def.SearchLimit.Type == SearchLimitType.NodesForAllMoves
+                 && !Def.Player2Def.EngineDef.SupportsNodesPerGameMode)
+                {
+                    throw new Exception($"Requested NodesPerGame mode is not supported by engine 2: {Def.Player2Def.EngineDef.ID}");
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="queueManager">optional associated queue manager if running in distributed mode</param>
+        /// <returns></returns>
+        public TournamentResultStats RunTournament(TournamentGameQueueManager queueManager = null)
+        {
+            if (Def.Engines.Count > 0)
+            {
+                foreach (var engine in Def.Engines)
+                {
+                    if (engine == null) throw new ArgumentNullException("engine is null)");
+                }
+            }
+            else
+            {
+                if (Def.Player1Def == null) throw new ArgumentNullException("Def.Player1Def is null)");
+                if (Def.Player2Def == null) throw new ArgumentNullException("Def.Player2Def is null)");
+            }
+
+
+            VerifyEnginesCompatible();
+
+            QueueManager = queueManager;
+            TournamentResultStats parentTest;
+
+            if (Def.Engines.Count > 0)
+            {
+                parentTest = new(Def.Engines.Select(e => e.ID));
+            }
+
+            else
+            {
+                parentTest = new(Def.Player1Def.ID, Def.Player2Def.ID);
+            }
+
+            // Show differences between engine 1 and engine 2
+            Def.DumpParams();
+
+            // Prepare to create a set of task threads to run games
+            List<Task> tasks = new List<Task>();
+            List<TournamentGameThread> gameThreads = new List<TournamentGameThread>();
+
+            Directory.CreateDirectory(CeresUserSettingsManager.Settings.DirCeresOutput);
+
+            // If we are a worker process then run only a single game thread.
+            int numConcurrent = queueManager != null && !queueManager.IsCoordinator ? 1 : NumConcurrent;
+
+            for (int i = 0; i < numConcurrent; i++)
+            {
+                TournamentDef tournamentDefClone = Def.Clone();
+
+                // Make sure the threads will use either different or pooled evaluators
+                if (NumConcurrent > 1)
+                {
+                    TrySetRelativeDeviceIDIfNotPooled(tournamentDefClone, i);
+                }
+
+                //if (Def.Player1Def is GameEngineDefCeres
+                // && Def.Player2Def is GameEngineDefCeres
+                // && Def.Player1Def.SearchLimit.IsNodesLimit
+                // && Def.Player2Def.SearchLimit.IsNodesLimit)
+                //{
+                //    GameEngineDefCeres thisDefCeres1 = Def.Player1Def.EngineDef as GameEngineDefCeres;
+                //    GameEngineDefCeres thisDefCeres2 = Def.Player2Def.EngineDef as GameEngineDefCeres;
+
+                //    // TODO: possibly add optimization here which will share trees
+                //    //       with ReusePositionEvaluationsFromOtherTree.
+                //    //       See the suite manager for an example of how this is done.
+                //}
+
+                TournamentGameThread gameTest = new TournamentGameThread(tournamentDefClone, parentTest);
+                gameThreads.Add(gameTest);
+
+                Action action;
+                if (QueueManager == null)
+                {
+                    // Everything happens locally, data structures updated as part of processing.
+                    action = () => ThreadProcLocalWorker(i, gameTest);
+                }
+                else if (QueueManager.IsCoordinator)
+                {
+                    // We are coordinator. Repeatedly enqueue request to play game pairs and retireve/show results.
+                    action = () => ThreadProcCoordinator(i, gameTest);
+                }
+                else
+                {
+                    // Worker method (which will forward result data structure back to coordinator).
+                    action = () => ThreadProcDistributedWorker(i, gameTest);
+                }
+
+
+                Task thisTask = new Task(action);
+                tasks.Add(thisTask);
+                thisTask.Start();
+            }
+            Task.WaitAll(tasks.ToArray());
+
+            // Calculate and write summary line
+            long totalNodesEngine1 = gameThreads.Sum(g => g.TotalNodesEngine1);
+            long totalNodesEngine2 = gameThreads.Sum(g => g.TotalNodesEngine2);
+            int totalMovesEngine1 = gameThreads.Sum(g => g.TotalMovesEngine1);
+            int totalMovesEngine2 = gameThreads.Sum(g => g.TotalMovesEngine2);
+            float totalTimeEngine1 = gameThreads.Sum(g => g.TotalTimeEngine1);
+            float totalTimeEngine2 = gameThreads.Sum(g => g.TotalTimeEngine2);
+            float numGames = gameThreads.Sum(g => g.NumGames);
+
+            Def.Logger.Write("	      	                    			           ");
+            Def.Logger.WriteLine("     ------   ------     --------------   --------------   ----");
+            Def.Logger.Write("                                                ");
+            Def.Logger.Write("                     ");
+            Def.Logger.Write($"{totalTimeEngine1,9:F2}{totalTimeEngine2,9:F2}");
+            Def.Logger.Write($"{totalNodesEngine1,19:N0}{totalNodesEngine2,17:N0}   ");
+            Def.Logger.Write($"{Math.Round(totalMovesEngine1 / numGames, 0),4:F0}");
+
+            Def.Logger.WriteLine();
+            parentTest.Dump();
+            return parentTest;
+        }
+
     }
-
-    int numGamePairsLaunched = 0;
-    readonly object lockObj = new();
-
-
-    /// <summary>
-    /// Method called by threads to get the next available game to be played.
-    /// </summary>
-    /// <returns></returns>
-    int GetNextOpeningIndexForLocalThread(int maxOpenings)
-    {
-      if (Def.RandomizeOpenings) throw new NotImplementedException();
-
-      lock (lockObj)
-      {
-        if (numGamePairsLaunched < maxOpenings)
-        {
-          return numGamePairsLaunched++;
-        }
-        else
-          return -1;
-      }
-    }
-
-
-    /// <summary>
-    /// If running multiple match threads then we need to make sure the 
-    /// neural network evaluators are suitable for parallel execution, either by:
-    ///   - being of type Pooled, so that all evaluator definitions reference
-    ///     the same underlying evaluator which will pool positions from many
-    ///     threads into one batch, or
-    ///   - each thread being assigned to a different GPU
-    ///   
-    /// This method handles the latter case, if the evaluators are not pooled
-    /// then it will sequentially apply them to GPUs with successive indices.
-    /// 
-    /// TODO: detect error condition where the number of threads exceeds number of GPUs.
-    /// </summary>
-    /// <param name="def"></param>
-    /// <param name="relativeDeviceIndex"></param>
-    static void TrySetRelativeDeviceIDIfNotPooled(TournamentDef def, int relativeDeviceIndex)
-    {
-      def.Player1Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
-      def.Player2Def.EngineDef.ModifyDeviceIndexIfNotPooled(relativeDeviceIndex);
-    }
-
-    void VerifyEnginesCompatible()
-    {
-      if (Def.Player1Def.SearchLimit.Type == SearchLimitType.NodesForAllMoves
-       && !Def.Player1Def.EngineDef.SupportsNodesPerGameMode)
-      {
-        throw new Exception($"Requested NodesPerGame mode is not supported by engine 1: {Def.Player1Def.EngineDef.ID}");
-      }
-
-      if (Def.Player2Def.SearchLimit.Type == SearchLimitType.NodesForAllMoves
-       && !Def.Player2Def.EngineDef.SupportsNodesPerGameMode)
-      {
-        throw new Exception($"Requested NodesPerGame mode is not supported by engine 2: {Def.Player2Def.EngineDef.ID}");
-      }
-    }
-
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="queueManager">optional associated queue manager if running in distributed mode</param>
-    /// <returns></returns>
-    public TournamentResultStats RunTournament(TournamentGameQueueManager queueManager = null)
-    {
-      if (Def.Player1Def == null) throw new ArgumentNullException("Def.Player1Def is null)");
-      if (Def.Player2Def == null) throw new ArgumentNullException("Def.Player2Def is null)");
-
-      VerifyEnginesCompatible();
-
-      QueueManager = queueManager;
-
-      TournamentResultStats parentTest = new TournamentResultStats(Def.Player1Def.ID, Def.Player2Def.ID);
-
-      // Show differences between engine 1 and engine 2
-      Def.DumpParams();
-
-      // Prepare to create a set of task threads to run games
-      List<Task> tasks = new List<Task>();
-      List<TournamentGameThread> gameThreads = new List<TournamentGameThread>();
-
-      Directory.CreateDirectory(CeresUserSettingsManager.Settings.DirCeresOutput);
-
-      // If we are a worker process then run only a single game thread.
-      int numConcurrent = queueManager != null && !queueManager.IsCoordinator ? 1 : NumConcurrent;
-
-      for (int i = 0; i < numConcurrent; i++)
-      {
-        TournamentDef tournamentDefClone = Def.Clone();
-
-        // Make sure the threads will use either different or pooled evaluators
-        if (NumConcurrent > 1)
-        {
-          TrySetRelativeDeviceIDIfNotPooled(tournamentDefClone, i);
-        }
-
-        if (Def.Player1Def is GameEngineDefCeres
-         && Def.Player2Def is GameEngineDefCeres
-         && Def.Player1Def.SearchLimit.IsNodesLimit
-         && Def.Player2Def.SearchLimit.IsNodesLimit)
-        {
-          GameEngineDefCeres thisDefCeres1 = Def.Player1Def.EngineDef as GameEngineDefCeres;
-          GameEngineDefCeres thisDefCeres2 = Def.Player2Def.EngineDef as GameEngineDefCeres;
-
-          // TODO: possibly add optimization here which will share trees
-          //       with ReusePositionEvaluationsFromOtherTree.
-          //       See the suite manager for an example of how this is done.
-        }
-
-        TournamentGameThread gameTest = new TournamentGameThread(tournamentDefClone, parentTest);
-        gameThreads.Add(gameTest);
-
-        Action action;
-        if (QueueManager == null)
-        {
-          // Everything happens locally, data structures updated as part of processing.
-          action = () => ThreadProcLocalWorker(i, gameTest);
-        }
-        else if (QueueManager.IsCoordinator)
-        {
-          // We are coordinator. Repeatedly enqueue request to play game pairs and retireve/show results.
-          action = () => ThreadProcCoordinator(i, gameTest);
-        }
-        else
-        {
-          // Worker method (which will forward result data structure back to coordinator).
-          action = () => ThreadProcDistributedWorker(i, gameTest);
-        }
-
-
-        Task thisTask = new Task(action);
-        tasks.Add(thisTask);
-        thisTask.Start();
-      }
-      Task.WaitAll(tasks.ToArray());
-
-      // Calculate and write summary line
-      long totalNodesEngine1 = gameThreads.Sum(g => g.TotalNodesEngine1);
-      long totalNodesEngine2 = gameThreads.Sum(g => g.TotalNodesEngine2);
-      int totalMovesEngine1 = gameThreads.Sum(g => g.TotalMovesEngine1);
-      int totalMovesEngine2 = gameThreads.Sum(g => g.TotalMovesEngine2);
-      float totalTimeEngine1 = gameThreads.Sum(g => g.TotalTimeEngine1);
-      float totalTimeEngine2 = gameThreads.Sum(g => g.TotalTimeEngine2);
-      float numGames = gameThreads.Sum(g => g.NumGames);
-
-      Def.Logger.Write("	      	                    			           ");
-      Def.Logger.WriteLine("     ------   ------     --------------   --------------   ----");
-      Def.Logger.Write("                                                ");
-      Def.Logger.Write("                     ");
-      Def.Logger.Write($"{totalTimeEngine1,9:F2}{totalTimeEngine2,9:F2}");
-      Def.Logger.Write($"{totalNodesEngine1,19:N0}{totalNodesEngine2,17:N0}   ");
-      Def.Logger.Write($"{Math.Round(totalMovesEngine1 / numGames, 0),4:F0}");
-
-      Def.Logger.WriteLine();
-      parentTest.Dump();
-      return parentTest;
-    }
-
-  }
 }

--- a/src/Ceres.Features/Tournaments/TournamentManager.cs
+++ b/src/Ceres.Features/Tournaments/TournamentManager.cs
@@ -270,7 +270,14 @@ namespace Ceres.Features.Tournaments
             Def.Logger.Write($"{Math.Round(totalMovesEngine1 / numGames, 0),4:F0}");
 
             Def.Logger.WriteLine();
-            parentTest.Dump();
+            if (Def.Engines.Count > 0)
+            {
+                parentTest.DumpRoundRobin();
+            }
+            else
+            {
+                parentTest.Dump();
+            }
             return parentTest;
         }
 

--- a/src/Ceres.Features/Tournaments/TournamentResultStats.cs
+++ b/src/Ceres.Features/Tournaments/TournamentResultStats.cs
@@ -23,167 +23,385 @@ using Chess.Ceres.PlayEvaluation;
 
 namespace Ceres.Features.Tournaments
 {
+  /// <summary>
+  /// Statistics relating to the outcome of a tournament.
+  /// </summary>
+  public record TournamentResultStats
+  {
     /// <summary>
-    /// Statistics relating to the outcome of a tournament.
+    /// Table to store Win-Draw-Loss statistics against each opponent
     /// </summary>
-    public record TournamentResultStats
+    public Dictionary<string, (int, int, int)> Opponents { get; set; } = new Dictionary<string, (int, int, int)>();
+
+    public long Player1TotalNodes { set; get; }
+
+    public float Player1TotalTime { set; get; }
+
+    public long Player2TotalNodes { set; get; }
+
+    public float Player2TotalTime { set; get; }
+
+    /// <summary>
+    /// Name of player 1.
+    /// </summary>
+    public string Player1 { init; get; }
+
+    /// <summary>
+    /// Name of player 2.
+    /// </summary>
+    public string Player2 { init; get; }
+
+    /// <summary>
+    /// Number of wins by player 1.
+    /// </summary>
+    public int Player1Wins { set; get; }
+
+    /// <summary>
+    /// Number of draws.
+    /// </summary>
+    public int Draws { set; get; }
+
+    /// <summary>
+    /// Number of losses by player 1.
+    /// </summary>
+    public int Player1Losses { set; get; }
+
+    /// <summary>
+    /// Short string summarizing games outcome.
+    /// </summary>
+    public string GameOutcomesString { set; get; }
+
+    /// <summary>
+    /// Total number of games played.
+    /// </summary>
+    public int NumGames => Player1Wins + Draws + Player1Losses;
+
+    /// <summary>
+    /// List of TournamentResultStats for every player
+    /// </summary>
+    public List<TournamentResultStats> Results { get; set; }
+
+    public TournamentResultStats()
     {
-        /// <summary>
-        /// Name of player 1.
-        /// </summary>
-        public string Player1 { init; get; }
-
-        /// <summary>
-        /// Name of player 2.
-        /// </summary>
-        public string Player2 { init; get; }
-
-        /// <summary>
-        /// Number of wins by player 1.
-        /// </summary>
-        public int Player1Wins { set; get; }
-
-        /// <summary>
-        /// Number of draws.
-        /// </summary>
-        public int Draws { set; get; }
-
-        /// <summary>
-        /// Number of losses by player 1.
-        /// </summary>
-        public int Player1Losses { set; get; }
-
-        /// <summary>
-        /// Short string summarizing games outcome.
-        /// </summary>
-        public string GameOutcomesString { set; get; }
-
-        /// <summary>
-        /// Total number of games played.
-        /// </summary>
-        public int NumGames => Player1Wins + Draws + Player1Losses;
-        //public int GamesPlayed => Results.Sum(e => e.NumGames);
-
-        /// <summary>
-        /// Names for engines in a round robin tournament
-        /// </summary>
-        public List<string> PlayerNames { get; set; }
-
-        public List<TournamentResultStats> Results { get; set; }
-
-
-        public TournamentResultStats(IEnumerable<string> engines)
-        {
-            PlayerNames = engines.ToList();
-            Results = new List<TournamentResultStats>();
-        }
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="player1"></param>
-        /// <param name="player2"></param>
-        public TournamentResultStats(string player1, string player2)
-        {
-            Player1 = player1;
-            Player2 = player2;
-            Results = new List<TournamentResultStats>();
-        }
-
-
-        /// <summary>
-        /// Updates tournament statistics based on a game with specified result.
-        /// </summary>
-        /// <param name="thisResult"></param>
-        public void UpdateTournamentStats(TournamentGameInfo thisResult)
-        {
-            switch (thisResult.Result)
-            {
-                case TournamentGameResult.Win:
-                    Player1Wins++;
-                    GameOutcomesString += "+";
-                    break;
-
-                case TournamentGameResult.Loss:
-                    Player1Losses++;
-                    GameOutcomesString += "-";
-                    break;
-
-                default:
-                    Draws++;
-                    GameOutcomesString += "=";
-                    break;
-            }
-        }
-
-        void UpdateRRStats(TournamentResultStats stat, TournamentGameInfo result)
-        {
-            stat.UpdateTournamentStats(result);
-        }
-
-        public TournamentResultStats GetResultsForPlayer(string player1, string player2)
-        {
-            var white = Results.FirstOrDefault(e => e.Player1 == player1);
-
-            if (white == null)
-            {
-                var entry = new TournamentResultStats(player1, player2);
-                Results.Add(entry);
-                return entry;
-            }
-            return white;
-        }
-
-        public void UpdateRRTournamentStats(TournamentGameInfo thisResult, GameEngine engine1, GameEngine engine2)
-        {
-            TournamentResultStats stats;
-            stats = GetResultsForPlayer(engine1.ID, engine2.ID);
-            stats.UpdateRRStats(stats, thisResult);
-            var otherPlayer = GetResultsForPlayer(engine2.ID, engine1.ID);
-            var gameResultBlack =
-                thisResult.Result == TournamentGameResult.Win ? TournamentGameResult.Loss :
-                thisResult.Result == TournamentGameResult.Loss ? TournamentGameResult.Win :
-                TournamentGameResult.Draw;
-
-            var reverseResult = thisResult with { Result = gameResultBlack };
-            otherPlayer.UpdateRRStats(otherPlayer, reverseResult);
-            //GamesPlayed++;
-            
-        }
-
-
-        /// <summary>
-        /// Dumps summary to Console.
-        /// </summary>
-        public void Dump()
-        {
-            Console.WriteLine($"Tournament Results of {Player1} versus {Player2} in {NumGames} games");
-            Console.WriteLine($"  {Player1} wins {Player1Wins}");
-            Console.WriteLine($"  {Player1} draws {Draws}");
-            Console.WriteLine($"  {Player1} loses {Player1Losses}");
-
-            var eloInterval = EloCalculator.EloConfidenceInterval(Player1Wins, Draws, Player1Losses);
-            Console.WriteLine($"  ELO Difference {eloInterval.avg,4:F0} +/- {eloInterval.max - eloInterval.avg,4:F0}");
-        }
-
-        public void DumpRoundRobin()
-        {
-            var numberOfGames = Results.Sum(e => e.NumGames / 2);
-            Console.WriteLine($"Tournament Results from {numberOfGames} games");
-            WriteResults();
-        }
-
-        void WriteResults()
-        {
-            foreach (var item in Results)
-            {
-                Console.WriteLine($"  {item.Player1} wins {item.Player1Wins}");
-                Console.WriteLine($"  {item.Player1} draws {item.Draws}");
-                Console.WriteLine($"  {item.Player1} loses {item.Player1Losses}");
-                var eloInterval = EloCalculator.EloConfidenceInterval(item.Player1Wins, item.Draws, item.Player1Losses);
-                Console.WriteLine($"  ELO Difference {eloInterval.avg,4:F0} +/- {eloInterval.max - eloInterval.avg,4:F0}");
-                Console.WriteLine();
-            }
-        }
+      Results = new List<TournamentResultStats>();
     }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="player1"></param>
+    /// <param name="player2"></param>
+    public TournamentResultStats(string player1, string player2)
+    {
+      Player1 = player1;
+      Player2 = player2;
+    }
+
+    /// <summary>
+    /// Dump tournament summary to console
+    /// </summary>
+    public void DumpTournamentSummary(string referenceId)
+    {
+      Console.WriteLine("Tournament summary:");
+      DumpEngineTournamentSummary(referenceId);
+      Console.WriteLine();
+      DumpRoundRobinResultTable(referenceId);
+      Console.WriteLine();
+    }
+
+    /// <summary>
+    /// Dumps full engine summary table to Console
+    /// </summary>
+    void DumpEngineTournamentSummary(string referenceId)
+    {
+      var width = 180;
+      PrintLine(width);
+      var header = new List<string>() { "Player", "Rating", "Error +/-", "CFS (%)", "Points", "Played", "W-D-L", "D(%)", "Time", "Nodes" };
+      PrintCenterAlignedRow(header, width);
+      PrintLine(width);
+      foreach (var engine in Results)
+      {
+        WriteEngineSummary(engine, width, referenceId);
+      }
+      PrintLine(width);
+      Console.WriteLine();
+    }
+
+    /// <summary>
+    /// Write summary row for player1
+    /// </summary>
+    /// <param name="engineStat"></param>
+    /// <param name="width"></param>
+    void WriteEngineSummary(TournamentResultStats engineStat, int width, string referenceId)
+    {
+      var playerInfo = engineStat.Player1 == referenceId ? engineStat.Player1 + "*" : engineStat.Player1;
+      var score = engineStat.Player1Wins + (engineStat.Draws / 2.0);
+      //var numberOfGames = engineStat.Player1Losses + engineStat.Player1Wins + engineStat.Draws;
+      var wdl = $"{engineStat.Player1Wins}-{engineStat.Draws}-{engineStat.Player1Losses}";
+      var cfs = EloCalculator.LikelihoodSuperiority(engineStat.Player1Wins, engineStat.Draws, engineStat.Player1Losses);
+      var (min, avg, max) = EloCalculator.EloConfidenceInterval(engineStat.Player1Wins, engineStat.Draws, engineStat.Player1Losses);
+      var error = $"{(max - avg):F0}";
+      var draws = engineStat.Draws / (double)engineStat.NumGames;
+      var nodes = engineStat.Player1TotalNodes;
+      var time = engineStat.Player1TotalTime;
+      var rowItems = new List<string>()
+                { playerInfo, avg.ToString("F0"), error, cfs.ToString("P0"), score.ToString("F1"),
+                engineStat.NumGames.ToString(), wdl, draws.ToString("P2"), {time.ToString("F2")}, {nodes.ToString("N0")} };
+      PrintEngineRow(rowItems, width);
+    }
+
+    public void DumpRoundRobinResultTable(string referenceId)
+    {
+      //decide total width for table
+      int totalWidth = 20 * Results.Count;
+      Console.WriteLine("Tournament round robin table (W-D-L):");
+      DumpHeadingTable(totalWidth);
+      if (string.IsNullOrEmpty(referenceId))
+      {
+        for (int i = 0; i < Results.Count; i++)
+        {
+          var row = CreateRoundRobinRow(i);
+          PrintCenterAlignedRow(row, totalWidth);
+        }
+      }
+      else
+      {
+        var id = Results.FirstOrDefault(e => e.Player1 == referenceId);
+        if (id == null)
+        {
+          throw new Exception("Reference engine not found in Result table");
+        }
+        var index = Results.IndexOf(id);
+        var row = CreateRoundRobinRow(index);
+        PrintCenterAlignedRow(row, totalWidth);
+      }
+      PrintLine(totalWidth);
+    }
+
+    /// <summary>
+    /// Updates tournament statistics based on a game with specified result.
+    /// </summary>
+    /// <param name="thisResult"></param>
+    /// <param name="opponent"></param>
+    public void UpdateGameOutcome(TournamentGameInfo thisResult, string opponent)
+    {
+      var (win, draw, loss) = Opponents[opponent];
+      switch (thisResult.Result)
+      {
+        case TournamentGameResult.Win:
+          Player1Wins++;
+          Opponents[opponent] = (win + 1, draw, loss);
+          GameOutcomesString += "+";
+          break;
+
+        case TournamentGameResult.Loss:
+          Player1Losses++;
+          Opponents[opponent] = (win, draw, loss + 1);
+          GameOutcomesString += "-";
+          break;
+
+        default:
+          Draws++;
+          Opponents[opponent] = (win, draw + 1, loss);
+          GameOutcomesString += "=";
+          break;
+      }
+    }
+
+    /// <summary>
+    /// Get TournamentResultStats for player1 and set opponent as player 2
+    /// </summary>
+    /// <param name="player1"></param>
+    /// <param name="player2"></param>
+    /// <returns></returns>
+    public TournamentResultStats GetResultsForPlayer(string player1, string player2)
+    {
+      var whitePlayer = Results.FirstOrDefault(e => e.Player1 == player1);
+
+      if (whitePlayer == null)
+      {
+        var entry = new TournamentResultStats(player1, player2);
+        if (!entry.Opponents.ContainsKey(player2))
+        {
+          entry.Opponents.Add(player2, (0, 0, 0));
+        }
+        Results.Add(entry);
+        return entry;
+      }
+      if (!whitePlayer.Opponents.ContainsKey(player2))
+      {
+        whitePlayer.Opponents.Add(player2, (0, 0, 0));
+      }
+      return whitePlayer;
+    }
+
+    /// <summary>
+    /// Update tournament stat for player1 and opponent
+    /// </summary>
+    /// <param name="thisResult"></param>
+    /// <param name="engine"></param>
+
+    public void UpdateTournamentStats(TournamentGameInfo thisResult, GameEngine engine)
+    {
+      TournamentResultStats player1;
+      player1 = GetResultsForPlayer(engine.ID, engine.OpponentEngine.ID);
+      player1.UpdateGameOutcome(thisResult, engine.OpponentEngine.ID);
+      var player2 = GetResultsForPlayer(engine.OpponentEngine.ID, engine.ID);
+      var gameResultBlack =
+          thisResult.Result == TournamentGameResult.Win ? TournamentGameResult.Loss :
+          thisResult.Result == TournamentGameResult.Loss ? TournamentGameResult.Win :
+          TournamentGameResult.Draw;
+
+      var reverseResult = thisResult with { Result = gameResultBlack };
+      player2.UpdateGameOutcome(reverseResult, engine.ID);
+      player1.UpdateNodeCounterAndTimeUse(thisResult, player1, player2);
+    }
+
+    void UpdateNodeCounterAndTimeUse(TournamentGameInfo thisResult, TournamentResultStats player1, TournamentResultStats player2)
+    {
+      player1.Player1TotalNodes += thisResult.TotalNodesEngine1;
+      player2.Player1TotalNodes += thisResult.TotalNodesEngine2;
+      player1.Player1TotalTime += thisResult.TotalTimeEngine1;
+      player2.Player1TotalTime += thisResult.TotalTimeEngine2;
+    }
+
+    /// <summary>
+    /// Dumps Round Robin summary to Console
+    /// </summary>
+
+
+    /// <summary>
+    /// Dump dashes to console for a certain width
+    /// </summary>
+    /// <param name="width"></param>
+    void PrintLine(int width)
+    {
+      Console.WriteLine(new string('-', width));
+    }
+
+    /// <summary>
+    /// Dump center aligned text row to console
+    /// </summary>
+    /// <param name="columns"></param>
+    /// <param name="maxWidth"></param>
+
+    void PrintCenterAlignedRow(IEnumerable<string> columns, int maxWidth)
+    {
+      int Columnwidth = (maxWidth - columns.Count()) / columns.Count();
+      string row = "|";
+
+      foreach (string column in columns)
+      {
+        row += AlignCentre(column, Columnwidth) + "|";
+      }
+
+      Console.WriteLine(row);
+    }
+
+    void PrintEngineRow(List<string> columns, int maxWidth)
+    {
+      var numberOfColumns = columns.Count();
+      int Columnwidth = (maxWidth - columns.Count()) / columns.Count();
+      string row = "|";
+
+      for (int i = 0; i < numberOfColumns; i++)
+      {
+        if (i == numberOfColumns - 1)
+          row += AlignRight(columns[i], Columnwidth) + "|";
+        else
+          row += AlignCentre(columns[i], Columnwidth) + "|";
+      }
+
+      Console.WriteLine(row);
+    }
+
+    /// <summary>
+    /// Center align text in a column for a certain width
+    /// </summary>
+    /// <param name="text"></param>
+    /// <param name="width"></param>
+    /// <returns></returns>
+
+    string AlignCentre(string text, int width)
+    {
+      text = text.Length > width ? text.Substring(0, width - 3) + "..." : text;
+
+      if (string.IsNullOrEmpty(text))
+      {
+        return new string(' ', width);
+      }
+      else
+      {
+        return text.PadRight(width - (width - text.Length) / 2).PadLeft(width);
+      }
+    }
+
+    /// <summary>
+    /// Right align text in a column for a certain width
+    /// </summary>
+    /// <param name="text"></param>
+    /// <param name="width"></param>
+    /// <returns></returns>
+
+    string AlignRight(string text, int width)
+    {
+      text = text.Length > width ? text.Substring(0, width - 3) + "..." : text;
+
+      if (string.IsNullOrEmpty(text))
+      {
+        return new string(' ', width);
+      }
+      else
+      {
+        return text.PadLeft(width);
+      }
+    }
+
+    /// <summary>
+    /// Create Round Robin row for result table
+    /// </summary>
+    /// <param name="row"></param>
+    /// <returns></returns>
+    IEnumerable<string> CreateRoundRobinRow(int row)
+    {
+      const string empty = "-----";
+      int counter = 0;
+      var stat = Results[row];
+      yield return stat.Player1;
+      foreach (var opponent in stat.Opponents)
+      {
+        if (row == counter)
+        {
+          yield return empty;
+        }
+
+        var (win, draw, loss) = opponent.Value;
+        yield return $"{win}-{draw}-{loss}";
+        counter++;
+      }
+
+      if (row + 1 == Results.Count)
+      {
+        yield return empty;
+      }
+    }
+
+    /// <summary>
+    /// Dump Round Robin result header
+    /// </summary>
+    /// <param name="width"></param>
+
+    void DumpHeadingTable(int width)
+    {
+      var players = Results.Select(e => e.Player1);
+      var header = new List<string>();
+      header.Add("Engine");
+      header.AddRange(players);
+      PrintLine(width);
+      PrintCenterAlignedRow(header, width);
+      PrintLine(width);
+    }
+
+
+  }
 }

--- a/src/Ceres.Features/Tournaments/TournamentResultStats.cs
+++ b/src/Ceres.Features/Tournaments/TournamentResultStats.cs
@@ -109,12 +109,39 @@ namespace Ceres.Features.Tournaments
             }
         }
 
+        public void UpdateRRTournamentStats(TournamentGameInfo thisResult)
+        {
+            switch (thisResult.Result)
+            {
+                case TournamentGameResult.Win:
+                    Player1Wins++;
+                    GameOutcomesString += "+";
+                    break;
+
+                case TournamentGameResult.Loss:
+                    Player1Losses++;
+                    GameOutcomesString += "-";
+                    break;
+
+                default:
+                    Draws++;
+                    GameOutcomesString += "=";
+                    break;
+            }
+        }
+
 
         /// <summary>
         /// Dumps summary to Console.
         /// </summary>
         public void Dump()
         {
+            // need to add tournament results here too
+            if (false)
+            {
+
+            }
+            
             Console.WriteLine($"Tournament Results of {Player1} versus {Player2} in {NumGames} games");
             Console.WriteLine($"  {Player1} wins {Player1Wins}");
             Console.WriteLine($"  {Player1} draws {Draws}");

--- a/src/Ceres.Features/Tournaments/TournamentResultStats.cs
+++ b/src/Ceres.Features/Tournaments/TournamentResultStats.cs
@@ -14,103 +14,114 @@
 #region Using directives
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Chess.Ceres.PlayEvaluation;
 
 #endregion
 
 namespace Ceres.Features.Tournaments
 {
-  /// <summary>
-  /// Statistics relating to the outcome of a tournament.
-  /// </summary>
-  public record TournamentResultStats
-  {
     /// <summary>
-    /// Name of player 1.
+    /// Statistics relating to the outcome of a tournament.
     /// </summary>
-    public string Player1 { init; get; }
-
-    /// <summary>
-    /// Name of player 2.
-    /// </summary>
-    public string Player2 { init; get; }
-
-    /// <summary>
-    /// Number of wins by player 1.
-    /// </summary>
-    public int Player1Wins { set; get; }
-
-    /// <summary>
-    /// Number of draws.
-    /// </summary>
-    public int Draws { set; get; }
-
-    /// <summary>
-    /// Number of losses by player 1.
-    /// </summary>
-    public int Player1Losses { set; get; }
-
-    /// <summary>
-    /// Short string summarizing games outcome.
-    /// </summary>
-    public string GameOutcomesString { set; get; }
-
-    /// <summary>
-    /// Total number of games played.
-    /// </summary>
-    public int NumGames => Player1Wins + Draws + Player1Losses;
-
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    /// <param name="player1"></param>
-    /// <param name="player2"></param>
-    public TournamentResultStats(string player1, string player2)
+    public record TournamentResultStats
     {
-      Player1 = player1;
-      Player2 = player2;
+        /// <summary>
+        /// Name of player 1.
+        /// </summary>
+        public string Player1 { init; get; }
+
+        /// <summary>
+        /// Name of player 2.
+        /// </summary>
+        public string Player2 { init; get; }
+
+        /// <summary>
+        /// Number of wins by player 1.
+        /// </summary>
+        public int Player1Wins { set; get; }
+
+        /// <summary>
+        /// Number of draws.
+        /// </summary>
+        public int Draws { set; get; }
+
+        /// <summary>
+        /// Number of losses by player 1.
+        /// </summary>
+        public int Player1Losses { set; get; }
+
+        /// <summary>
+        /// Short string summarizing games outcome.
+        /// </summary>
+        public string GameOutcomesString { set; get; }
+
+        /// <summary>
+        /// Total number of games played.
+        /// </summary>
+        public int NumGames => Player1Wins + Draws + Player1Losses;
+
+        public List<string> PlayerNames { get; set; }
+
+
+        public TournamentResultStats(IEnumerable<string> engines)
+        {
+            PlayerNames = engines.ToList();
+            //Player1 = player1;
+            //Player2 = player2;
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="player1"></param>
+        /// <param name="player2"></param>
+        public TournamentResultStats(string player1, string player2)
+        {
+            Player1 = player1;
+            Player2 = player2;
+        }
+
+
+        /// <summary>
+        /// Updates tournament statistics based on a game with specified result.
+        /// </summary>
+        /// <param name="thisResult"></param>
+        public void UpdateTournamentStats(TournamentGameInfo thisResult)
+        {
+            switch (thisResult.Result)
+            {
+                case TournamentGameResult.Win:
+                    Player1Wins++;
+                    GameOutcomesString += "+";
+                    break;
+
+                case TournamentGameResult.Loss:
+                    Player1Losses++;
+                    GameOutcomesString += "-";
+                    break;
+
+                default:
+                    Draws++;
+                    GameOutcomesString += "=";
+                    break;
+            }
+        }
+
+
+        /// <summary>
+        /// Dumps summary to Console.
+        /// </summary>
+        public void Dump()
+        {
+            Console.WriteLine($"Tournament Results of {Player1} versus {Player2} in {NumGames} games");
+            Console.WriteLine($"  {Player1} wins {Player1Wins}");
+            Console.WriteLine($"  {Player1} draws {Draws}");
+            Console.WriteLine($"  {Player1} loses {Player1Losses}");
+
+            var eloInterval = EloCalculator.EloConfidenceInterval(Player1Wins, Draws, Player1Losses);
+            Console.WriteLine($"  ELO Difference {eloInterval.avg,4:F0} +/- {eloInterval.max - eloInterval.avg,4:F0}");
+        }
     }
-
-
-    /// <summary>
-    /// Updates tournament statistics based on a game with specified result.
-    /// </summary>
-    /// <param name="thisResult"></param>
-    public void UpdateTournamentStats(TournamentGameInfo thisResult)
-    {
-      switch (thisResult.Result)
-      {
-        case TournamentGameResult.Win:
-          Player1Wins++;
-          GameOutcomesString += "+";
-          break;
-
-        case TournamentGameResult.Loss:
-          Player1Losses++;
-          GameOutcomesString += "-";
-          break;
-
-        default:
-          Draws++;
-          GameOutcomesString += "=";
-          break;
-      }
-    }
-
-
-    /// <summary>
-    /// Dumps summary to Console.
-    /// </summary>
-    public void Dump()
-    {
-      Console.WriteLine($"Tournament Results of {Player1} versus {Player2} in {NumGames} games");
-      Console.WriteLine($"  {Player1} wins {Player1Wins}");
-      Console.WriteLine($"  {Player1} draws {Draws}");
-      Console.WriteLine($"  {Player1} loses {Player1Losses}");
-
-      var eloInterval = EloCalculator.EloConfidenceInterval(Player1Wins, Draws, Player1Losses);
-      Console.WriteLine($"  ELO Difference {eloInterval.avg,4:F0} +/- {eloInterval.max - eloInterval.avg,4:F0}");
-    }
-  }
 }

--- a/src/Ceres.MCTS/MCTSNodes/Analysis/MCTSNodePVDump.cs
+++ b/src/Ceres.MCTS/MCTSNodes/Analysis/MCTSNodePVDump.cs
@@ -28,322 +28,335 @@ using Ceres.MCTS.MTCSNodes.Struct;
 
 namespace Ceres.MCTS.MTCSNodes.Analysis
 {
-  /// <summary>
-  /// Static helper methods for dumping contents of tree to Console.
-  /// </summary>
-  public static class MCTSPosTreeNodeDumper
-  {
-    static void DumpWithColor(float v, string s, float thresholdRed, float thresholdGreen, TextWriter writer)
-    {
-      if (writer != Console.Out)
-      {
-        // No point in using color if not the Console
-        writer.Write(s);
-      }
-      else
-      {
-        ConsoleColor defaultColor = Console.ForegroundColor;
-
-        try
-        {
-          if (v > thresholdGreen)
-          {
-            Console.ForegroundColor = ConsoleColor.Green;
-          }
-          else if (v < thresholdRed)
-          {
-            Console.ForegroundColor = ConsoleColor.Red;
-          }
-
-          writer.Write(s);
-        }
-        finally
-        {
-          Console.ForegroundColor = defaultColor;
-        }
-      }
-    }
-
-
-    static void DumpNodeStr(MCTSNode searchRootNode, MCTSNode node, 
-                            int countTimesSeen, bool fullDetail, TextWriter writer = null)
-    {
-      int depth = node.Depth - searchRootNode.Depth;
-
-      writer = writer ?? Console.Out;
-
-      node.Tree.Annotate(node);
-
-      char extraChar = ' ';
-      switch (node.Terminal)
-      {
-        case GameResult.Checkmate:
-          extraChar = 'C';
-          break;
-        case GameResult.Draw:
-          extraChar = 'D';
-          break;
-        default:
-          if (countTimesSeen > 1)
-          {
-            extraChar = countTimesSeen > 9 ? '9' : countTimesSeen.ToString()[0];
-          }
-
-          break;
-      }
-
-      float multiplier = 1; // currently alternate perspective
-
-      float pctOfVisits = node.IsRoot ? 100.0f : (100.0f * node.N / node.Parent.N);
-
-      MCTSNode bestMove = default;
-// TODO: someday show this too      MCTSNode nextBestMove = null;
-      if (!node.IsRoot)
-      {
-        MCTSNode[] parentsChildrenSortedQ = node.ChildrenSorted(innerNode => -multiplier * (float)innerNode.Q);
-        if (parentsChildrenSortedQ.Length > 0)
-        {
-          bestMove = parentsChildrenSortedQ[0];
-        }
-        //        if (parentsChildrenSortedQ.Length > 1) nextBestMove = parentsChildrenSortedQ[1];
-      }
-
-      // Depth, move
-      writer.Write($"{depth,3}. ");
-      writer.Write(extraChar);
-      writer.Write($" {node.NumPolicyMoves,3} ");
-
-      writer.Write($"{node.Index,13:N0}");
-
-      string san = node.IsRoot ? "" : MGMoveConverter.ToMove(node.Annotation.PriorMoveMG).ToSAN(in node.Parent.Annotation.Pos);
-//      string sanNextBest = node.IsRoot ? "" : MGMoveConverter.ToMove(nextBestMove.Annotation.PriorMoveMG).ToSAN(in node.Parent.Annotation.Pos);
-      if (node.Annotation.Pos.MiscInfo.SideToMove == SideType.White)
-      {
-        writer.Write($"      ");
-        writer.Write($"{san,6}");
-
-      }
-      else
-      {
-        writer.Write($"{san,6}");
-        writer.Write($"      ");
-      }
-
-//      float diffBestNextBestQ = 0;
-//      if (nextBestMove != null) diffBestNextBestQ = (float)(bestMove.Q - nextBestMove.Q);
-//      writer.Write($"{  (nextBestMove?.Annotation == null ? "" : nextBestMove.Annotation.PriorMoveMG.ToString()),8}");
-//      writer.Write($"{diffBestNextBestQ,8:F2}");
-
-
-      writer.Write($"{node.N,13:N0} ");
-      writer.Write($" {pctOfVisits,5:F0}%");
-      writer.Write($"   {100.0 * node.P,6:F2}%  ");
-      DumpWithColor(multiplier * node.V, $" {multiplier * node.V,6:F3}  ", -0.2f, 0.2f, writer);
-//      DumpWithColor(multiplier * node.VSecondary, $" {multiplier * node.VSecondary,6:F3} ", -0.2f, 0.2f);
-      double q = multiplier * node.Q;
-      DumpWithColor((float)q, $" {q,6:F3} ", -0.2f, 0.2f, writer);
-
-      //      float qStdDev = MathF.Sqrt(node.Ref.VVariance);
-      //      if (float.IsNaN(qStdDev))
-      //        writer.WriteLine("found negative var");
-      //      writer.Write($" +/-{qStdDev,5:F2}  ");
-
-      bool invert = multiplier == -1;
-      writer.Write($" {(invert ? node.LossP : node.WinP),5:F2}/{node.DrawP,5:F2}/{(invert ? node.WinP : node.LossP),5:F2}  ");
-
-      writer.Write($" {(invert ? node.LAvg : node.WAvg),5:F2}/{node.DAvg,5:F2}/{(invert ? node.WAvg : node.LAvg),5:F2}  ");
-
-      //      writer.Write($"   {node.Ref.QUpdatesWtdAvg,5:F2}  ");
-      //      writer.Write($" +/-:{MathF.Sqrt(node.Ref.QUpdatesWtdVariance),5:F2}  ");
-      //      writer.Write($" {node.Ref.TrendBonusToP,5:F2}  ");
-
-      writer.Write($" {node.MPosition,3:F0} ");
-      writer.Write($" {node.MAvg,3:F0}  ");
-
-      if (fullDetail)
-      {
-        int numPieces = node.Annotation.Pos.PieceCount;
-
-//        writer.Write($" {PosStr(node.Annotation.Pos)} ");
-        writer.Write($" {node.Annotation.Pos.FEN}");
-      }
-
-
-      writer.WriteLine();
-    }
-
-    private static void WriteHeaders(bool fullDetail, TextWriter writer)
-    {
-      // Write headers
-      writer.Write(" Dep  T #M    FirstVisit   MvWh  MvBl           N  Visits    Policy     V         Q     WPos  DPos  LPos   WTree DTree LTree  MPos MTree");
-      if (fullDetail)
-      {
-        writer.WriteLine("  FEN");
-      }
-      else
-      {
-        writer.WriteLine();
-      }
-
-      if (fullDetail)
-      {
-        writer.WriteLine("----  - --  ------------  -----  ---- -----------  ------  --------  -------    -----   ----  ----  ----   -----  ---- -----  ---- -----");
-      }
-      else
-      {
-        writer.WriteLine();
-      }
-    }
-
-
-    static string ToStr(char pieceChar, int count, int maxCount)
-    {
-      string ret = "";
-
-      if (count > maxCount)
-      {
-        // Rare case of more than expected number of pieces (due to promotion)
-        ret += pieceChar + count.ToString();
-        for (int i = 0; i < maxCount - 2; i++)
-        {
-          ret += " ";
-        }
-      }
-      else
-      {
-        for (int i = 0; i < maxCount; i++)
-        {
-          if (count > i)
-          {
-            ret += pieceChar;
-          }
-          else
-          {
-            ret += " ";
-          }
-        }
-      }
-      return ret;
-    }
-
-
     /// <summary>
-    /// Returns a compact string describing the number of each type of piece on
-    /// on the board in the position. Example: "K R BBN PPPPPPP   k r bbn ppppppp"
+    /// Static helper methods for dumping contents of tree to Console.
     /// </summary>
-    /// <param name="pos"></param>
-    /// <returns></returns>
-    static string PosStr(Position pos)
+    public static class MCTSPosTreeNodeDumper
     {
-      string str = "K";
-
-      str += ToStr('Q', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Queen)), 1);
-      str += ToStr('R', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Rook)), 2);
-      str += ToStr('B', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Bishop)), 2);
-      str += ToStr('N', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Knight)), 2);
-      str += ToStr('P', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Pawn)), 8);
-
-      str += "  k";
-      str += ToStr('q', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Queen)), 1);
-      str += ToStr('r', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Rook)), 2);
-      str += ToStr('b', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Bishop)), 2);
-      str += ToStr('n', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Knight)), 2);
-      str += ToStr('p', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Pawn)), 8);
-
-      return str;
-    }
-
-
-    public static void DumpAllNodes(MCTSIterator context, ref MCTSNodeStruct node, 
-                                    Base.DataType.Trees.TreeTraversalType type = Base.DataType.Trees.TreeTraversalType.BreadthFirst, 
-                                    bool childDetail = false)
-    {
-      int index = 1;
-
-      // Visit all nodes and verify various conditions are true
-      node.Traverse(context.Tree.Store,
-                          (ref MCTSNodeStruct node) =>
-                          {
-                            Console.WriteLine(index + " " + node);
-                            if (childDetail)
-                            {
-                              int childIndex = 0;
-                              foreach (MCTSNodeStructChild childInfo in node.Children)
-                                Console.WriteLine($"  {childIndex++,3} {childInfo}");
-                            }
-                            index++;
-                            return true;
-                          }, type);
-    }
-
-
-    static MCTSNode DescendMovesToNode(MCTSNode rootNode, List<MGMove> moves)
-    {
-      MCTSNode node = rootNode;
-
-      foreach (MGMove move in moves)
-      {
-        int? childIndex = node.StructRef.ChildIndexWithMove(move);
-        if (childIndex is null)
+        static void DumpWithColor(float v, string s, float thresholdRed, float thresholdGreen, TextWriter writer)
         {
-          throw new Exception($"Move  {move} not found at node {node}");
-        }
-        else
-        {
-          (node, _, _) = node.ChildAtIndexInfo(childIndex.Value);
-        }
-      }
-      return node;
-    }
-
-
-    public static void DumpPV(MCTSNode node, bool fullDetail, TextWriter writer = null)
-    {
-      using (new SearchContextExecutionBlock(node.Context))
-      {
-        writer = writer ?? Console.Out;
-
-        writer.WriteLine();
-        WriteHeaders(fullDetail, writer);
-
-        List<Position> seenPositions = new List<Position>();
-
-        int CountDuplicatePos(Position pos)
-        {
-          int count = 0;
-          foreach (Position priorPos in seenPositions)
-          {
-            if (pos.EqualAsRepetition(in priorPos))
+            if (writer != Console.Out)
             {
-              count++;
+                // No point in using color if not the Console
+                writer.Write(s);
             }
-          }
+            else
+            {
+                ConsoleColor defaultColor = Console.ForegroundColor;
 
-          return count;
+                try
+                {
+                    if (v > thresholdGreen)
+                    {
+                        Console.ForegroundColor = ConsoleColor.Green;
+                    }
+                    else if (v < thresholdRed)
+                    {
+                        Console.ForegroundColor = ConsoleColor.Red;
+                    }
+
+                    writer.Write(s);
+                }
+                finally
+                {
+                    Console.ForegroundColor = defaultColor;
+                }
+            }
         }
 
-        int depth = 0;
-        MCTSNode searchRootNode = node;
-        while (true)
+
+        static void DumpNodeStr(MCTSNode searchRootNode, MCTSNode node,
+                                int countTimesSeen, bool fullDetail, TextWriter writer = null)
         {
-          node.Tree.Annotate(node);
-          seenPositions.Add(node.Annotation.Pos);
-          int countSeen = CountDuplicatePos(node.Annotation.Pos);
+            int depth = node.Depth - searchRootNode.Depth;
 
-          DumpNodeStr(searchRootNode, node, countSeen, fullDetail, writer);
+            writer = writer ?? Console.Out;
 
-          if (node.NumChildrenVisited == 0)
-          {
-            return;
-          }
+            node.Tree.Annotate(node);
 
-          node = node.BestMove(false);
+            char extraChar = ' ';
+            switch (node.Terminal)
+            {
+                case GameResult.Checkmate:
+                    extraChar = 'C';
+                    break;
+                case GameResult.Draw:
+                    extraChar = 'D';
+                    break;
+                default:
+                    if (countTimesSeen > 1)
+                    {
+                        extraChar = countTimesSeen > 9 ? '9' : countTimesSeen.ToString()[0];
+                    }
 
-          depth++;
+                    break;
+            }
+
+            float multiplier = 1; // currently alternate perspective
+
+            float pctOfVisits = node.IsRoot ? 100.0f : (100.0f * node.N / node.Parent.N);
+
+            MCTSNode bestMove = default;
+            // TODO: someday show this too      MCTSNode nextBestMove = null;
+            if (!node.IsRoot)
+            {
+                MCTSNode[] parentsChildrenSortedQ = node.ChildrenSorted(innerNode => -multiplier * (float)innerNode.Q);
+                if (parentsChildrenSortedQ.Length > 0)
+                {
+                    bestMove = parentsChildrenSortedQ[0];
+                }
+                //        if (parentsChildrenSortedQ.Length > 1) nextBestMove = parentsChildrenSortedQ[1];
+            }
+
+            // Depth, move
+            writer.Write($"{depth,3}. ");
+            writer.Write(extraChar);
+            writer.Write($" {node.NumPolicyMoves,3} ");
+
+            writer.Write($"{node.Index,13:N0}");
+
+            string san = node.IsRoot ? "" : MGMoveConverter.ToMove(node.Annotation.PriorMoveMG).ToSAN(in node.Parent.Annotation.Pos);
+            //      string sanNextBest = node.IsRoot ? "" : MGMoveConverter.ToMove(nextBestMove.Annotation.PriorMoveMG).ToSAN(in node.Parent.Annotation.Pos);
+            if (node.Annotation.Pos.MiscInfo.SideToMove == SideType.White)
+            {
+                writer.Write($"      ");
+                writer.Write($"{san,6}");
+
+            }
+            else
+            {
+                writer.Write($"{san,6}");
+                writer.Write($"      ");
+            }
+
+            //      float diffBestNextBestQ = 0;
+            //      if (nextBestMove != null) diffBestNextBestQ = (float)(bestMove.Q - nextBestMove.Q);
+            //      writer.Write($"{  (nextBestMove?.Annotation == null ? "" : nextBestMove.Annotation.PriorMoveMG.ToString()),8}");
+            //      writer.Write($"{diffBestNextBestQ,8:F2}");
+
+
+            writer.Write($"{node.N,13:N0} ");
+            writer.Write($" {pctOfVisits,5:F0}%");
+            writer.Write($"   {100.0 * node.P,6:F2}%  ");
+            DumpWithColor(multiplier * node.V, $" {multiplier * node.V,6:F3}  ", -0.2f, 0.2f, writer);
+            //      DumpWithColor(multiplier * node.VSecondary, $" {multiplier * node.VSecondary,6:F3} ", -0.2f, 0.2f);
+            double q = multiplier * node.Q;
+            DumpWithColor((float)q, $" {q,6:F3} ", -0.2f, 0.2f, writer);
+
+            //      float qStdDev = MathF.Sqrt(node.Ref.VVariance);
+            //      if (float.IsNaN(qStdDev))
+            //        writer.WriteLine("found negative var");
+            //      writer.Write($" +/-{qStdDev,5:F2}  ");
+
+            bool invert = multiplier == -1;
+            writer.Write($" {(invert ? node.LossP : node.WinP),5:F2}/{node.DrawP,5:F2}/{(invert ? node.WinP : node.LossP),5:F2}  ");
+
+            writer.Write($" {(invert ? node.LAvg : node.WAvg),5:F2}/{node.DAvg,5:F2}/{(invert ? node.WAvg : node.LAvg),5:F2}  ");
+
+            //      writer.Write($"   {node.Ref.QUpdatesWtdAvg,5:F2}  ");
+            //      writer.Write($" +/-:{MathF.Sqrt(node.Ref.QUpdatesWtdVariance),5:F2}  ");
+            //      writer.Write($" {node.Ref.TrendBonusToP,5:F2}  ");
+
+            writer.Write($" {node.MPosition,3:F0} ");
+            writer.Write($" {node.MAvg,3:F0}  ");
+
+            if (fullDetail)
+            {
+                int numPieces = node.Annotation.Pos.PieceCount;
+
+                //        writer.Write($" {PosStr(node.Annotation.Pos)} ");
+                writer.Write($" {node.Annotation.Pos.FEN}");
+            }
+
+
+            writer.WriteLine();
         }
-      }
-    }
 
-  }
+        private static void WriteHeaders(bool fullDetail, TextWriter writer)
+        {
+            // Write headers
+            writer.Write(" Dep  T #M    FirstVisit   MvWh  MvBl           N  Visits    Policy     V         Q     WPos  DPos  LPos   WTree DTree LTree  MPos MTree");
+            if (fullDetail)
+            {
+                writer.WriteLine("  FEN");
+            }
+            else
+            {
+                writer.WriteLine();
+            }
+
+            if (fullDetail)
+            {
+                writer.WriteLine("----  - --  ------------  -----  ---- -----------  ------  --------  -------    -----   ----  ----  ----   -----  ---- -----  ---- -----");
+            }
+            else
+            {
+                writer.WriteLine();
+            }
+        }
+
+
+        static string ToStr(char pieceChar, int count, int maxCount)
+        {
+            string ret = "";
+
+            if (count > maxCount)
+            {
+                // Rare case of more than expected number of pieces (due to promotion)
+                ret += pieceChar + count.ToString();
+                for (int i = 0; i < maxCount - 2; i++)
+                {
+                    ret += " ";
+                }
+            }
+            else
+            {
+                for (int i = 0; i < maxCount; i++)
+                {
+                    if (count > i)
+                    {
+                        ret += pieceChar;
+                    }
+                    else
+                    {
+                        ret += " ";
+                    }
+                }
+            }
+            return ret;
+        }
+
+
+        /// <summary>
+        /// Returns a compact string describing the number of each type of piece on
+        /// on the board in the position. Example: "K R BBN PPPPPPP   k r bbn ppppppp"
+        /// </summary>
+        /// <param name="pos"></param>
+        /// <returns></returns>
+        static string PosStr(Position pos)
+        {
+            string str = "K";
+
+            str += ToStr('Q', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Queen)), 1);
+            str += ToStr('R', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Rook)), 2);
+            str += ToStr('B', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Bishop)), 2);
+            str += ToStr('N', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Knight)), 2);
+            str += ToStr('P', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Pawn)), 8);
+
+            str += "  k";
+            str += ToStr('q', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Queen)), 1);
+            str += ToStr('r', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Rook)), 2);
+            str += ToStr('b', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Bishop)), 2);
+            str += ToStr('n', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Knight)), 2);
+            str += ToStr('p', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Pawn)), 8);
+
+            return str;
+        }
+
+
+        public static void DumpAllNodes(MCTSIterator context, ref MCTSNodeStruct node,
+                                        Base.DataType.Trees.TreeTraversalType type = Base.DataType.Trees.TreeTraversalType.BreadthFirst,
+                                        bool childDetail = false)
+        {
+            int index = 1;
+
+            // Visit all nodes and verify various conditions are true
+            node.Traverse(context.Tree.Store,
+                                (ref MCTSNodeStruct node) =>
+                                {
+                                    Console.WriteLine(index + " " + node);
+                                    if (childDetail)
+                                    {
+                                        int childIndex = 0;
+                                        foreach (MCTSNodeStructChild childInfo in node.Children)
+                                            Console.WriteLine($"  {childIndex++,3} {childInfo}");
+                                    }
+                                    index++;
+                                    return true;
+                                }, type);
+        }
+
+
+        static MCTSNode DescendMovesToNode(MCTSNode rootNode, List<MGMove> moves)
+        {
+            MCTSNode node = rootNode;
+
+            foreach (MGMove move in moves)
+            {
+                int? childIndex = node.StructRef.ChildIndexWithMove(move);
+                if (childIndex is null)
+                {
+                    throw new Exception($"Move  {move} not found at node {node}");
+                }
+                else
+                {
+                    (node, _, _) = node.ChildAtIndexInfo(childIndex.Value);
+                }
+            }
+            return node;
+        }
+
+
+        public static void DumpPV(MCTSNode node, bool fullDetail, TextWriter writer = null)
+        {
+            try
+            {
+                using (new SearchContextExecutionBlock(node.Context))
+                {
+                    writer = writer ?? Console.Out;
+
+                    writer.WriteLine();
+                    WriteHeaders(fullDetail, writer);
+
+                    List<Position> seenPositions = new List<Position>();
+
+                    int CountDuplicatePos(Position pos)
+                    {
+                        int count = 0;
+                        foreach (Position priorPos in seenPositions)
+                        {
+                            if (pos.EqualAsRepetition(in priorPos))
+                            {
+                                count++;
+                            }
+                        }
+
+                        return count;
+                    }
+
+                    int depth = 0;
+                    MCTSNode searchRootNode = node;
+                    while (true)
+                    {
+                        node.Tree.Annotate(node);
+                        seenPositions.Add(node.Annotation.Pos);
+                        int countSeen = CountDuplicatePos(node.Annotation.Pos);
+
+                        DumpNodeStr(searchRootNode, node, countSeen, fullDetail, writer);
+
+                        if (node.NumChildrenVisited == 0)
+                        {
+                            return;
+                        }
+
+                        node = node.BestMove(false);
+
+                        depth++;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Dump failed with message: {e.Message}");
+                writer.Write($"Dump failed with message: {e.Message}");
+                Console.WriteLine($"Stacktrace: {e.StackTrace}");
+                writer.Write($"Stacktrace: {e.StackTrace}");
+                Console.WriteLine($"Inner exception: {e.InnerException.Message}");
+                writer.Write($"Inner exception: {e.InnerException.Message}");
+                //throw;
+            }
+        }
+
+    }
 
 }

--- a/src/Ceres.MCTS/MCTSNodes/Analysis/MCTSNodePVDump.cs
+++ b/src/Ceres.MCTS/MCTSNodes/Analysis/MCTSNodePVDump.cs
@@ -28,335 +28,335 @@ using Ceres.MCTS.MTCSNodes.Struct;
 
 namespace Ceres.MCTS.MTCSNodes.Analysis
 {
-    /// <summary>
-    /// Static helper methods for dumping contents of tree to Console.
-    /// </summary>
-    public static class MCTSPosTreeNodeDumper
+  /// <summary>
+  /// Static helper methods for dumping contents of tree to Console.
+  /// </summary>
+  public static class MCTSPosTreeNodeDumper
+  {
+    static void DumpWithColor(float v, string s, float thresholdRed, float thresholdGreen, TextWriter writer)
     {
-        static void DumpWithColor(float v, string s, float thresholdRed, float thresholdGreen, TextWriter writer)
+      if (writer != Console.Out)
+      {
+        // No point in using color if not the Console
+        writer.Write(s);
+      }
+      else
+      {
+        ConsoleColor defaultColor = Console.ForegroundColor;
+
+        try
         {
-            if (writer != Console.Out)
-            {
-                // No point in using color if not the Console
-                writer.Write(s);
-            }
-            else
-            {
-                ConsoleColor defaultColor = Console.ForegroundColor;
+          if (v > thresholdGreen)
+          {
+            Console.ForegroundColor = ConsoleColor.Green;
+          }
+          else if (v < thresholdRed)
+          {
+            Console.ForegroundColor = ConsoleColor.Red;
+          }
 
-                try
-                {
-                    if (v > thresholdGreen)
-                    {
-                        Console.ForegroundColor = ConsoleColor.Green;
-                    }
-                    else if (v < thresholdRed)
-                    {
-                        Console.ForegroundColor = ConsoleColor.Red;
-                    }
-
-                    writer.Write(s);
-                }
-                finally
-                {
-                    Console.ForegroundColor = defaultColor;
-                }
-            }
+          writer.Write(s);
         }
-
-
-        static void DumpNodeStr(MCTSNode searchRootNode, MCTSNode node,
-                                int countTimesSeen, bool fullDetail, TextWriter writer = null)
+        finally
         {
-            int depth = node.Depth - searchRootNode.Depth;
-
-            writer = writer ?? Console.Out;
-
-            node.Tree.Annotate(node);
-
-            char extraChar = ' ';
-            switch (node.Terminal)
-            {
-                case GameResult.Checkmate:
-                    extraChar = 'C';
-                    break;
-                case GameResult.Draw:
-                    extraChar = 'D';
-                    break;
-                default:
-                    if (countTimesSeen > 1)
-                    {
-                        extraChar = countTimesSeen > 9 ? '9' : countTimesSeen.ToString()[0];
-                    }
-
-                    break;
-            }
-
-            float multiplier = 1; // currently alternate perspective
-
-            float pctOfVisits = node.IsRoot ? 100.0f : (100.0f * node.N / node.Parent.N);
-
-            MCTSNode bestMove = default;
-            // TODO: someday show this too      MCTSNode nextBestMove = null;
-            if (!node.IsRoot)
-            {
-                MCTSNode[] parentsChildrenSortedQ = node.ChildrenSorted(innerNode => -multiplier * (float)innerNode.Q);
-                if (parentsChildrenSortedQ.Length > 0)
-                {
-                    bestMove = parentsChildrenSortedQ[0];
-                }
-                //        if (parentsChildrenSortedQ.Length > 1) nextBestMove = parentsChildrenSortedQ[1];
-            }
-
-            // Depth, move
-            writer.Write($"{depth,3}. ");
-            writer.Write(extraChar);
-            writer.Write($" {node.NumPolicyMoves,3} ");
-
-            writer.Write($"{node.Index,13:N0}");
-
-            string san = node.IsRoot ? "" : MGMoveConverter.ToMove(node.Annotation.PriorMoveMG).ToSAN(in node.Parent.Annotation.Pos);
-            //      string sanNextBest = node.IsRoot ? "" : MGMoveConverter.ToMove(nextBestMove.Annotation.PriorMoveMG).ToSAN(in node.Parent.Annotation.Pos);
-            if (node.Annotation.Pos.MiscInfo.SideToMove == SideType.White)
-            {
-                writer.Write($"      ");
-                writer.Write($"{san,6}");
-
-            }
-            else
-            {
-                writer.Write($"{san,6}");
-                writer.Write($"      ");
-            }
-
-            //      float diffBestNextBestQ = 0;
-            //      if (nextBestMove != null) diffBestNextBestQ = (float)(bestMove.Q - nextBestMove.Q);
-            //      writer.Write($"{  (nextBestMove?.Annotation == null ? "" : nextBestMove.Annotation.PriorMoveMG.ToString()),8}");
-            //      writer.Write($"{diffBestNextBestQ,8:F2}");
-
-
-            writer.Write($"{node.N,13:N0} ");
-            writer.Write($" {pctOfVisits,5:F0}%");
-            writer.Write($"   {100.0 * node.P,6:F2}%  ");
-            DumpWithColor(multiplier * node.V, $" {multiplier * node.V,6:F3}  ", -0.2f, 0.2f, writer);
-            //      DumpWithColor(multiplier * node.VSecondary, $" {multiplier * node.VSecondary,6:F3} ", -0.2f, 0.2f);
-            double q = multiplier * node.Q;
-            DumpWithColor((float)q, $" {q,6:F3} ", -0.2f, 0.2f, writer);
-
-            //      float qStdDev = MathF.Sqrt(node.Ref.VVariance);
-            //      if (float.IsNaN(qStdDev))
-            //        writer.WriteLine("found negative var");
-            //      writer.Write($" +/-{qStdDev,5:F2}  ");
-
-            bool invert = multiplier == -1;
-            writer.Write($" {(invert ? node.LossP : node.WinP),5:F2}/{node.DrawP,5:F2}/{(invert ? node.WinP : node.LossP),5:F2}  ");
-
-            writer.Write($" {(invert ? node.LAvg : node.WAvg),5:F2}/{node.DAvg,5:F2}/{(invert ? node.WAvg : node.LAvg),5:F2}  ");
-
-            //      writer.Write($"   {node.Ref.QUpdatesWtdAvg,5:F2}  ");
-            //      writer.Write($" +/-:{MathF.Sqrt(node.Ref.QUpdatesWtdVariance),5:F2}  ");
-            //      writer.Write($" {node.Ref.TrendBonusToP,5:F2}  ");
-
-            writer.Write($" {node.MPosition,3:F0} ");
-            writer.Write($" {node.MAvg,3:F0}  ");
-
-            if (fullDetail)
-            {
-                int numPieces = node.Annotation.Pos.PieceCount;
-
-                //        writer.Write($" {PosStr(node.Annotation.Pos)} ");
-                writer.Write($" {node.Annotation.Pos.FEN}");
-            }
-
-
-            writer.WriteLine();
+          Console.ForegroundColor = defaultColor;
         }
-
-        private static void WriteHeaders(bool fullDetail, TextWriter writer)
-        {
-            // Write headers
-            writer.Write(" Dep  T #M    FirstVisit   MvWh  MvBl           N  Visits    Policy     V         Q     WPos  DPos  LPos   WTree DTree LTree  MPos MTree");
-            if (fullDetail)
-            {
-                writer.WriteLine("  FEN");
-            }
-            else
-            {
-                writer.WriteLine();
-            }
-
-            if (fullDetail)
-            {
-                writer.WriteLine("----  - --  ------------  -----  ---- -----------  ------  --------  -------    -----   ----  ----  ----   -----  ---- -----  ---- -----");
-            }
-            else
-            {
-                writer.WriteLine();
-            }
-        }
-
-
-        static string ToStr(char pieceChar, int count, int maxCount)
-        {
-            string ret = "";
-
-            if (count > maxCount)
-            {
-                // Rare case of more than expected number of pieces (due to promotion)
-                ret += pieceChar + count.ToString();
-                for (int i = 0; i < maxCount - 2; i++)
-                {
-                    ret += " ";
-                }
-            }
-            else
-            {
-                for (int i = 0; i < maxCount; i++)
-                {
-                    if (count > i)
-                    {
-                        ret += pieceChar;
-                    }
-                    else
-                    {
-                        ret += " ";
-                    }
-                }
-            }
-            return ret;
-        }
-
-
-        /// <summary>
-        /// Returns a compact string describing the number of each type of piece on
-        /// on the board in the position. Example: "K R BBN PPPPPPP   k r bbn ppppppp"
-        /// </summary>
-        /// <param name="pos"></param>
-        /// <returns></returns>
-        static string PosStr(Position pos)
-        {
-            string str = "K";
-
-            str += ToStr('Q', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Queen)), 1);
-            str += ToStr('R', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Rook)), 2);
-            str += ToStr('B', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Bishop)), 2);
-            str += ToStr('N', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Knight)), 2);
-            str += ToStr('P', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Pawn)), 8);
-
-            str += "  k";
-            str += ToStr('q', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Queen)), 1);
-            str += ToStr('r', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Rook)), 2);
-            str += ToStr('b', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Bishop)), 2);
-            str += ToStr('n', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Knight)), 2);
-            str += ToStr('p', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Pawn)), 8);
-
-            return str;
-        }
-
-
-        public static void DumpAllNodes(MCTSIterator context, ref MCTSNodeStruct node,
-                                        Base.DataType.Trees.TreeTraversalType type = Base.DataType.Trees.TreeTraversalType.BreadthFirst,
-                                        bool childDetail = false)
-        {
-            int index = 1;
-
-            // Visit all nodes and verify various conditions are true
-            node.Traverse(context.Tree.Store,
-                                (ref MCTSNodeStruct node) =>
-                                {
-                                    Console.WriteLine(index + " " + node);
-                                    if (childDetail)
-                                    {
-                                        int childIndex = 0;
-                                        foreach (MCTSNodeStructChild childInfo in node.Children)
-                                            Console.WriteLine($"  {childIndex++,3} {childInfo}");
-                                    }
-                                    index++;
-                                    return true;
-                                }, type);
-        }
-
-
-        static MCTSNode DescendMovesToNode(MCTSNode rootNode, List<MGMove> moves)
-        {
-            MCTSNode node = rootNode;
-
-            foreach (MGMove move in moves)
-            {
-                int? childIndex = node.StructRef.ChildIndexWithMove(move);
-                if (childIndex is null)
-                {
-                    throw new Exception($"Move  {move} not found at node {node}");
-                }
-                else
-                {
-                    (node, _, _) = node.ChildAtIndexInfo(childIndex.Value);
-                }
-            }
-            return node;
-        }
-
-
-        public static void DumpPV(MCTSNode node, bool fullDetail, TextWriter writer = null)
-        {
-            try
-            {
-                using (new SearchContextExecutionBlock(node.Context))
-                {
-                    writer = writer ?? Console.Out;
-
-                    writer.WriteLine();
-                    WriteHeaders(fullDetail, writer);
-
-                    List<Position> seenPositions = new List<Position>();
-
-                    int CountDuplicatePos(Position pos)
-                    {
-                        int count = 0;
-                        foreach (Position priorPos in seenPositions)
-                        {
-                            if (pos.EqualAsRepetition(in priorPos))
-                            {
-                                count++;
-                            }
-                        }
-
-                        return count;
-                    }
-
-                    int depth = 0;
-                    MCTSNode searchRootNode = node;
-                    while (true)
-                    {
-                        node.Tree.Annotate(node);
-                        seenPositions.Add(node.Annotation.Pos);
-                        int countSeen = CountDuplicatePos(node.Annotation.Pos);
-
-                        DumpNodeStr(searchRootNode, node, countSeen, fullDetail, writer);
-
-                        if (node.NumChildrenVisited == 0)
-                        {
-                            return;
-                        }
-
-                        node = node.BestMove(false);
-
-                        depth++;
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"Dump failed with message: {e.Message}");
-                writer.Write($"Dump failed with message: {e.Message}");
-                Console.WriteLine($"Stacktrace: {e.StackTrace}");
-                writer.Write($"Stacktrace: {e.StackTrace}");
-                Console.WriteLine($"Inner exception: {e.InnerException.Message}");
-                writer.Write($"Inner exception: {e.InnerException.Message}");
-                //throw;
-            }
-        }
-
+      }
     }
+
+
+    static void DumpNodeStr(MCTSNode searchRootNode, MCTSNode node,
+                            int countTimesSeen, bool fullDetail, TextWriter writer = null)
+    {
+      int depth = node.Depth - searchRootNode.Depth;
+
+      writer = writer ?? Console.Out;
+
+      node.Tree.Annotate(node);
+
+      char extraChar = ' ';
+      switch (node.Terminal)
+      {
+        case GameResult.Checkmate:
+          extraChar = 'C';
+          break;
+        case GameResult.Draw:
+          extraChar = 'D';
+          break;
+        default:
+          if (countTimesSeen > 1)
+          {
+            extraChar = countTimesSeen > 9 ? '9' : countTimesSeen.ToString()[0];
+          }
+
+          break;
+      }
+
+      float multiplier = 1; // currently alternate perspective
+
+      float pctOfVisits = node.IsRoot ? 100.0f : (100.0f * node.N / node.Parent.N);
+
+      MCTSNode bestMove = default;
+      // TODO: someday show this too      MCTSNode nextBestMove = null;
+      if (!node.IsRoot)
+      {
+        MCTSNode[] parentsChildrenSortedQ = node.ChildrenSorted(innerNode => -multiplier * (float)innerNode.Q);
+        if (parentsChildrenSortedQ.Length > 0)
+        {
+          bestMove = parentsChildrenSortedQ[0];
+        }
+        //        if (parentsChildrenSortedQ.Length > 1) nextBestMove = parentsChildrenSortedQ[1];
+      }
+
+      // Depth, move
+      writer.Write($"{depth,3}. ");
+      writer.Write(extraChar);
+      writer.Write($" {node.NumPolicyMoves,3} ");
+
+      writer.Write($"{node.Index,13:N0}");
+
+      string san = node.IsRoot ? "" : MGMoveConverter.ToMove(node.Annotation.PriorMoveMG).ToSAN(in node.Parent.Annotation.Pos);
+      //      string sanNextBest = node.IsRoot ? "" : MGMoveConverter.ToMove(nextBestMove.Annotation.PriorMoveMG).ToSAN(in node.Parent.Annotation.Pos);
+      if (node.Annotation.Pos.MiscInfo.SideToMove == SideType.White)
+      {
+        writer.Write($"      ");
+        writer.Write($"{san,6}");
+
+      }
+      else
+      {
+        writer.Write($"{san,6}");
+        writer.Write($"      ");
+      }
+
+      //      float diffBestNextBestQ = 0;
+      //      if (nextBestMove != null) diffBestNextBestQ = (float)(bestMove.Q - nextBestMove.Q);
+      //      writer.Write($"{  (nextBestMove?.Annotation == null ? "" : nextBestMove.Annotation.PriorMoveMG.ToString()),8}");
+      //      writer.Write($"{diffBestNextBestQ,8:F2}");
+
+
+      writer.Write($"{node.N,13:N0} ");
+      writer.Write($" {pctOfVisits,5:F0}%");
+      writer.Write($"   {100.0 * node.P,6:F2}%  ");
+      DumpWithColor(multiplier * node.V, $" {multiplier * node.V,6:F3}  ", -0.2f, 0.2f, writer);
+      //      DumpWithColor(multiplier * node.VSecondary, $" {multiplier * node.VSecondary,6:F3} ", -0.2f, 0.2f);
+      double q = multiplier * node.Q;
+      DumpWithColor((float)q, $" {q,6:F3} ", -0.2f, 0.2f, writer);
+
+      //      float qStdDev = MathF.Sqrt(node.Ref.VVariance);
+      //      if (float.IsNaN(qStdDev))
+      //        writer.WriteLine("found negative var");
+      //      writer.Write($" +/-{qStdDev,5:F2}  ");
+
+      bool invert = multiplier == -1;
+      writer.Write($" {(invert ? node.LossP : node.WinP),5:F2}/{node.DrawP,5:F2}/{(invert ? node.WinP : node.LossP),5:F2}  ");
+
+      writer.Write($" {(invert ? node.LAvg : node.WAvg),5:F2}/{node.DAvg,5:F2}/{(invert ? node.WAvg : node.LAvg),5:F2}  ");
+
+      //      writer.Write($"   {node.Ref.QUpdatesWtdAvg,5:F2}  ");
+      //      writer.Write($" +/-:{MathF.Sqrt(node.Ref.QUpdatesWtdVariance),5:F2}  ");
+      //      writer.Write($" {node.Ref.TrendBonusToP,5:F2}  ");
+
+      writer.Write($" {node.MPosition,3:F0} ");
+      writer.Write($" {node.MAvg,3:F0}  ");
+
+      if (fullDetail)
+      {
+        int numPieces = node.Annotation.Pos.PieceCount;
+
+        //        writer.Write($" {PosStr(node.Annotation.Pos)} ");
+        writer.Write($" {node.Annotation.Pos.FEN}");
+      }
+
+
+      writer.WriteLine();
+    }
+
+    private static void WriteHeaders(bool fullDetail, TextWriter writer)
+    {
+      // Write headers
+      writer.Write(" Dep  T #M    FirstVisit   MvWh  MvBl           N  Visits    Policy     V         Q     WPos  DPos  LPos   WTree DTree LTree  MPos MTree");
+      if (fullDetail)
+      {
+        writer.WriteLine("  FEN");
+      }
+      else
+      {
+        writer.WriteLine();
+      }
+
+      if (fullDetail)
+      {
+        writer.WriteLine("----  - --  ------------  -----  ---- -----------  ------  --------  -------    -----   ----  ----  ----   -----  ---- -----  ---- -----");
+      }
+      else
+      {
+        writer.WriteLine();
+      }
+    }
+
+
+    static string ToStr(char pieceChar, int count, int maxCount)
+    {
+      string ret = "";
+
+      if (count > maxCount)
+      {
+        // Rare case of more than expected number of pieces (due to promotion)
+        ret += pieceChar + count.ToString();
+        for (int i = 0; i < maxCount - 2; i++)
+        {
+          ret += " ";
+        }
+      }
+      else
+      {
+        for (int i = 0; i < maxCount; i++)
+        {
+          if (count > i)
+          {
+            ret += pieceChar;
+          }
+          else
+          {
+            ret += " ";
+          }
+        }
+      }
+      return ret;
+    }
+
+
+    /// <summary>
+    /// Returns a compact string describing the number of each type of piece on
+    /// on the board in the position. Example: "K R BBN PPPPPPP   k r bbn ppppppp"
+    /// </summary>
+    /// <param name="pos"></param>
+    /// <returns></returns>
+    static string PosStr(Position pos)
+    {
+      string str = "K";
+
+      str += ToStr('Q', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Queen)), 1);
+      str += ToStr('R', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Rook)), 2);
+      str += ToStr('B', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Bishop)), 2);
+      str += ToStr('N', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Knight)), 2);
+      str += ToStr('P', pos.PieceCountOfType(new Piece(SideType.White, PieceType.Pawn)), 8);
+
+      str += "  k";
+      str += ToStr('q', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Queen)), 1);
+      str += ToStr('r', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Rook)), 2);
+      str += ToStr('b', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Bishop)), 2);
+      str += ToStr('n', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Knight)), 2);
+      str += ToStr('p', pos.PieceCountOfType(new Piece(SideType.Black, PieceType.Pawn)), 8);
+
+      return str;
+    }
+
+
+    public static void DumpAllNodes(MCTSIterator context, ref MCTSNodeStruct node,
+                                    Base.DataType.Trees.TreeTraversalType type = Base.DataType.Trees.TreeTraversalType.BreadthFirst,
+                                    bool childDetail = false)
+    {
+      int index = 1;
+
+      // Visit all nodes and verify various conditions are true
+      node.Traverse(context.Tree.Store,
+                          (ref MCTSNodeStruct node) =>
+                          {
+                            Console.WriteLine(index + " " + node);
+                            if (childDetail)
+                            {
+                              int childIndex = 0;
+                              foreach (MCTSNodeStructChild childInfo in node.Children)
+                                Console.WriteLine($"  {childIndex++,3} {childInfo}");
+                            }
+                            index++;
+                            return true;
+                          }, type);
+    }
+
+
+    static MCTSNode DescendMovesToNode(MCTSNode rootNode, List<MGMove> moves)
+    {
+      MCTSNode node = rootNode;
+
+      foreach (MGMove move in moves)
+      {
+        int? childIndex = node.StructRef.ChildIndexWithMove(move);
+        if (childIndex is null)
+        {
+          throw new Exception($"Move  {move} not found at node {node}");
+        }
+        else
+        {
+          (node, _, _) = node.ChildAtIndexInfo(childIndex.Value);
+        }
+      }
+      return node;
+    }
+
+
+    public static void DumpPV(MCTSNode node, bool fullDetail, TextWriter writer = null)
+    {
+      try
+      {
+        using (new SearchContextExecutionBlock(node.Context))
+        {
+          writer = writer ?? Console.Out;
+
+          writer.WriteLine();
+          WriteHeaders(fullDetail, writer);
+
+          List<Position> seenPositions = new List<Position>();
+
+          int CountDuplicatePos(Position pos)
+          {
+            int count = 0;
+            foreach (Position priorPos in seenPositions)
+            {
+              if (pos.EqualAsRepetition(in priorPos))
+              {
+                count++;
+              }
+            }
+
+            return count;
+          }
+
+          int depth = 0;
+          MCTSNode searchRootNode = node;
+          while (true)
+          {
+            node.Tree.Annotate(node);
+            seenPositions.Add(node.Annotation.Pos);
+            int countSeen = CountDuplicatePos(node.Annotation.Pos);
+
+            DumpNodeStr(searchRootNode, node, countSeen, fullDetail, writer);
+
+            if (node.NumChildrenVisited == 0)
+            {
+              return;
+            }
+
+            node = node.BestMove(false);
+
+            depth++;
+          }
+        }
+      }
+      catch (Exception e)
+      {
+        Console.WriteLine($"Dump failed with message: {e.Message}");
+        writer.Write($"Dump failed with message: {e.Message}");
+        Console.WriteLine($"Stacktrace: {e.StackTrace}");
+        writer.Write($"Stacktrace: {e.StackTrace}");
+        //Console.WriteLine($"Inner exception: {e.InnerException.Message}");
+        //writer.Write($"Inner exception: {e.InnerException.Message}");
+        //throw;
+      }
+    }
+
+  }
 
 }

--- a/src/Ceres/APIExamples/TournamentTest.cs
+++ b/src/Ceres/APIExamples/TournamentTest.cs
@@ -356,8 +356,7 @@ namespace Ceres.APIExamples
 #endif
       }
 
-      var engines = new List<EnginePlayerDef>() { playerCeres1, playerCeres2 };
-      TournamentDef def = new TournamentDef("TOURN", engines);
+      TournamentDef def = new TournamentDef("TOURN", playerCeres1, playerCeres2);
       //        TournamentDef def = new TournamentDef("TOURN", playerCeres1UCI, playerCeres93);
       //TournamentDef def = new TournamentDef("TOURN", playerCeres93, playerCeres1);
 
@@ -455,8 +454,7 @@ namespace Ceres.APIExamples
       EnginePlayerDef playerSF = new EnginePlayerDef(sf14Engine, TIME_CONTROL);
 
       // Create a tournament definition
-      var engines = new List<EnginePlayerDef>() { playerCeres, playerSF };
-      TournamentDef tournDef = new TournamentDef("Ceres_vs_Stockfish", engines);
+      TournamentDef tournDef = new TournamentDef("Ceres_vs_Stockfish", playerCeres, playerSF);
       tournDef.NumGamePairs = NUM_GAME_PAIRS;
       tournDef.OpeningsFileName = "WCEC.pgn";
       tournDef.ShowGameMoves = false;
@@ -509,9 +507,7 @@ namespace Ceres.APIExamples
       EnginePlayerDef playerSf14Slow = new EnginePlayerDef(sf14Engine, TIME_CONTROL * 0.5f, "SF14*0.5");
 
       // Create a tournament definition
-      var engines = new List<EnginePlayerDef>() { playerCeres1, playerSf14, playerLeela };
-
-      TournamentDef tournDef = new TournamentDef("Round Robin Test", engines);
+      TournamentDef tournDef = new TournamentDef("Round Robin Test", playerCeres1, playerSf14, playerLeela);
       tournDef.ReferenceEngineId = playerCeres1.ID;
       tournDef.NumGamePairs = NUM_GAME_PAIRS;
       tournDef.OpeningsFileName = "WCEC_decisive.pgn";
@@ -575,9 +571,7 @@ namespace Ceres.APIExamples
 
 
       // Create a tournament definition
-      var engines = new List<EnginePlayerDef>() { playerCeres, playerLeela, playerLeela2 };
-
-      TournamentDef tournDef = new TournamentDef("Tournament A", engines);
+      TournamentDef tournDef = new TournamentDef("Tournament A", playerCeres, playerLeela, playerLeela2);
       // Create a tournament definition
       //TournamentDef tournDef = new TournamentDef("Ceres_vs_Leela", playerCeres, playerLeela);
       tournDef.NumGamePairs = 1;

--- a/src/Ceres/APIExamples/TournamentTest.cs
+++ b/src/Ceres/APIExamples/TournamentTest.cs
@@ -58,8 +58,8 @@ namespace Ceres.APIExamples
     {
       foreach (Process p in Process.GetProcesses())
       {
-         if (p.ProcessName.ToUpper().StartsWith("CERES") && p.Id != Process.GetCurrentProcess().Id)
-           p.Kill();
+        if (p.ProcessName.ToUpper().StartsWith("CERES") && p.Id != Process.GetCurrentProcess().Id)
+          p.Kill();
       }
     }
 
@@ -136,8 +136,8 @@ namespace Ceres.APIExamples
       NNEvaluatorDef evalDefSecondary2 = null;
 
 
-//      public NNEvaluatorDynamic(NNEvaluator[] evaluators,
-//                        Func<IEncodedPositionBatchFlat, int> dynamicEvaluatorIndexPredicate = null)
+      //      public NNEvaluatorDynamic(NNEvaluator[] evaluators,
+      //                        Func<IEncodedPositionBatchFlat, int> dynamicEvaluatorIndexPredicate = null)
 
       //evalDef1 = NNEvaluatorDefFactory.FromSpecification("ONNX:tfmodelc", "GPU:0");
 
@@ -154,9 +154,9 @@ namespace Ceres.APIExamples
       //      limit1 = SearchLimit.SecondsForAllMovess(90, 1f);
       limit1 = SearchLimit.SecondsForAllMoves(100, 0.5f) * 0.2f;
       //limit1 = SearchLimit.SecondsPerMove(1);
-//limit1 = SearchLimit.SecondsForAllMoves(50, 0.1f) * 1.1f;
-//ok      limit1 = SearchLimit.NodesPerMove(350_000); try test3.pgn against T75 opponent Ceres93 (in first position, 50% of time misses win near move 12
-      
+      //limit1 = SearchLimit.SecondsForAllMoves(50, 0.1f) * 1.1f;
+      //ok      limit1 = SearchLimit.NodesPerMove(350_000); try test3.pgn against T75 opponent Ceres93 (in first position, 50% of time misses win near move 12
+
       SearchLimit limit2 = limit1;
 
       // Don't output log if very small games
@@ -167,11 +167,11 @@ namespace Ceres.APIExamples
       GameEngineDefCeres engineDefCeres2 = new GameEngineDefCeres("Ceres2", evalDef2, evalDefSecondary2, new ParamsSearch(), new ParamsSelect(),
                                                                   null, outputLog ? "Ceres2.log.txt" : null);
 
-//      engineDefCeres1.SearchParams.EnableUseSiblingEvaluations = true;
-     engineDefCeres1.SearchParams.TestFlag = true;
+      //      engineDefCeres1.SearchParams.EnableUseSiblingEvaluations = true;
+      engineDefCeres1.SearchParams.TestFlag = true;
 
-//      engineDefCeres1.SelectParams.CPUCT       *= 1.075f;
-//      engineDefCeres1.SelectParams.CPUCTAtRoot *= 1.075f;
+      //      engineDefCeres1.SelectParams.CPUCT       *= 1.075f;
+      //      engineDefCeres1.SelectParams.CPUCTAtRoot *= 1.075f;
 
       //      engineDefCeres1.SearchParams.EnableUseSiblingEvaluations = true;
 
@@ -256,7 +256,7 @@ namespace Ceres.APIExamples
       //engineDefCeres1.SelectParams.PolicySoftmax = 1.5f;
 
       //engineDefCeres1.SelectParams.EnableExplorationGuard = true;
-      
+
       //      engineDefCeres1.SearchParams.Execution.FlowDualSelectors = false;
       // TODO: support this in GameEngineDefCeresUCI
       bool forceDisableSmartPruning = limit1.IsNodesLimit;
@@ -313,7 +313,7 @@ namespace Ceres.APIExamples
                                                                          : @$"\\synology\dev\chess\data\epd\{BASE_NAME}.epd",
                                                 playerCeres1, playerCeres2, null);
 
-//        suiteDef.MaxNumPositions = 200;
+        //        suiteDef.MaxNumPositions = 200;
         suiteDef.EPDLichessPuzzleFormat = suiteDef.EPDFileName.ToUpper().Contains("LICHESS");
 
         //suiteDef.EPDFilter = s => !s.Contains(".exe"); // For NICE suite, these represent positions with multiple choices
@@ -356,7 +356,8 @@ namespace Ceres.APIExamples
 #endif
       }
 
-      TournamentDef def = new TournamentDef("TOURN", playerCeres1, playerCeres2);
+      var engines = new List<EnginePlayerDef>() { playerCeres1, playerCeres2 };
+      TournamentDef def = new TournamentDef("TOURN", engines);
       //        TournamentDef def = new TournamentDef("TOURN", playerCeres1UCI, playerCeres93);
       //TournamentDef def = new TournamentDef("TOURN", playerCeres93, playerCeres1);
 
@@ -364,12 +365,12 @@ namespace Ceres.APIExamples
       def.NumGamePairs = 203;// 500;// 203;//203;// 102; 203
       def.ShowGameMoves = false;
 
-//      string baseName = "tcec1819";
-string      baseName = "4mvs_+90_+99";
-//      baseName = "book-ply8-unifen-Q-0.25-0.40";
-//      baseName = "test3";
-//      baseName = "tcec_big";
-//      baseName = "endgame-16-piece-book_Q-0.0-0.6_1";
+      //      string baseName = "tcec1819";
+      string baseName = "4mvs_+90_+99";
+      //      baseName = "book-ply8-unifen-Q-0.25-0.40";
+      //      baseName = "test3";
+      //      baseName = "tcec_big";
+      //      baseName = "endgame-16-piece-book_Q-0.0-0.6_1";
       def.OpeningsFileName = SoftwareManager.IsLinux ? @$"/mnt/syndev/chess/data/openings/{baseName}.pgn"
                                                      : @$"\\synology\dev\chess\data\openings\{baseName}.pgn";
 
@@ -423,177 +424,180 @@ string      baseName = "4mvs_+90_+99";
 
     public static void TestSF(int index, bool gitVersion)
     {
-            // Initialize settings by loading configuration file
-            //CeresUserSettingsManager.LoadFromFile(@"c:\dev\ceres\artifacts\release\net5.0\ceres.json");
+      // Initialize settings by loading configuration file
+      //CeresUserSettingsManager.LoadFromFile(@"c:\dev\ceres\artifacts\release\net5.0\ceres.json");
 
-            // Define constants for engine parameters
-            string SF14_EXE = Path.Combine(CeresUserSettingsManager.Settings.DirExternalEngines, "Stockfish14.exe");
-            const int SF_THREADS = 8;
-            const int SF_TB_SIZE_MB = 1024;
+      // Define constants for engine parameters
+      string SF14_EXE = Path.Combine(CeresUserSettingsManager.Settings.DirExternalEngines, "Stockfish14.1.exe");
+      const int SF_THREADS = 8;
+      const int SF_TB_SIZE_MB = 1024;
 
-            string CERES_NETWORK = CeresUserSettingsManager.Settings.DefaultNetworkSpecString; //"LC0:703810";
-            const string CERES_GPU = "GPU:0";
+      string CERES_NETWORK = CeresUserSettingsManager.Settings.DefaultNetworkSpecString; //"LC0:703810";
+      const string CERES_GPU = "GPU:0";
 
-            string TB_DIR = CeresUserSettingsManager.Settings.DirTablebases;
-            SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(10*60, 1f); //* 0.15f;            
-            const int NUM_GAME_PAIRS = 20;
-            const string logfile = "ceresLTC.log.txt"; //Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "ceres.log.txt");
+      string TB_DIR = CeresUserSettingsManager.Settings.DirTablebases;
+      SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(10, 0.5f); //* 0.15f;            
+      const int NUM_GAME_PAIRS = 50;
+      const string logfile = "ceres.log.txt"; //Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "ceres.log.txt");
 
-            // Define Stockfish engine (via UCI) 
-            GameEngineDefUCI sf14Engine = new GameEngineDefUCI("SF14", new GameEngineUCISpec("SF14", SF14_EXE, SF_THREADS, SF_TB_SIZE_MB, TB_DIR));
+      // Define Stockfish engine (via UCI) 
+      GameEngineDefUCI sf14Engine = new GameEngineDefUCI("SF14", new GameEngineUCISpec("SF14", SF14_EXE, SF_THREADS, SF_TB_SIZE_MB, TB_DIR));
 
-            // Define Ceres engine (in process) with associated neural network and GPU and parameter customizations
-            NNEvaluatorDef ceresNNDef = NNEvaluatorDefFactory.FromSpecification(CERES_NETWORK, CERES_GPU);
-            GameEngineDefCeres engineDefCeres1 = new GameEngineDefCeres("Ceres1", ceresNNDef, null,
-                                                                        new ParamsSearch() { /* FutilityPruningStopSearchEnabled = false, */ },
-                                                                        new ParamsSelect(),
-                                                                        logFileName: logfile);
+      // Define Ceres engine (in process) with associated neural network and GPU and parameter customizations
+      NNEvaluatorDef ceresNNDef = NNEvaluatorDefFactory.FromSpecification(CERES_NETWORK, CERES_GPU);
+      GameEngineDefCeres engineDefCeres1 = new GameEngineDefCeres("Ceres1", ceresNNDef, null,
+                                                                  new ParamsSearch() { /* FutilityPruningStopSearchEnabled = false, */ },
+                                                                  new ParamsSelect(),
+                                                                  logFileName: logfile);
 
-            // Define players using these engines and specified time control
-            EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres1, TIME_CONTROL);
-            EnginePlayerDef playerSF = new EnginePlayerDef(sf14Engine, TIME_CONTROL);
+      // Define players using these engines and specified time control
+      EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres1, TIME_CONTROL);
+      EnginePlayerDef playerSF = new EnginePlayerDef(sf14Engine, TIME_CONTROL);
 
-            // Create a tournament definition
-            TournamentDef tournDef = new TournamentDef("Ceres_vs_Stockfish", playerCeres, playerSF);
-            tournDef.NumGamePairs = NUM_GAME_PAIRS;
-            tournDef.OpeningsFileName = "WCEC_decisive.pgn";
-            tournDef.ShowGameMoves = false;
+      // Create a tournament definition
+      var engines = new List<EnginePlayerDef>() { playerCeres, playerSF };
+      TournamentDef tournDef = new TournamentDef("Ceres_vs_Stockfish", engines);
+      tournDef.NumGamePairs = NUM_GAME_PAIRS;
+      tournDef.OpeningsFileName = "WCEC.pgn";
+      tournDef.ShowGameMoves = false;
 
-            // Run the tournament
-            TimingStats stats = new TimingStats();
-            TournamentResultStats results;
-            using (new TimingBlock(stats, TimingBlock.LoggingType.None))
-            {
-                results = new TournamentManager(tournDef).RunTournament();
-            }
-            Console.WriteLine();
-            Console.WriteLine($"Tournament completed in {stats.ElapsedTimeSecs,8:F2} seconds.");
-            Console.WriteLine(playerCeres + " " + results.GameOutcomesString);
-            Console.ReadLine();
-        }
-
-
-        public static void TestSFLeela(int index, bool gitVersion)
-        {
-            // Define constants for engine parameters  
-            string SF14_EXE = Path.Combine(CeresUserSettingsManager.Settings.DirExternalEngines, "Stockfish14.exe");
-            string leela_EXE = Path.Combine(CeresUserSettingsManager.Settings.DirExternalEngines, "lc0-v0.28.0-windows-gpu-nvidia-cuda", "LC0.exe");
-            const int SF_THREADS = 8;
-            const int SF_TB_SIZE_MB = 1024;
-            string TB_DIR = CeresUserSettingsManager.Settings.DirTablebases;            
-            string CERES_NETWORK = CeresUserSettingsManager.Settings.DefaultNetworkSpecString; //"LC0:703810";
-            const string CERES_GPU = "GPU:0";
-
-            SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(60, 0.5f) * 0.1f;            
-            const int NUM_GAME_PAIRS = 2;
-            const string logfile = "ceres.log.txt";
-
-            // Define Stockfish engine (via UCI) 
-            GameEngineDefUCI sf14Engine = new GameEngineDefUCI("SF14", new GameEngineUCISpec("SF14", SF14_EXE, SF_THREADS, SF_TB_SIZE_MB, TB_DIR));
-
-            // Define Ceres engine (in process) with associated neural network and GPU and parameter customizations
-            NNEvaluatorDef ceresNNDef = NNEvaluatorDefFactory.FromSpecification(CERES_NETWORK, CERES_GPU);
-            GameEngineDefCeres engineDefCeres1 = new GameEngineDefCeres("Ceres1", ceresNNDef, null, new ParamsSearch(), new ParamsSelect(), logFileName: logfile);
-            GameEngineDefCeres engineDefCeres2 = new GameEngineDefCeres("Ceres2", ceresNNDef, null, new ParamsSearch(), new ParamsSelect(), logFileName: "ceres2.log.txt");
-
-            // Define Leela engine (in process) with associated neural network and GPU and parameter customizations
-            GameEngineDefLC0 engineDefLC0 = new GameEngineDefLC0("LC0", ceresNNDef, forceDisableSmartPruning: false, null, null);
-
-            // Define players using these engines and specified time control
-            EnginePlayerDef playerCeres1 = new EnginePlayerDef(engineDefCeres1, TIME_CONTROL);
-            EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLC0, TIME_CONTROL);
-            EnginePlayerDef playerSf14 = new EnginePlayerDef(sf14Engine, TIME_CONTROL);
-            EnginePlayerDef playerCeres2 = new EnginePlayerDef(engineDefCeres2, TIME_CONTROL);
-            EnginePlayerDef playerSf14Slow = new EnginePlayerDef(sf14Engine, TIME_CONTROL * 0.5f,"SF14*0.5");
-
-            // Create a tournament definition
-            var engines = new List<EnginePlayerDef>() { playerCeres1, playerLeela, playerCeres2, playerSf14 };
-            
-            TournamentDef tournDef = new TournamentDef("Round Robin Test", engines);
-            tournDef.NumGamePairs = NUM_GAME_PAIRS;
-            tournDef.OpeningsFileName = "WCEC_decisive.pgn";
-            tournDef.ShowGameMoves = false;
-
-            // Run the tournament
-            TimingStats stats = new TimingStats();
-            TournamentResultStats results;
-            using (new TimingBlock(stats, TimingBlock.LoggingType.None))
-            {
-                results = new TournamentManager(tournDef).RunTournament();
-            }
-            Console.WriteLine();
-            Console.WriteLine($"Tournament completed in {stats.ElapsedTimeSecs,8:F2} seconds.");
-            //foreach (var engine in engines)
-            //{
-            //    Console.WriteLine();
-            //    Console.WriteLine(engine + " " + results.GameOutcomesString);
-            //}
-            
-            Console.ReadLine();
-        }
-
-        public static void TestLeela(int index, bool gitVersion)
-        {
-            // Initialize settings by loading configuration file
-            //CeresUserSettingsManager.LoadFromFile(@"c:\dev\ceres\artifacts\release\net5.0\ceres.json");
-
-            //example code:
-            // SearchLimit TIME_CONTROL = SearchLimit.NodesPerMove(10_000);
-            // for Ceres, set: new ParamsSearch() { FutilityPruningStopSearchEnabled = false, },            
-            // for LC0 player, set in constructor: forceDisableSmartPruning:true
-
-            // Define constants for engine parameters           
-
-            string leela_EXE = Path.Combine(CeresUserSettingsManager.Settings.DirExternalEngines, "lc0-v0.28.0-windows-gpu-nvidia-cuda", "LC0.exe");
-            string CERES_NETWORK = CeresUserSettingsManager.Settings.DefaultNetworkSpecString; //"LC0:703810";
-            const string CERES_GPU = "GPU:0";
-            string TB_DIR = CeresUserSettingsManager.Settings.DirTablebases;
-            SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(60, 0.5f); // * 0.5f;
-            const string logfileCeres = "ceres.log.txt";
+      // Run the tournament
+      TimingStats stats = new TimingStats();
+      TournamentResultStats results;
+      using (new TimingBlock(stats, TimingBlock.LoggingType.None))
+      {
+        results = new TournamentManager(tournDef).RunTournament();
+      }
+      Console.WriteLine();
+      Console.WriteLine($"Tournament completed in {stats.ElapsedTimeSecs,8:F2} seconds.");
+      Console.WriteLine(playerCeres + " " + results.GameOutcomesString);
+      Console.ReadLine();
+    }
 
 
-            // Define Ceres engine (in process) with associated neural network and GPU and parameter customizations
-            NNEvaluatorDef ceresNNDef = NNEvaluatorDefFactory.FromSpecification(CERES_NETWORK, CERES_GPU);
-            GameEngineDefCeres engineDefCeres = new GameEngineDefCeres("Ceres", ceresNNDef, null,
-                                                                        new ParamsSearch() { /* FutilityPruningStopSearchEnabled = false, */ },
-                                                                        new ParamsSelect(),
-                                                                        logFileName: logfileCeres);
+    public static void TestSFLeela(int index, bool gitVersion)
+    {
+      // Define constants for engine parameters  
+      string SF14_EXE = Path.Combine(CeresUserSettingsManager.Settings.DirExternalEngines, "Stockfish14.1.exe");
+      //string leela_EXE = Path.Combine(CeresUserSettingsManager.Settings.DirExternalEngines, "lc0-v0.28.0-windows-gpu-nvidia-cuda", "LC0.exe");
+      const int SF_THREADS = 8;
+      const int SF_TB_SIZE_MB = 1024;
+      string TB_DIR = CeresUserSettingsManager.Settings.DirTablebases;
+      string CERES_NETWORK = CeresUserSettingsManager.Settings.DefaultNetworkSpecString; //"LC0:703810";
+      const string CERES_GPU = "GPU:0";
 
-            // Define Leela engine (in process) with associated neural network and GPU and parameter customizations
-            GameEngineDefLC0 engineDefLC0 = new GameEngineDefLC0("LC0", ceresNNDef, forceDisableSmartPruning: false, null, null);
-            
-            //NNEvaluatorDef leelaNNDef = NNEvaluatorDefFactory.FromSpecification($"LC0:{CERES_NETWORK}", CERES_GPU);
-            //GameEngineDefUCI engineDefLeela1 = new GameEngineDefUCI("Leela", new GameEngineUCISpec("LC0",leela_EXE, syzygyPath: TB_DIR));           
+      SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(60, 0.5f) * 0.05f;
+      const int NUM_GAME_PAIRS = 1;
+      const string logfile = "CeresRR.log.txt";
 
-            // Define players using these engines and specified time control
-            EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres, TIME_CONTROL);
-            EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLC0, TIME_CONTROL);
+      // Define Stockfish engine (via UCI) 
+      GameEngineDefUCI sf14Engine = new GameEngineDefUCI("SF14.1", new GameEngineUCISpec("SF14.1", SF14_EXE, SF_THREADS, SF_TB_SIZE_MB, TB_DIR));
+
+      // Define Ceres engine (in process) with associated neural network and GPU and parameter customizations
+      NNEvaluatorDef ceresNNDef = NNEvaluatorDefFactory.FromSpecification(CERES_NETWORK, CERES_GPU);
+      GameEngineDefCeres engineDefCeres1 = new GameEngineDefCeres("Ceres1", ceresNNDef, null, new ParamsSearch(), new ParamsSelect(), logFileName: logfile);
+      GameEngineDefCeres engineDefCeres2 = new GameEngineDefCeres("Ceres2", ceresNNDef, null, new ParamsSearch(), new ParamsSelect(), logFileName: "ceres2.log.txt");
+
+      // Define Leela engine (in process) with associated neural network and GPU and parameter customizations
+      GameEngineDefLC0 engineDefLC0 = new GameEngineDefLC0("LC0", ceresNNDef, forceDisableSmartPruning: false, null, null);
+
+      // Define players using these engines and specified time control
+      EnginePlayerDef playerCeres1 = new EnginePlayerDef(engineDefCeres1, TIME_CONTROL);
+      EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLC0, TIME_CONTROL);
+      EnginePlayerDef playerSf14 = new EnginePlayerDef(sf14Engine, TIME_CONTROL);
+      EnginePlayerDef playerCeres2 = new EnginePlayerDef(engineDefCeres2, TIME_CONTROL);
+      EnginePlayerDef playerSf14Slow = new EnginePlayerDef(sf14Engine, TIME_CONTROL * 0.5f, "SF14*0.5");
+
+      // Create a tournament definition
+      var engines = new List<EnginePlayerDef>() { playerCeres1, playerSf14, playerLeela };
+
+      TournamentDef tournDef = new TournamentDef("Round Robin Test", engines);
+      tournDef.ReferenceEngineId = playerCeres1.ID;
+      tournDef.NumGamePairs = NUM_GAME_PAIRS;
+      tournDef.OpeningsFileName = "WCEC_decisive.pgn";
+      tournDef.ShowGameMoves = false;
+
+      // Run the tournament
+      TimingStats stats = new TimingStats();
+      TournamentResultStats results;
+      using (new TimingBlock(stats, TimingBlock.LoggingType.None))
+      {
+        results = new TournamentManager(tournDef).RunTournament();
+      }
+      Console.WriteLine();
+      Console.WriteLine($"Tournament completed in {stats.ElapsedTimeSecs,8:F2} seconds.");
+      Console.ReadLine();
+    }
+
+    public static void TestLeela(int index, bool gitVersion)
+    {
+      // Initialize settings by loading configuration file
+      //CeresUserSettingsManager.LoadFromFile(@"c:\dev\ceres\artifacts\release\net5.0\ceres.json");
+
+      //example code:
+      // SearchLimit TIME_CONTROL = SearchLimit.NodesPerMove(10_000);
+      // for Ceres, set: new ParamsSearch() { FutilityPruningStopSearchEnabled = false, },            
+      // for LC0 player, set in constructor: forceDisableSmartPruning:true
+
+      // Define constants for engine parameters           
+
+      string leela_EXE = Path.Combine(CeresUserSettingsManager.Settings.DirExternalEngines, "lc0-v0.28.0-windows-gpu-nvidia-cuda", "LC0.exe");
+      string CERES_NETWORK = CeresUserSettingsManager.Settings.DefaultNetworkSpecString; //"LC0:703810";
+      const string CERES_GPU = "GPU:0";
+      string TB_DIR = CeresUserSettingsManager.Settings.DirTablebases;
+      SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(30, 1f) * 0.07f;
+      const string logfileCeres = "ceres.log.txt";
+
+      // Define Ceres engine (in process) with associated neural network and GPU and parameter customizations
+      NNEvaluatorDef ceresNNDef = NNEvaluatorDefFactory.FromSpecification(CERES_NETWORK, CERES_GPU);
+      GameEngineDefCeres engineDefCeres = new GameEngineDefCeres("Ceres-1", ceresNNDef, null,
+                                                                  new ParamsSearch() { /* FutilityPruningStopSearchEnabled = false, */ },
+                                                                  new ParamsSelect(),
+                                                                  logFileName: logfileCeres);
+
+      GameEngineDefCeres engineDef1Ceres = new GameEngineDefCeres("Ceres-2", ceresNNDef, null,
+                                                      new ParamsSearch() { /* FutilityPruningStopSearchEnabled = false, */ },
+                                                      new ParamsSelect(),
+                                                      logFileName: "ceres2.log.txt");
+
+      // Define Leela engine (in process) with associated neural network and GPU and parameter customizations
+      GameEngineDefLC0 engineDefLC0 = new GameEngineDefLC0("LC0-1", ceresNNDef, forceDisableSmartPruning: false, null, null);
+      GameEngineDefLC0 engineDef1LC0 = new GameEngineDefLC0("LC0-2", ceresNNDef, forceDisableSmartPruning: true, null, null);
+
+      //NNEvaluatorDef leelaNNDef = NNEvaluatorDefFactory.FromSpecification($"LC0:{CERES_NETWORK}", CERES_GPU);
+      //GameEngineDefUCI engineDefLeela1 = new GameEngineDefUCI("Leela", new GameEngineUCISpec("LC0",leela_EXE, syzygyPath: TB_DIR));           
+
+      // Define players using these engines and specified time control
+      EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres, TIME_CONTROL);
+      EnginePlayerDef playerCeres2 = new EnginePlayerDef(engineDef1Ceres, TIME_CONTROL);
+      EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLC0, TIME_CONTROL);
+      EnginePlayerDef playerLeela2 = new EnginePlayerDef(engineDef1LC0, TIME_CONTROL);
 
 
-            // Create a tournament definition
-            var engines = new List<EnginePlayerDef>() { playerCeres, playerLeela };
+      // Create a tournament definition
+      var engines = new List<EnginePlayerDef>() { playerCeres, playerLeela, playerLeela2 };
 
-            TournamentDef tournDef = new TournamentDef("Tournament A", engines);
-            // Create a tournament definition
-            //TournamentDef tournDef = new TournamentDef("Ceres_vs_Leela", playerCeres, playerLeela);
-            tournDef.NumGamePairs = 50;
-            tournDef.OpeningsFileName = "WCEC_decisive.pgn";
-            tournDef.ShowGameMoves = false;
+      TournamentDef tournDef = new TournamentDef("Tournament A", engines);
+      // Create a tournament definition
+      //TournamentDef tournDef = new TournamentDef("Ceres_vs_Leela", playerCeres, playerLeela);
+      tournDef.NumGamePairs = 1;
+      tournDef.OpeningsFileName = "WCEC_decisive.pgn";
+      tournDef.ShowGameMoves = false;
 
-            // Run the tournament
-            TimingStats stats = new TimingStats();
-            TournamentResultStats results;
-            using (new TimingBlock(stats, TimingBlock.LoggingType.None))
-            {
-                results = new TournamentManager(tournDef).RunTournament();
-            }
-            Console.WriteLine();
-            Console.WriteLine($"Tournament completed in {stats.ElapsedTimeSecs,8:F2} seconds.");
-            Console.WriteLine(playerCeres + " " + results.GameOutcomesString);
-            Console.ReadLine();
-        }
+      // Run the tournament
+      TimingStats stats = new TimingStats();
+      TournamentResultStats results;
+      using (new TimingBlock(stats, TimingBlock.LoggingType.None))
+      {
+        results = new TournamentManager(tournDef).RunTournament();
+      }
+      Console.WriteLine();
+      Console.WriteLine($"Tournament completed in {stats.ElapsedTimeSecs,8:F2} seconds.");
+      Console.WriteLine(playerCeres + " " + results.GameOutcomesString);
+      Console.ReadLine();
+    }
 
-        static NNEvaluatorDef EvaluatorValueOnly(string netID1, string netID2, int gpuID, bool valueNet1)
+    static NNEvaluatorDef EvaluatorValueOnly(string netID1, string netID2, int gpuID, bool valueNet1)
     {
       string wtStr1 = valueNet1 ? "0.5;1.0;0.5" : "0.5;0.0;0.5";
       string wtStr2 = valueNet1 ? "0.5;0.0;0.5" : "0.5;1.0;0.5";

--- a/src/Ceres/APIExamples/TournamentTest.cs
+++ b/src/Ceres/APIExamples/TournamentTest.cs
@@ -484,8 +484,8 @@ string      baseName = "4mvs_+90_+99";
             string CERES_NETWORK = CeresUserSettingsManager.Settings.DefaultNetworkSpecString; //"LC0:703810";
             const string CERES_GPU = "GPU:0";
 
-            SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(60, 0.5f); // * 0.1f;            
-            const int NUM_GAME_PAIRS = 4;
+            SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(60, 0.5f) * 0.1f;            
+            const int NUM_GAME_PAIRS = 2;
             const string logfile = "ceres.log.txt";
 
             // Define Stockfish engine (via UCI) 
@@ -493,23 +493,23 @@ string      baseName = "4mvs_+90_+99";
 
             // Define Ceres engine (in process) with associated neural network and GPU and parameter customizations
             NNEvaluatorDef ceresNNDef = NNEvaluatorDefFactory.FromSpecification(CERES_NETWORK, CERES_GPU);
-            GameEngineDefCeres engineDefCeres = new GameEngineDefCeres("Ceres", ceresNNDef, null,
-                                                                        new ParamsSearch() { /* FutilityPruningStopSearchEnabled = false, */ },
-                                                                        new ParamsSelect(),
-                                                                        logFileName: logfile);
+            GameEngineDefCeres engineDefCeres1 = new GameEngineDefCeres("Ceres1", ceresNNDef, null, new ParamsSearch(), new ParamsSelect(), logFileName: logfile);
+            GameEngineDefCeres engineDefCeres2 = new GameEngineDefCeres("Ceres2", ceresNNDef, null, new ParamsSearch(), new ParamsSelect(), logFileName: "ceres2.log.txt");
 
             // Define Leela engine (in process) with associated neural network and GPU and parameter customizations
             GameEngineDefLC0 engineDefLC0 = new GameEngineDefLC0("LC0", ceresNNDef, forceDisableSmartPruning: false, null, null);
 
             // Define players using these engines and specified time control
-            EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres, TIME_CONTROL);
+            EnginePlayerDef playerCeres1 = new EnginePlayerDef(engineDefCeres1, TIME_CONTROL);
             EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLC0, TIME_CONTROL);
             EnginePlayerDef playerSf14 = new EnginePlayerDef(sf14Engine, TIME_CONTROL);
+            EnginePlayerDef playerCeres2 = new EnginePlayerDef(engineDefCeres2, TIME_CONTROL);
+            EnginePlayerDef playerSf14Slow = new EnginePlayerDef(sf14Engine, TIME_CONTROL * 0.5f,"SF14*0.5");
 
             // Create a tournament definition
-            var engines = new List<EnginePlayerDef>() { playerCeres, playerLeela, playerSf14 };
+            var engines = new List<EnginePlayerDef>() { playerCeres1, playerLeela, playerCeres2, playerSf14 };
             
-            TournamentDef tournDef = new TournamentDef("Tournament A", engines);
+            TournamentDef tournDef = new TournamentDef("Round Robin Test", engines);
             tournDef.NumGamePairs = NUM_GAME_PAIRS;
             tournDef.OpeningsFileName = "WCEC_decisive.pgn";
             tournDef.ShowGameMoves = false;
@@ -523,7 +523,12 @@ string      baseName = "4mvs_+90_+99";
             }
             Console.WriteLine();
             Console.WriteLine($"Tournament completed in {stats.ElapsedTimeSecs,8:F2} seconds.");
-            Console.WriteLine(playerCeres + " " + results.GameOutcomesString);
+            //foreach (var engine in engines)
+            //{
+            //    Console.WriteLine();
+            //    Console.WriteLine(engine + " " + results.GameOutcomesString);
+            //}
+            
             Console.ReadLine();
         }
 
@@ -532,13 +537,18 @@ string      baseName = "4mvs_+90_+99";
             // Initialize settings by loading configuration file
             //CeresUserSettingsManager.LoadFromFile(@"c:\dev\ceres\artifacts\release\net5.0\ceres.json");
 
+            //example code:
+            // SearchLimit TIME_CONTROL = SearchLimit.NodesPerMove(10_000);
+            // for Ceres, set: new ParamsSearch() { FutilityPruningStopSearchEnabled = false, },            
+            // for LC0 player, set in constructor: forceDisableSmartPruning:true
+
             // Define constants for engine parameters           
 
             string leela_EXE = Path.Combine(CeresUserSettingsManager.Settings.DirExternalEngines, "lc0-v0.28.0-windows-gpu-nvidia-cuda", "LC0.exe");
             string CERES_NETWORK = CeresUserSettingsManager.Settings.DefaultNetworkSpecString; //"LC0:703810";
             const string CERES_GPU = "GPU:0";
             string TB_DIR = CeresUserSettingsManager.Settings.DirTablebases;
-            SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(60, 0.5f) * 0.2f;
+            SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(60, 0.5f); // * 0.5f;
             const string logfileCeres = "ceres.log.txt";
 
 
@@ -559,9 +569,14 @@ string      baseName = "4mvs_+90_+99";
             EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres, TIME_CONTROL);
             EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLC0, TIME_CONTROL);
 
+
             // Create a tournament definition
-            TournamentDef tournDef = new TournamentDef("Ceres_vs_Leela", playerCeres, playerLeela);
-            tournDef.NumGamePairs = 20;
+            var engines = new List<EnginePlayerDef>() { playerCeres, playerLeela };
+
+            TournamentDef tournDef = new TournamentDef("Tournament A", engines);
+            // Create a tournament definition
+            //TournamentDef tournDef = new TournamentDef("Ceres_vs_Leela", playerCeres, playerLeela);
+            tournDef.NumGamePairs = 50;
             tournDef.OpeningsFileName = "WCEC_decisive.pgn";
             tournDef.ShowGameMoves = false;
 

--- a/src/Ceres/APIExamples/TournamentTest.cs
+++ b/src/Ceres/APIExamples/TournamentTest.cs
@@ -435,9 +435,9 @@ string      baseName = "4mvs_+90_+99";
             const string CERES_GPU = "GPU:0";
 
             string TB_DIR = CeresUserSettingsManager.Settings.DirTablebases;
-            SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(60, 0.5f); //* 0.15f;            
-            const int NUM_GAME_PAIRS = 36;
-            const string logfile = "ceres.log.txt"; //Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "ceres.log.txt");
+            SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(10*60, 1f); //* 0.15f;            
+            const int NUM_GAME_PAIRS = 20;
+            const string logfile = "ceresLTC.log.txt"; //Path.Combine(CeresUserSettingsManager.Settings.DirCeresOutput, "ceres.log.txt");
 
             // Define Stockfish engine (via UCI) 
             GameEngineDefUCI sf14Engine = new GameEngineDefUCI("SF14", new GameEngineUCISpec("SF14", SF14_EXE, SF_THREADS, SF_TB_SIZE_MB, TB_DIR));
@@ -491,20 +491,19 @@ string      baseName = "4mvs_+90_+99";
             // Define Stockfish engine (via UCI) 
             GameEngineDefUCI sf14Engine = new GameEngineDefUCI("SF14", new GameEngineUCISpec("SF14", SF14_EXE, SF_THREADS, SF_TB_SIZE_MB, TB_DIR));
 
-            // Define Leela engine (via UCI) with associated neural network and GPU and parameter customizations
-            NNEvaluatorDef leelaNNDef = NNEvaluatorDefFactory.FromSpecification($"LC0:{CERES_NETWORK}", CERES_GPU);
-            GameEngineDefUCI engineDefLeela1 = new GameEngineDefUCI("Leela", new GameEngineUCISpec("LC0", leela_EXE, syzygyPath: TB_DIR));
-            
             // Define Ceres engine (in process) with associated neural network and GPU and parameter customizations
             NNEvaluatorDef ceresNNDef = NNEvaluatorDefFactory.FromSpecification(CERES_NETWORK, CERES_GPU);
-            GameEngineDefCeres engineDefCeres1 = new GameEngineDefCeres("Ceres", ceresNNDef, null,
+            GameEngineDefCeres engineDefCeres = new GameEngineDefCeres("Ceres", ceresNNDef, null,
                                                                         new ParamsSearch() { /* FutilityPruningStopSearchEnabled = false, */ },
                                                                         new ParamsSelect(),
                                                                         logFileName: logfile);
 
+            // Define Leela engine (in process) with associated neural network and GPU and parameter customizations
+            GameEngineDefLC0 engineDefLC0 = new GameEngineDefLC0("LC0", ceresNNDef, forceDisableSmartPruning: false, null, null);
+
             // Define players using these engines and specified time control
-            EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres1, TIME_CONTROL);
-            EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLeela1, TIME_CONTROL);
+            EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres, TIME_CONTROL);
+            EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLC0, TIME_CONTROL);
             EnginePlayerDef playerSf14 = new EnginePlayerDef(sf14Engine, TIME_CONTROL);
 
             // Create a tournament definition
@@ -542,24 +541,27 @@ string      baseName = "4mvs_+90_+99";
             SearchLimit TIME_CONTROL = SearchLimit.SecondsForAllMoves(60, 0.5f) * 0.2f;
             const string logfileCeres = "ceres.log.txt";
 
-            // Define Leela engine (in process) with associated neural network and GPU and parameter customizations
-            NNEvaluatorDef leelaNNDef = NNEvaluatorDefFactory.FromSpecification($"LC0:{CERES_NETWORK}", CERES_GPU);
-            GameEngineDefUCI engineDefLeela1 = new GameEngineDefUCI("Leela", new GameEngineUCISpec("LC0",leela_EXE, syzygyPath: TB_DIR));           
 
             // Define Ceres engine (in process) with associated neural network and GPU and parameter customizations
             NNEvaluatorDef ceresNNDef = NNEvaluatorDefFactory.FromSpecification(CERES_NETWORK, CERES_GPU);
-            GameEngineDefCeres engineDefCeres1 = new GameEngineDefCeres("Ceres", ceresNNDef, null,
+            GameEngineDefCeres engineDefCeres = new GameEngineDefCeres("Ceres", ceresNNDef, null,
                                                                         new ParamsSearch() { /* FutilityPruningStopSearchEnabled = false, */ },
                                                                         new ParamsSelect(),
                                                                         logFileName: logfileCeres);
 
+            // Define Leela engine (in process) with associated neural network and GPU and parameter customizations
+            GameEngineDefLC0 engineDefLC0 = new GameEngineDefLC0("LC0", ceresNNDef, forceDisableSmartPruning: false, null, null);
+            
+            //NNEvaluatorDef leelaNNDef = NNEvaluatorDefFactory.FromSpecification($"LC0:{CERES_NETWORK}", CERES_GPU);
+            //GameEngineDefUCI engineDefLeela1 = new GameEngineDefUCI("Leela", new GameEngineUCISpec("LC0",leela_EXE, syzygyPath: TB_DIR));           
+
             // Define players using these engines and specified time control
-            EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres1, TIME_CONTROL);
-            EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLeela1, TIME_CONTROL);
+            EnginePlayerDef playerCeres = new EnginePlayerDef(engineDefCeres, TIME_CONTROL);
+            EnginePlayerDef playerLeela = new EnginePlayerDef(engineDefLC0, TIME_CONTROL);
 
             // Create a tournament definition
             TournamentDef tournDef = new TournamentDef("Ceres_vs_Leela", playerCeres, playerLeela);
-            tournDef.NumGamePairs = 2;
+            tournDef.NumGamePairs = 20;
             tournDef.OpeningsFileName = "WCEC_decisive.pgn";
             tournDef.ShowGameMoves = false;
 

--- a/src/Ceres/Commands/FeatureTournParams.cs
+++ b/src/Ceres/Commands/FeatureTournParams.cs
@@ -64,7 +64,8 @@ namespace Ceres.Commands
     {
       (EnginePlayerDef player1, EnginePlayerDef player2) = tournParams.GetEngineDefs(true);
 
-      TournamentDef def = new TournamentDef("Tournament", player1, player2);
+      var engines = new List<EnginePlayerDef>() { player1, player2 };
+      TournamentDef def = new TournamentDef("Tournament", engines);
       def.ShowGameMoves = tournParams.ShowMoves;
 
       if (tournParams.Openings != null)

--- a/src/Ceres/Commands/FeatureTournParams.cs
+++ b/src/Ceres/Commands/FeatureTournParams.cs
@@ -64,8 +64,7 @@ namespace Ceres.Commands
     {
       (EnginePlayerDef player1, EnginePlayerDef player2) = tournParams.GetEngineDefs(true);
 
-      var engines = new List<EnginePlayerDef>() { player1, player2 };
-      TournamentDef def = new TournamentDef("Tournament", engines);
+      TournamentDef def = new TournamentDef("Tournament", player1, player2);
       def.ShowGameMoves = tournParams.ShowMoves;
 
       if (tournParams.Openings != null)

--- a/src/Ceres/Program.cs
+++ b/src/Ceres/Program.cs
@@ -81,7 +81,7 @@ namespace Ceres
 
       if (args.Length > 0 && (args[0].ToUpper() == "CUSTOM" || args[0].StartsWith("WORKER")))
       {
-        TournamentTest.TestSFLeela(0,true); return;
+        TournamentTest.TestSF(0,true); return;
         //        SuiteTest.RunSuiteTest(); return;
       }
 

--- a/src/Ceres/Program.cs
+++ b/src/Ceres/Program.cs
@@ -81,7 +81,7 @@ namespace Ceres
 
       if (args.Length > 0 && (args[0].ToUpper() == "CUSTOM" || args[0].StartsWith("WORKER")))
       {
-        TournamentTest.Test(); return;
+        TournamentTest.TestSF(0,true); return;
         //        SuiteTest.RunSuiteTest(); return;
       }
 

--- a/src/Ceres/Program.cs
+++ b/src/Ceres/Program.cs
@@ -66,7 +66,7 @@ namespace Ceres
       LoggerTypes loggerTypes = LoggerTypes.WinDebugLogger | LoggerTypes.ConsoleLogger;
       CeresEnvironment.Initialize(loggerTypes, logLevel);
 
-      CeresEnvironment.MONITORING_METRICS = !CommandLineWorkerSpecification.IsWorker 
+      CeresEnvironment.MONITORING_METRICS = !CommandLineWorkerSpecification.IsWorker
                                            && CeresUserSettingsManager.Settings.LaunchMonitor;
 
       //      if (CeresUserSettingsManager.Settings.DirLC0Networks != null)
@@ -81,7 +81,7 @@ namespace Ceres
 
       if (args.Length > 0 && (args[0].ToUpper() == "CUSTOM" || args[0].StartsWith("WORKER")))
       {
-        TournamentTest.TestSFLeela(0,true); return;
+        //TournamentTest.TestSFLeela(0, true); return;
         //        SuiteTest.RunSuiteTest(); return;
       }
 

--- a/src/Ceres/Program.cs
+++ b/src/Ceres/Program.cs
@@ -81,7 +81,7 @@ namespace Ceres
 
       if (args.Length > 0 && (args[0].ToUpper() == "CUSTOM" || args[0].StartsWith("WORKER")))
       {
-        TournamentTest.TestSF(0,true); return;
+        TournamentTest.TestSFLeela(0,true); return;
         //        SuiteTest.RunSuiteTest(); return;
       }
 

--- a/src/Ceres/Properties/launchSettings.json
+++ b/src/Ceres/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Ceres": {
       "commandName": "Project",
+      "commandLineArgs": "CUSTOM",
       "nativeDebugging": false
     },
     "Docker": {


### PR DESCRIPTION
I did add some improvements to the tournament features in Ceres. You are now able to run tournaments from code with a list of engines. The normal tournament is a round robin tournament were every engine plays a pair of openings against each other. I also enabled a extra feature to use a reference engine as the main engine to play against all other engines (the other engines don't play games against each other).  In order to support these new features I added some new tables for tournament stats that can be dumped to Console.