### PR TITLE
Added Chess960 support

### DIFF
--- a/src/Ceres.Chess/LC0/Positions/Basic/EncodedMove.cs
+++ b/src/Ceres.Chess/LC0/Positions/Basic/EncodedMove.cs
@@ -77,8 +77,8 @@ namespace Ceres.Chess.EncodedPositions.Basic
     {
       Debug.Assert(!isCastling || from.Rank == 0); // first rank
       Debug.Assert(!isCastling || to.Rank == 0); // first rank
-      Debug.Assert(!isCastling || from.File == 4); // E1
-      Debug.Assert(!isCastling || to.File == 0 || to.File == 7); // A1 or H1
+      //Debug.Assert(!isCastling || from.File == 4); // E1
+      //Debug.Assert(!isCastling || to.File == 0 || to.File == 7); // A1 or H1
 
       int val = to.Value +
                 (from.Value << 6) +
@@ -231,7 +231,7 @@ namespace Ceres.Chess.EncodedPositions.Basic
     /// Returns index of this move in the neural network (or -1, for moves that are not possible)
     /// In range [0.1857]
     /// </summary>
-    public int IndexNeuralNet => indexesToNNIndices[IndexPacked];    
+    public int IndexNeuralNet => indexesToNNIndices[IndexPacked];
 
 #if WORKS_BUT_SLOW_UNNEEDED
     /// <summary>
@@ -319,8 +319,10 @@ namespace Ceres.Chess.EncodedPositions.Basic
 
       if (pieceInfoWasAvailable)
       {
-        if ((index == 97 || index == 103) && isKingMove) // castling
+        if (raw.IsCastling && isKingMove)
+        {
           return new EncodedMove((ushort)(raw.IndexPacked | MaskCastling));
+        }
         else if (isPawnMove && raw.ToSquare.Rank == 7) // promotion
         {
           char possiblePromoChar = NEURAL_NET_MOVE_STR[index][^1];

--- a/src/Ceres.Chess/MoveGen/Converters/ConverterMGMoveEncodedMove.cs
+++ b/src/Ceres.Chess/MoveGen/Converters/ConverterMGMoveEncodedMove.cs
@@ -80,7 +80,7 @@ namespace Ceres.Chess.MoveGen.Converters
                                             MCChessPositionPieceEnum.BlackRook, MCChessPositionPieceEnum.BlackQueen, MCChessPositionPieceEnum.BlackKing };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static FromTo CalcFromTo(int i)
+    internal static FromTo CalcFromTo(int i)
     {
       EncodedMove lzMove = new EncodedMove((ushort)i);
 
@@ -104,9 +104,8 @@ namespace Ceres.Chess.MoveGen.Converters
         return CalcFromTo(thisMove.RawValue & (16384 - 1));
     }
 
-
     public static MGMove EncodedMoveToMGChessMove(EncodedMove thisMove, in MGPosition position)
-   {
+    {
       MGMove moveMG = DoEncodedMoveToMGChessMove(thisMove, in position);
       if (position.SideToMove == SideType.Black)
       {
@@ -126,24 +125,26 @@ namespace Ceres.Chess.MoveGen.Converters
     static MGMove DoEncodedMoveToMGChessMove(EncodedMove thisMove, in MGPosition position)
     {
       Debug.Assert(position != default);
-
       FromTo fromTo = CalcFromTo(thisMove.RawValue & (16384 - 1));
       byte fromSquare = fromTo.From;
       byte toSquare = fromTo.To;
-
+      bool blackToMove = position.BlackToMove;
       PieceType pieceMoving = position.PieceMoving(thisMove);
+      MCChessPositionPieceEnum rawPieceAtToSquare = position.PieceCapturingRaw(thisMove);
+
+      var performedCastling =
+        pieceMoving == PieceType.King &&
+        ((blackToMove && rawPieceAtToSquare == MCChessPositionPieceEnum.BlackRook) || (!blackToMove && rawPieceAtToSquare == MCChessPositionPieceEnum.WhiteRook));
+
       if (pieceMoving == PieceType.None)
       {
         throw new Exception("Illegal move " + thisMove + " in position " + position.ToPosition.FEN);
       }
       PieceType pieceCapture = position.PieceCapturing(thisMove);
-
-      MCChessPositionPieceEnum rawPieceAtToSquare = position.PieceCapturingRaw(thisMove);
-
-      bool blackToMove = position.BlackToMove;
       MCChessPositionPieceEnum pieceMG = PieceToMGPiece(pieceMoving, blackToMove);
       int pieceMGFlags = (int)pieceMG << MGMove.PIECE_SHIFT;
       int captureFlag = 0;
+
       if (pieceCapture != PieceType.None)
       {
         captureFlag = (int)MGMove.MGChessMoveFlags.Capture;
@@ -170,50 +171,32 @@ namespace Ceres.Chess.MoveGen.Converters
         };
 
         Debug.Assert(promotionPart != 0);
-        return new MGMove(fromSquare, toSquare, (MGMove.MGChessMoveFlags)(promotionPart | pieceMGFlags | captureFlag));
+        return new MGMove(fromSquare, toSquare, (MGMove.MGChessMoveFlags)(promotionPart | pieceMGFlags | captureFlag));       
       }
       else
       {
-        bool isCastling = false;
-
-        int thisNNIndex = thisMove.IndexNeuralNet;
-        bool isCastlingFromAndToSquares = thisNNIndex == 103 || thisNNIndex == 97;
-        if (isCastlingFromAndToSquares)
-        {
-          isCastling = (pieceMoving == PieceType.King);
-        }
-
-        if (isCastling)
+        if (performedCastling)
         {
           int castlingPart;
-          if (toSquare <= 4)
-          {
+          if (toSquare < fromSquare)
             castlingPart = (int)MGMove.MGChessMoveFlags.CastleShort;
-            toSquare = 1;
-          }
           else
-          {
             castlingPart = (int)MGMove.MGChessMoveFlags.CastleLong;
-            toSquare = 5;
-          }
 
+          Debug.Assert(castlingPart != 0);
           return new MGMove(fromSquare, toSquare, (MGMove.MGChessMoveFlags)(castlingPart | pieceMGFlags));
         }
-
-        // If the LZPositionMove happens to have the castling flag set,  make sure we agree
-        Debug.Assert(!(thisMove.IsCastling && !isCastling));
 
         // Check for double pawn move
         bool isDoublePawnMove = thisMove.FromSquare.IsRank2 && thisMove.ToSquare.IsRank4 && pieceMoving == PieceType.Pawn;
         MGMove.MGChessMoveFlags flagsDefault = isDoublePawnMove ? MGMove.MGChessMoveFlags.DoublePawnMove : 0;
-
-        return new MGMove(fromSquare, toSquare, (MGMove.MGChessMoveFlags)((int)flagsDefault | pieceMGFlags | captureFlag));
+        return new MGMove(fromSquare, toSquare, (MGMove.MGChessMoveFlags)((int)flagsDefault | pieceMGFlags | captureFlag));        
       }
     }
 
     public static MCChessPositionPieceEnum PieceToMGPiece(PieceType pieceMoving, bool blackToMove)
     {
-      return blackToMove ? blackPieceToMGPieceCode[(int)pieceMoving] 
+      return blackToMove ? blackPieceToMGPieceCode[(int)pieceMoving]
                          : whitePieceToMGPieceCode[(int)pieceMoving];
     }
 
@@ -265,11 +248,19 @@ namespace Ceres.Chess.MoveGen.Converters
       {
         if (thisMove.CastleShort)
         {
-          return moveCastle;
+          Square sqFrom = squareMap[thisMove.FromSquareIndex];
+          Square sqTo = squareMap[thisMove.ToSquareIndex];
+
+          return new EncodedMove(new EncodedSquare(sqFrom.SquareIndexStartA1),
+                                 new EncodedSquare(sqTo.SquareIndexStartA1), promotion, true);
         }
         else if (thisMove.CastleLong)
         {
-          return moveCastleLong;
+          Square sqFrom = squareMap[thisMove.FromSquareIndex];
+          Square sqTo = squareMap[thisMove.ToSquareIndex];
+
+          return new EncodedMove(new EncodedSquare(sqFrom.SquareIndexStartA1),
+                                 new EncodedSquare(sqTo.SquareIndexStartA1), promotion, true);
         }
         else if (thisMove.IsPromotion)
         {
@@ -296,7 +287,7 @@ namespace Ceres.Chess.MoveGen.Converters
 
       Square squareFrom = squareMap[thisMove.FromSquareIndex];
       Square squareTo = squareMap[thisMove.ToSquareIndex];
-      return new EncodedMove(new EncodedSquare(squareFrom.SquareIndexStartA1), 
+      return new EncodedMove(new EncodedSquare(squareFrom.SquareIndexStartA1),
                              new EncodedSquare(squareTo.SquareIndexStartA1), promotion, false);
     }
 

--- a/src/Ceres.Chess/MoveGen/Converters/ConverterMGMoveEncodedMove.cs
+++ b/src/Ceres.Chess/MoveGen/Converters/ConverterMGMoveEncodedMove.cs
@@ -132,7 +132,7 @@ namespace Ceres.Chess.MoveGen.Converters
       PieceType pieceMoving = position.PieceMoving(thisMove);
       MCChessPositionPieceEnum rawPieceAtToSquare = position.PieceCapturingRaw(thisMove);
 
-      var performedCastling =
+      bool performedCastling =
         pieceMoving == PieceType.King &&
         ((blackToMove && rawPieceAtToSquare == MCChessPositionPieceEnum.BlackRook) || (!blackToMove && rawPieceAtToSquare == MCChessPositionPieceEnum.WhiteRook));
 

--- a/src/Ceres.Chess/MoveGen/Converters/MGChessPositionConverter.cs
+++ b/src/Ceres.Chess/MoveGen/Converters/MGChessPositionConverter.cs
@@ -244,7 +244,7 @@ namespace Ceres.Chess.MoveGen.Converters
     /// <param name="piece"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static int MGPieceFromPiece(Piece piece)
+     internal static int MGPieceFromPiece(Piece piece)
       => piece.Side == SideType.White
                      ? PieceMapWhite[(int)piece.Type]
                      : PieceMapBlack[(int)piece.Type];

--- a/src/Ceres.Chess/MoveGen/Converters/MGMoveConverter.cs
+++ b/src/Ceres.Chess/MoveGen/Converters/MGMoveConverter.cs
@@ -79,7 +79,7 @@ namespace Ceres.Chess.MoveGen.Converters
 
       MGMoveList moves = new MGMoveList();
       MGMoveGen.GenerateMoves(in mgPos, moves);
-      for (int i=0; i<moves.NumMovesUsed;i++)
+      for (int i = 0; i < moves.NumMovesUsed; i++)
       {
         if (moves.MovesArray[i].EqualsMove(move))
           return moves.MovesArray[i];

--- a/src/Ceres.Chess/MoveGen/Converters/MoveInMGMovesArrayLocator.cs
+++ b/src/Ceres.Chess/MoveGen/Converters/MoveInMGMovesArrayLocator.cs
@@ -51,7 +51,7 @@ namespace Ceres.Chess.MoveGen.Converters
       int i = startIndex;
       while (i < numMovesUsed - 3)
       {
-        if (moves[i    ].FromAndToCombined == fromAndTo) return i;
+        if (moves[i].FromAndToCombined == fromAndTo) return i;
         if (moves[i + 1].FromAndToCombined == fromAndTo) return i + 1;
         if (moves[i + 2].FromAndToCombined == fromAndTo) return i + 2;
         if (moves[i + 3].FromAndToCombined == fromAndTo) return i + 3;

--- a/src/Ceres.Chess/MoveGen/MGMove.cs
+++ b/src/Ceres.Chess/MoveGen/MGMove.cs
@@ -30,7 +30,7 @@ namespace Ceres.Chess.MoveGen
   using BitBoard = System.UInt64;
 
   [Serializable]
-  [StructLayout(LayoutKind.Explicit, Pack = 1, Size=4)]
+  [StructLayout(LayoutKind.Explicit, Pack = 1, Size = 4)]
   public partial struct MGMove
   {
     #region Field
@@ -99,18 +99,17 @@ namespace Ceres.Chess.MoveGen
       Unsafe.SkipInit<uint>(out AllFieldsCombined);
 
       Piece = piece;
-  }
+    }
 
 
-  /// <summary>
-  /// Constructor
-  /// </summary>
-  /// <param name="from"></param>
-  /// <param name="to"></param>
-  /// <param name="flags"></param>
-  public MGMove(byte from, byte to, MGChessMoveFlags flags)
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="from"></param>
+    /// <param name="to"></param>
+    /// <param name="flags"></param>
+    public MGMove(byte from, byte to, MGChessMoveFlags flags)
     {
-      Debug.Assert(from != to);
       Debug.Assert(from < 64);
       Debug.Assert(to < 64);
 
@@ -154,8 +153,8 @@ namespace Ceres.Chess.MoveGen
     internal const int PIECE_SHIFT = 12;
     internal const int MOVE_COUNT_SHIFT = 17;
 
-    public const MGChessMoveFlags PromotionFlags = (MGChessMoveFlags.PromoteKnight | MGChessMoveFlags.PromoteBishop 
-                                                 |  MGChessMoveFlags.PromoteRook   | MGChessMoveFlags.PromoteQueen);
+    public const MGChessMoveFlags PromotionFlags = (MGChessMoveFlags.PromoteKnight | MGChessMoveFlags.PromoteBishop
+                                                 | MGChessMoveFlags.PromoteRook | MGChessMoveFlags.PromoteQueen);
 
     /// <summary>
     /// Returns a new MGMove initialized from a specified raw value.
@@ -195,9 +194,9 @@ namespace Ceres.Chess.MoveGen
     /// <summary>
     /// Returns a value (0, 1, 2, 4 or 8) corresonding to none, Knight, Bishop, Rook, or Queen.
     /// </summary>
-    public short PromotionValue => promoFlagsToEnum[(short)((int)(Flags & PromotionFlags)>>7)];
-    
-    
+    public short PromotionValue => promoFlagsToEnum[(short)((int)(Flags & PromotionFlags) >> 7)];
+
+
     /// <summary>
     /// Returns if the move is a promotion.
     /// </summary>
@@ -273,7 +272,7 @@ namespace Ceres.Chess.MoveGen
     /// Returns if the move is either a castle or promotion move.
     /// </summary>
     public bool IsCastleOrPromotion
-      => (Flags & (MGChessMoveFlags.CastleShort 
+      => (Flags & (MGChessMoveFlags.CastleShort
                  | MGChessMoveFlags.CastleLong
                  | MGChessMoveFlags.PromoteQueen
                  | MGChessMoveFlags.PromoteRook
@@ -364,8 +363,8 @@ namespace Ceres.Chess.MoveGen
     {
       [MethodImpl(MethodImplOptions.AggressiveInlining)]
       get
-      { 
-        return (MGPositionConstants.MCChessPositionPieceEnum)(((int)(Flags & MGChessMoveFlags.Piece)) >> PIECE_SHIFT); 
+      {
+        return (MGPositionConstants.MCChessPositionPieceEnum)(((int)(Flags & MGChessMoveFlags.Piece)) >> PIECE_SHIFT);
       }
 
       set
@@ -375,7 +374,7 @@ namespace Ceres.Chess.MoveGen
       }
     }
 
-#region Overrides
+    #region Overrides
 
     public override int GetHashCode()
     {
@@ -383,13 +382,13 @@ namespace Ceres.Chess.MoveGen
     }
     public override string ToString() => MoveStr(MGMoveNotationStyle.LongAlgebraic);
 
-    public static bool operator ==(MGMove move1, MGMove move2) => move1.Equals(move2);    
+    public static bool operator ==(MGMove move1, MGMove move2) => move1.Equals(move2);
 
     public static bool operator !=(MGMove move1, MGMove move2) => !move1.Equals(move2);
 
     public override bool Equals(object obj) => obj is MGMove && Equals((MGMove)obj);
 
-#endregion
+    #endregion
 
     /// <summary>
     /// Helper comparer class for MGMove which uses FromAndToCombined.
@@ -427,7 +426,7 @@ namespace Ceres.Chess.MoveGen
       {
         return true;
       }
-      
+
       return false;
     }
 

--- a/src/Ceres.Chess/MoveGen/MGMoveDump.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveDump.cs
@@ -53,6 +53,7 @@ SOFTWARE.
 
 #region Using directives
 
+using Ceres.Chess.EncodedPositions.Basic;
 using System;
 using System.Numerics;
 using System.Text;
@@ -128,14 +129,14 @@ namespace Ceres.Chess.MoveGen
       int from = BitOperations.TrailingZeroCount(bbFrom);
       int to = BitOperations.TrailingZeroCount(bbTo);
 
-      if(style == MGMoveNotationStyle.StandardCastlingFormat)
+      if (style == MGMoveNotationStyle.StandardCastlingFormat)
       {
         if (IsCastle)
-        {
-          bool isWhite = ToSquare.Rank == 0;
-          if (isWhite)
-            return CastleLong ? "e1c1" : "e1g1";
-          else
+        {                 
+          bool isWhite = Piece == MGPositionConstants.MCChessPositionPieceEnum.WhiteKing;
+          if (isWhite && FromSquareIndex == 3)
+            return CastleLong ?  "e1c1" : "e1g1";
+          else if (!isWhite && FromSquareIndex == 59)
             return CastleLong ? "e8c8" : "e8g8";
         }
         return string.Empty;
@@ -146,7 +147,7 @@ namespace Ceres.Chess.MoveGen
         if (CastleShort) return "O-O";
         if (CastleLong) return "O-O-O";
       }
-    
+
       char c1 = (char)('h' - (from % 8));
       char c2 = (char)('h' - (to % 8));
 

--- a/src/Ceres.Chess/MoveGen/MGMoveDump.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveDump.cs
@@ -95,11 +95,16 @@ namespace Ceres.Chess.MoveGen
     /// <summary>
     /// Leela chess zero coordinate format, with 960 extension for castling moves.
     /// </summary>
-    LC0Coordinate960Format
+    LC0Coordinate960Format,
+
+    /// <summary>
+    /// Normal castling moves, e.g. e1g1 and e1c1.
+    /// </summary>
+    StandardCastlingFormat
   };
 
 
-  
+
   /// <summary>
   /// Methods on MGMove related to dumping to strings (diagnostic).
   /// </summary>
@@ -123,22 +128,17 @@ namespace Ceres.Chess.MoveGen
       int from = BitOperations.TrailingZeroCount(bbFrom);
       int to = BitOperations.TrailingZeroCount(bbTo);
 
-      if (style == MGMoveNotationStyle.LC0Coordinate960Format)
+      if(style == MGMoveNotationStyle.StandardCastlingFormat)
       {
         if (IsCastle)
         {
-          // Castling moves always indicate target file at edge of board
           bool isWhite = ToSquare.Rank == 0;
-          if (isWhite) 
-            return CastleLong ? "e1a1" : "e1h1";
+          if (isWhite)
+            return CastleLong ? "e1c1" : "e1g1";
           else
-            return CastleLong ? "e8a8" : "e8h8";
+            return CastleLong ? "e8c8" : "e8g8";
         }
-        else
-        {
-          // Not castle, so in that case the format will be identical to LC0 coordinate.
-          style = MGMoveNotationStyle.LC0Coordinate;
-        }
+        return string.Empty;
       }
 
       if (style != MGMoveNotationStyle.CoOrdinate && style != MGMoveNotationStyle.LC0Coordinate)
@@ -146,7 +146,7 @@ namespace Ceres.Chess.MoveGen
         if (CastleShort) return "O-O";
         if (CastleLong) return "O-O-O";
       }
-
+    
       char c1 = (char)('h' - (from % 8));
       char c2 = (char)('h' - (to % 8));
 
@@ -176,8 +176,8 @@ namespace Ceres.Chess.MoveGen
           p = "?";
           break;
       }
-      
-      if ((style == MGMoveNotationStyle.LongAlgebraic) 
+
+      if ((style == MGMoveNotationStyle.LongAlgebraic)
        || (style == MGMoveNotationStyle.ShortAlgebraic)
        || (style == MGMoveNotationStyle.StandardAlgebraic)
        || (style == MGMoveNotationStyle.LC0Coordinate))

--- a/src/Ceres.Chess/MoveGen/MGMoveFromString.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveFromString.cs
@@ -42,9 +42,12 @@ namespace Ceres.Chess.MoveGen
         return MGMoveConverter.MGMoveFromPosAndMove(in position, mfp.Move);
       }
       else
+      {
+        System.Diagnostics.Debug.Assert(pos.IsLegalMove(move));
         return move;
-    }
+      }
 
+    }
 
     /// <summary>
     /// Attempts to parse a move string in coordinate or long algebraic format.
@@ -63,16 +66,17 @@ namespace Ceres.Chess.MoveGen
 
       MGMoveList moves = new MGMoveList();
       MGMoveGen.GenerateMoves(in pos, moves);
+
       foreach (MGMove moveTry in moves.MovesArray)
       {
         // Accept moves in any of multiple formats, including Chess 960 (for castling variation)
         if (String.Equals(moveTry.MoveStr(MGMoveNotationStyle.LC0Coordinate), moveStr, StringComparison.OrdinalIgnoreCase)
-         || String.Equals(moveTry.MoveStr(MGMoveNotationStyle.LC0Coordinate960Format), moveStr, StringComparison.OrdinalIgnoreCase)
-         || String.Equals(moveTry.MoveStr(MGMoveNotationStyle.LongAlgebraic), moveStr, StringComparison.OrdinalIgnoreCase))
+         || String.Equals(moveTry.MoveStr(MGMoveNotationStyle.LongAlgebraic), moveStr, StringComparison.OrdinalIgnoreCase)
+         || String.Equals(moveTry.MoveStr(MGMoveNotationStyle.StandardCastlingFormat), moveStr, StringComparison.OrdinalIgnoreCase))
         {
           move = moveTry;
           return true;
-        }           
+        }
       }
 
       move = default;

--- a/src/Ceres.Chess/MoveGen/MGMoveFromString.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveFromString.cs
@@ -75,6 +75,12 @@ namespace Ceres.Chess.MoveGen
          || String.Equals(moveTry.MoveStr(MGMoveNotationStyle.StandardCastlingFormat), moveStr, StringComparison.OrdinalIgnoreCase))
         {
           move = moveTry;
+          //if (moveTry.IsCastle)
+          //{
+          //  var res1 = moveTry.MoveStr(MGMoveNotationStyle.LC0Coordinate);
+          //  var res2 = moveTry.MoveStr(MGMoveNotationStyle.LongAlgebraic);
+          //  var res3 = moveTry.MoveStr(MGMoveNotationStyle.StandardCastlingFormat);
+          //}
           return true;
         }
       }

--- a/src/Ceres.Chess/MoveGen/MGMoveGen.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveGen.cs
@@ -53,6 +53,7 @@ SOFTWARE.
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 #endregion
@@ -116,7 +117,7 @@ namespace Ceres.Chess.MoveGen
     [ThreadStatic]
     static MGMoveList movesTemp;
 
-    public enum MoveGenMode {  AllMoves, AtLeastOneMoveIfAnyExists };
+    public enum MoveGenMode { AllMoves, AtLeastOneMoveIfAnyExists };
 
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -233,22 +234,13 @@ namespace Ceres.Chess.MoveGen
 
                 square = MGPositionConstants.MoveRight[q] & whiteFree;
                 AddWhiteMoveToListIfLegal(in P, moves, q, square, MGPositionConstants.WKING);
-                
-                bool isWhiteInCheck = IsWhiteInCheck(P.A, P.B, P.C, P.D);
-                BitBoard rookPos = ~P.A & ~P.B & P.C & ~P.D;
 
-                // Conditionally generate O-O move:
-                if (
-                  (currentSquare == MGPositionConstants.WHITEKINGPOS) &&          // King is in correct Position AND
-                  (P.WhiteCanCastle) &&               // White still has castle rights AND
-                  (MGPositionConstants.WHITECASTLEZONE & occupied) == 0 &&        // Castle Zone (f1,g1) is clear AND
-                  ((rookPos & MGPositionConstants.WHITEKRPOS) != 0) && // KRook is in correct Position AND
-                  (!moves.MovesArray[moves.NumMovesUsed].IllegalMove) &&          // Last generated move (1 step to right) was legal AND
-                  !isWhiteInCheck                                                 // King is not in Check
-                  )
+                ulong rookSquare;
+                // Conditionally generate O-O move:               
+                if (P.WhiteCanCastle && QBBoperations.CanWhiteKingReachShortRook(in P, out rookSquare))
                 {
                   // OK to Castle
-                  square = MGPositionConstants.G1;                    // Move King to g1
+                  square = rookSquare;
                   M.Flags = 0;
                   M.CastleShort = true;
                   AddWhiteMoveToListIfLegal(in P, moves, q, square, MGPositionConstants.WKING, M.Flags);
@@ -260,18 +252,12 @@ namespace Ceres.Chess.MoveGen
                 square = MGPositionConstants.MoveLeft[q] & whiteFree;
                 AddWhiteMoveToListIfLegal(in P, moves, q, square, MGPositionConstants.WKING);
 
-                // Conditionally generate O-O-O move:
-                if (
-                  (currentSquare == MGPositionConstants.WHITEKINGPOS) &&          // King is in correct Position AND
-                  (P.WhiteCanCastleLong) &&             // White still has castle-long rights AND
-                  (MGPositionConstants.WHITECASTLELONGZONE & occupied) == 0 &&    // Castle Long Zone (b1,c1,d1) is clear AND	
-                  ((rookPos & MGPositionConstants.WHITEQRPOS) != 0) && // QRook is in correct Position AND
-                  (!moves.MovesArray[moves.NumMovesUsed].IllegalMove) &&          // Last generated move (1 step to left) was legal AND
-                  !isWhiteInCheck                                                 // King is not in Check
-                  )
+
+                // Conditionally generate O-O-O move:                
+                if (P.WhiteCanCastleLong && QBBoperations.CanWhiteKingReachLongRook(in P, out rookSquare))
                 {
                   // Ok to Castle Long
-                  square = MGPositionConstants.C1;                    // Move King to c1
+                  square = rookSquare;
                   M.Flags = 0;
                   M.CastleLong = true;
                   AddWhiteMoveToListIfLegal(in P, moves, q, square, MGPositionConstants.WKING, M.Flags);
@@ -378,7 +364,7 @@ namespace Ceres.Chess.MoveGen
           break;
       } while (true);
 
-//      moves.MovesArray[0].MoveCount = (byte)(moves.NumMovesUsed);
+      //      moves.MovesArray[0].MoveCount = (byte)(moves.NumMovesUsed);
 
       // Create 'no more moves' move to mark end of list:	
       moves.MovesArray[moves.NumMovesUsed].FromSquareIndex = 0;
@@ -386,7 +372,6 @@ namespace Ceres.Chess.MoveGen
       moves.MovesArray[moves.NumMovesUsed].Piece = 0;
       moves.MovesArray[moves.NumMovesUsed].NoMoreMoves = true;
     }
-
 
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -412,25 +397,38 @@ namespace Ceres.Chess.MoveGen
       thisMove.Piece = (MGPositionConstants.MCChessPositionPieceEnum)piece;
 
       BitBoard O = (ulong)~((1UL << fromsquare) | (ulong)to);
-
       BitBoard QA, QB, QC, QD;
 
       if (thisMove.CastleShort)
       {
-        QA = P.A ^ 0x000000000000000a;
-        QB = P.B ^ 0x000000000000000a;
-        QC = P.C ^ 0x000000000000000f;
+        BitBoard rookSq = QBBoperations.LSB(((~P.A & ~P.B & P.C & ~P.D)) & 0x00000000000000FF);
+        BitBoard rookPos = 1UL << (int)rookSq;
+        rookPos = rookPos == 4 ? 0 : rookPos | 4;
+        ulong kingToSq = 2; //g1 in decimals
+        ulong kingIdx = 1; //g1 represented as index from h1..a1
+        BitBoard kingPos = fromsquare == kingIdx ? 0 : (1UL << fromsquare) | kingToSq;
+        BitBoard kingAndRooks = kingPos == rookPos ? 0 : kingPos | rookPos;
+        QA = P.A ^ kingPos;
+        QB = P.B ^ kingPos;
+        QC = P.C ^ kingAndRooks;
         QD = P.D;
-        //			Q.D &= 0xfffffffffffffff0;	// clear colour of e1,f1,g1,h1 (make white)
       }
+
       else if (thisMove.CastleLong)
       {
-        QA = P.A ^ 0x0000000000000028;
-        QB = P.B ^ 0x0000000000000028;
-        QC = P.C ^ 0x00000000000000b8;
+        BitBoard rookSq = QBBoperations.MSB(((~P.A & ~P.B & P.C & ~P.D)) & 0x00000000000000FF);
+        BitBoard rookPos = 1UL << (int)rookSq;
+        rookPos = rookPos == 16 ? 0 : rookPos | 16;
+        ulong kingToSq = 32; //c1 in decimals
+        ulong kingIdx = 5; //c1 represented as index from h1..a8
+        BitBoard kingPos = fromsquare == kingIdx ? 0 : (1UL << fromsquare) | kingToSq;
+        BitBoard kingAndRooks = kingPos == rookPos ? 0 : kingPos | rookPos;
+        QA = P.A ^ kingPos;
+        QB = P.B ^ kingPos;
+        QC = P.C ^ kingAndRooks;
         QD = P.D;
-        //			Q.D &= 0xffffffffffffff07;	// clear colour of a1,b1,c1,d1,e1 (make white)
       }
+
       else
       {
         // clear old and new square:  
@@ -483,36 +481,36 @@ namespace Ceres.Chess.MoveGen
     }
 
 
-    static void AddWhitePromotionsToListIfLegal(in MGPosition P, MGMoveList moves, 
+    static void AddWhitePromotionsToListIfLegal(in MGPosition P, MGMoveList moves,
                                                 byte fromsquare, BitBoard to, ulong piece, MGMove.MGChessMoveFlags flags = 0)
-   {
-    if (to != 0)
     {
-      moves.InsureMoveArrayHasRoom(4);
+      if (to != 0)
+      {
+        moves.InsureMoveArrayHasRoom(4);
 
-      ref MGMove thisMove = ref moves.MovesArray[moves.NumMovesUsed];
+        ref MGMove thisMove = ref moves.MovesArray[moves.NumMovesUsed];
 
-      thisMove.FromSquareIndex = fromsquare;
-      thisMove.ToSquareIndex = MGMoveGenFillFunctions.GetSquareIndex(to);
-      thisMove.Flags = flags;
-      thisMove.Piece = (MGPositionConstants.MCChessPositionPieceEnum)piece;
+        thisMove.FromSquareIndex = fromsquare;
+        thisMove.ToSquareIndex = MGMoveGenFillFunctions.GetSquareIndex(to);
+        thisMove.Flags = flags;
+        thisMove.Piece = (MGPositionConstants.MCChessPositionPieceEnum)piece;
 
-      BitBoard O = ~((1UL << fromsquare) | to);
+        BitBoard O = ~((1UL << fromsquare) | to);
 
-      // clear old and new square
-      BitBoard QA = P.A & O;
-      BitBoard QB = P.B & O;
-      BitBoard QC = P.C & O;
-      BitBoard QD = P.D & O;
+        // clear old and new square
+        BitBoard QA = P.A & O;
+        BitBoard QB = P.B & O;
+        BitBoard QC = P.C & O;
+        BitBoard QD = P.D & O;
 
-      // Populate new square with Queen:
-      QB |= to;
-      QC |= to;
-    // Q.D |= to;  (DJE) **** TO DO: This line is present in the black version, why was it not present here??? possibly this is correct?
+        // Populate new square with Queen:
+        QB |= to;
+        QC |= to;
+        // Q.D |= to;  (DJE) **** TO DO: This line is present in the black version, why was it not present here??? possibly this is correct?
 
-      // Test for capture:
-      BitBoard PAB = (P.A & P.B); // Bitboard containing EnPassants and kings:
-      moves.MovesArray[moves.NumMovesUsed].Capture = (to & P.D & ~PAB) != 0;
+        // Test for capture:
+        BitBoard PAB = (P.A & P.B); // Bitboard containing EnPassants and kings:
+        moves.MovesArray[moves.NumMovesUsed].Capture = (to & P.D & ~PAB) != 0;
 
         if (!IsWhiteInCheck(QA, QB, QC, QD))                   // Does proposed move put our (white) king in Check ?
         {
@@ -543,8 +541,8 @@ namespace Ceres.Chess.MoveGen
         }
         else
           moves.MovesArray[moves.NumMovesUsed].IllegalMove = true;
-        }
       }
+    }
 
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -647,21 +645,12 @@ namespace Ceres.Chess.MoveGen
                 square = MGPositionConstants.MoveRight[q] & blackFree;
                 AddBlackMoveToListIfLegal(in P, moves, q, square, MGPositionConstants.BKING);
 
-                bool isBlackInCheck = IsBlackInCheck(P.A, P.B, P.C, P.D);
-                BitBoard rookPos = ~P.A & ~P.B & P.C & P.D;
-
+                ulong rookSquare;
                 // Conditionally generate O-O move:
-                if (
-                  (currentSquare == MGPositionConstants.BLACKKINGPOS) &&          // King is in correct Position AND
-                  (P.BlackCanCastle) &&               // Black still has castle rights AND
-                  (MGPositionConstants.BLACKCASTLEZONE & occupied) == 0 &&        // Castle Zone (f8,g8) is clear	AND
-                  ((rookPos & MGPositionConstants.BLACKKRPOS) != 0) &&  // KRook is in correct Position AND
-                  (!moves.MovesArray[moves.NumMovesUsed].IllegalMove) &&          // Last generated move (1 step to right) was legal AND
-                  !isBlackInCheck                                                 // King is not in Check
-                  )
+                if (P.BlackCanCastle && QBBoperations.CanBlackKingReachShortRook(in P, out rookSquare))
                 {
                   // OK to Castle
-                  square = MGPositionConstants.G8; // Move King to g8
+                  square = rookSquare;
                   M.Flags = 0;
                   M.CastleShort = true;
                   AddBlackMoveToListIfLegal(in P, moves, q, square, MGPositionConstants.BKING, M.Flags);
@@ -673,18 +662,11 @@ namespace Ceres.Chess.MoveGen
                 square = MGPositionConstants.MoveLeft[q] & blackFree;
                 AddBlackMoveToListIfLegal(in P, moves, q, square, MGPositionConstants.BKING);
 
-                // Conditionally generate O-O-O move:
-                if (
-                  (currentSquare == MGPositionConstants.BLACKKINGPOS) &&        // King is in correct Position AND
-                  (P.BlackCanCastleLong) &&                                     // Black still has castle-long rights AND
-                  ((rookPos & MGPositionConstants.BLACKQRPOS) != 0) &&          // QRook is in correct Position AND
-                  (!moves.MovesArray[moves.NumMovesUsed].IllegalMove) &&        // Last generated move (1 step to left) was legal AND
-                  (MGPositionConstants.BLACKCASTLELONGZONE & occupied) == 0 &&  // Castle Long Zone (b8,c8,d8) is clear
-                  !isBlackInCheck                                               // King is not in Check
-                  )
+                // Conditionally generate O-O-O move:                
+                if (P.BlackCanCastleLong && QBBoperations.CanBlackKingReachLongRook(in P, out rookSquare))
                 {
                   // OK to castle Long
-                  square = MGPositionConstants.C8;                    // Move King to c8
+                  square = rookSquare;
                   M.Flags = 0;
                   M.CastleLong = true;
                   AddBlackMoveToListIfLegal(in P, moves, q, square, MGPositionConstants.BKING, M.Flags);
@@ -790,7 +772,7 @@ namespace Ceres.Chess.MoveGen
           break;
       } while (true);
 
-//      moves.MovesArray[0].MoveCount = (byte)moves.NumMovesUsed;
+      //      moves.MovesArray[0].MoveCount = (byte)moves.NumMovesUsed;
 
       // Create 'no more moves' move to mark end of list:	
       moves.MovesArray[moves.NumMovesUsed].FromSquareIndex = 0;
@@ -830,18 +812,33 @@ namespace Ceres.Chess.MoveGen
 
       if (thisMove.CastleShort)
       {
-        QA = P.A ^ 0x0a00000000000000;
-        QB = P.B ^ 0x0a00000000000000;
-        QC = P.C ^ 0x0f00000000000000;
-        QD = P.D ^ 0x0f00000000000000;
+        ulong kingToSq = 144115188075855872; //g8 in decimals
+        ulong kingIdx = 57; //g8 represented as index from h1..a8
+        BitBoard kingPos = fromsquare == kingIdx ? 0 : (1UL << fromsquare) | kingToSq;
+        BitBoard rookSq = QBBoperations.LSB((((~P.A & ~P.B & P.C) & P.D) & 0xFF00000000000000UL));
+        BitBoard rookPos = (1UL << (int)rookSq | 288230376151711744);
+        QA = P.A ^ kingPos;
+        QB = P.B ^ kingPos;
+        QC = P.C ^ (rookPos | kingPos);
+        QD = P.D ^ (rookPos | kingPos);
+        //			Q.D &= 0xfffffffffffffff0;	// clear colour of e1,f1,g1,h1 (make white)
       }
+
       else if (thisMove.CastleLong)
       {
-        QA = P.A ^ 0x2800000000000000;
-        QB = P.B ^ 0x2800000000000000;
-        QC = P.C ^ 0xb800000000000000;
-        QD = P.D ^ 0xb800000000000000;
+        ulong kingToSq = 2305843009213693952; //c8 in decimals
+        ulong kingIdx = 61; //c8 represented as index from h1..a8
+        BitBoard kingPos = fromsquare == kingIdx ? 0 : (1UL << fromsquare) | kingToSq;
+        BitBoard rookSq = QBBoperations.MSB((((~P.A & ~P.B & P.C) & P.D) & 0xFF00000000000000UL));
+        BitBoard rookPos = (1UL << (int)rookSq | 1152921504606846976);
+
+        QA = P.A ^ kingPos;
+        QB = P.B ^ kingPos;
+        QC = P.C ^ (rookPos | kingPos);
+        QD = P.D ^ (rookPos | kingPos);
+        //			Q.D &= 0xffffffffffffff07;	// clear colour of a1,b1,c1,d1,e1 (make white)
       }
+
       else
       {
         // clear old and new square  
@@ -895,7 +892,7 @@ namespace Ceres.Chess.MoveGen
     }
 
 
-    static void AddBlackPromotionsToListIfLegal(in MGPosition P, MGMoveList moves, byte fromsquare, BitBoard to, ulong piece, MGMove.MGChessMoveFlags flags=0)
+    static void AddBlackPromotionsToListIfLegal(in MGPosition P, MGMoveList moves, byte fromsquare, BitBoard to, ulong piece, MGMove.MGChessMoveFlags flags = 0)
     {
       if (to != 0)
       {
@@ -932,7 +929,7 @@ namespace Ceres.Chess.MoveGen
           // make an additional 3 copies for underpromotions
           moves.MovesArray[moves.NumMovesUsed + 1] = thisMove;
           moves.MovesArray[moves.NumMovesUsed + 2] = thisMove;
-          moves.MovesArray[moves.NumMovesUsed + 3] = thisMove; 
+          moves.MovesArray[moves.NumMovesUsed + 3] = thisMove;
 
           // set Promotion flags accordingly:
           moves.MovesArray[moves.NumMovesUsed].PromoteQueen = true;
@@ -945,7 +942,7 @@ namespace Ceres.Chess.MoveGen
             moves.MovesArray[moves.NumMovesUsed].Check = true;
 #endif
 #endif
-          
+
           moves.MovesArray[moves.NumMovesUsed + 1].PromoteRook = true;
           moves.MovesArray[moves.NumMovesUsed + 2].PromoteBishop = true;
           moves.MovesArray[moves.NumMovesUsed + 3].PromoteKnight = true;
@@ -1028,7 +1025,7 @@ namespace Ceres.Chess.MoveGen
     }
 
 
-    static bool IsWhiteInCheck(BitBoard ZA, BitBoard ZB, BitBoard ZC, BitBoard ZD)
+    internal static bool IsWhiteInCheck(BitBoard ZA, BitBoard ZB, BitBoard ZC, BitBoard ZD)
     {
       BitBoard ZAandZB = ZA & ZB;
       BitBoard WhiteKing = ZAandZB & ZC & ~ZD;
@@ -1057,7 +1054,7 @@ namespace Ceres.Chess.MoveGen
       return (X & WhiteKing) != 0;
     }
 
-    static bool IsBlackInCheck(BitBoard ZA, BitBoard ZB, BitBoard ZC, BitBoard ZD)
+    internal static bool IsBlackInCheck(BitBoard ZA, BitBoard ZB, BitBoard ZC, BitBoard ZD)
     {
       BitBoard ZAandZB = ZA & ZB;
 
@@ -1088,7 +1085,7 @@ namespace Ceres.Chess.MoveGen
 
     public static bool IsInCheck(in MGPosition P, bool bIsBlack)
     {
-      return bIsBlack ? IsBlackInCheck(P.A, P.B, P.C, P.D) 
+      return bIsBlack ? IsBlackInCheck(P.A, P.B, P.C, P.D)
                       : IsWhiteInCheck(P.A, P.B, P.C, P.D);
     }
 

--- a/src/Ceres.Chess/MoveGen/MGMoveGenTest.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveGenTest.cs
@@ -84,7 +84,7 @@ namespace Ceres.Chess.MoveGen.Test
       ulong castleCount = 0;
       ulong captures = 0;
       //add primitive timing with stopwatch
-      var sw = new Stopwatch();
+      Stopwatch sw = new Stopwatch();
       sw.Start();
       using (new TimingBlock("\n", TimingBlock.LoggingType.Console))
       {
@@ -94,17 +94,17 @@ namespace Ceres.Chess.MoveGen.Test
         PerftCollect(chessPos, depth, 1, null, ref moveCount, ref castleCount, ref captures);
       }
       sw.Stop();
-      var ms = sw.ElapsedMilliseconds;
+      long ms = sw.ElapsedMilliseconds;
       //sw.Reset();
-      var secs = ms / 1000.0; //nodes per second
-      var nps = moveCount / secs;
-      var cc = Console.ForegroundColor; //get current console color
+      double secs = ms / 1000.0; //nodes per second
+      double nps = moveCount / secs;
+      ConsoleColor cc = Console.ForegroundColor; //get current console color
       string msg = $"NPS = {nps.ToString("N0")}, Nodes = {moveCount.ToString("N0")} with {castleCount.ToString("N0")} castles and {captures.ToString("N0")} captures\n";
       if (moveCount != correctCount)
       {
         //write red color to console if failed
         Console.ForegroundColor = ConsoleColor.Red;
-        var board = MGChessPositionConverter.MGChessPositionFromFEN(fen);
+        MGPosition board = MGChessPositionConverter.MGChessPositionFromFEN(fen);
         string asciBoard = board.BoardString;
         Console.WriteLine(asciBoard);
         Console.WriteLine(" " + moveCount.ToString("N0") + " FAIL ");
@@ -126,7 +126,7 @@ namespace Ceres.Chess.MoveGen.Test
       MGPosition chessPos = MGChessPositionConverter.MGChessPositionFromFEN(fen);
       //chessPos.Dump();      
       ulong moveCount = 0;
-      var sw = new Stopwatch();
+      Stopwatch sw = new Stopwatch();
       sw.Start();
       using (new TimingBlock("Perft " + fen + " correct #" + correctCount))
       {
@@ -134,18 +134,18 @@ namespace Ceres.Chess.MoveGen.Test
         Perft(chessPos, depth, 1, null, ref moveCount);
       }
       sw.Stop();
-      var ms = sw.ElapsedMilliseconds;
+      double ms = sw.ElapsedMilliseconds;
       //nodes per second
-      var secs = ms / 1000.0;
-      var nps = moveCount / secs;
+      double secs = ms / 1000.0;
+      double nps = moveCount / secs;
       //get current console color
-      var cc = Console.ForegroundColor;
+      ConsoleColor cc = Console.ForegroundColor;
       if (moveCount != correctCount)
       {
         //write red color to console if failed
         Console.ForegroundColor = ConsoleColor.Red;
-        var board = MGChessPositionConverter.MGChessPositionFromFEN(fen);
-        var asciBoard = board.BoardString;
+        MGPosition board = MGChessPositionConverter.MGChessPositionFromFEN(fen);
+        string asciBoard = board.BoardString;
         Console.WriteLine(asciBoard);
         Console.WriteLine(" " + moveCount + " FAIL");
         Console.WriteLine(" " + nps.ToString("N0") + " NPS");
@@ -219,15 +219,15 @@ namespace Ceres.Chess.MoveGen.Test
     public static Chess960Record ParseChess960Record(string input)
     {
       //Console.WriteLine(input);
-      var parts = input.Split('\t');
-      var positionNumber = int.Parse(parts[0]);
-      var fen = parts[1];
-      var depth1 = long.Parse(parts[2]);
-      var depth2 = long.Parse(parts[3]);
-      var depth3 = long.Parse(parts[4]);
-      var depth4 = long.Parse(parts[5]);
-      var depth5 = long.Parse(parts[6]);
-      var depth6 = long.Parse(parts[7]);
+      string[] parts = input.Split('\t');
+      int positionNumber = int.Parse(parts[0]);
+      string fen = parts[1];
+      long depth1 = long.Parse(parts[2]);
+      long depth2 = long.Parse(parts[3]);
+      long depth3 = long.Parse(parts[4]);
+      long depth4 = long.Parse(parts[5]);
+      long depth5 = long.Parse(parts[6]);
+      long depth6 = long.Parse(parts[7]);
 
       return new Chess960Record
       {
@@ -244,15 +244,15 @@ namespace Ceres.Chess.MoveGen.Test
 
     public static Chess960Record[] ParseFile(string filePath)
     {
-      var lines = System.IO.File.ReadAllLines(filePath).Skip(1).ToArray();
-      var records = lines.Select(ParseChess960Record).ToArray();
+      string[] lines = System.IO.File.ReadAllLines(filePath).Skip(1).ToArray();
+      Chess960Record[] records = lines.Select(ParseChess960Record).ToArray();
       return records;
     }
 
     public static IEnumerable<Chess960Record> GetChess960Positions(int numberOfPositions)
     {
-      var positions = CHESS960PERFT_POS.Split(Environment.NewLine).Skip(1).Take(numberOfPositions).ToArray();
-      foreach (var line in positions)
+      string[] positions = CHESS960PERFT_POS.Split(Environment.NewLine).Skip(1).Take(numberOfPositions).ToArray();
+      foreach (string line in positions)
       {
         yield return ParseChess960Record(line);
       }
@@ -275,18 +275,18 @@ namespace Ceres.Chess.MoveGen.Test
 
     public static void RunChess960Verification(int depth, int numberOfPositions = 960)
     {
-      var records = GetChess960Positions(numberOfPositions); // tests.Skip(1).Select(ParseChess960Record).Take(numberOfPositions).ToArray();     
-      var ordered = records; //records.OrderBy(r => GetDepthValue(depth, r));
-      var npsStats = new List<double>();
+      IEnumerable<Chess960Record> records = GetChess960Positions(numberOfPositions); // tests.Skip(1).Select(ParseChess960Record).Take(numberOfPositions).ToArray();     
+      IEnumerable<Chess960Record> ordered = records; //records.OrderBy(r => GetDepthValue(depth, r));
+      List<double> npsStats = new List<double>();
       //var nodeStats = new List<long>();
-      foreach (var record in ordered)
+      foreach (Chess960Record record in ordered)
       {
         Console.WriteLine($"Position Number: {record.PositionNumber}");
-        var perftDepth = GetDepthValue(depth, record);
+        long perftDepth = GetDepthValue(depth, record);
         double nps = RunPerftWithStatsOnPosition(record.FEN, depth, (ulong)perftDepth);
         npsStats.Add(nps);
       }
-      var cc = Console.ForegroundColor;
+      ConsoleColor cc = Console.ForegroundColor;
       string finalStatsForAllPerftPositions = $"\nAverage NPS perft speed for {numberOfPositions} Chess960 positions at depth {depth} = {npsStats.Average().ToString("N0")}";
       Console.ForegroundColor = ConsoleColor.Green;
       Console.WriteLine(finalStatsForAllPerftPositions);
@@ -567,7 +567,7 @@ namespace Ceres.Chess.MoveGen.Test
         nodeCount += (ulong)movesThisDepth.NumMovesUsed;
         for (int i = 0; i < movesThisDepth.NumMovesUsed; i++)
         {
-          var m = movesThisDepth.MovesArray[i];
+          MGMove m = movesThisDepth.MovesArray[i];
           if (m.IsCastle)
             castleCount++;
           if (m.Capture)
@@ -630,7 +630,7 @@ namespace Ceres.Chess.MoveGen.Test
         for (int i = 0; i < movesThisDepth.NumMovesUsed; i++)
         {
           MGPosition Q = new MGPosition(P);
-          var m = movesThisDepth.MovesArray[i];
+          MGMove m = movesThisDepth.MovesArray[i];
           Q.MakeMove(m);
 
 #if MG_USE_HASH

--- a/src/Ceres.Chess/MoveGen/MGMoveGenTest.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveGenTest.cs
@@ -1,0 +1,1634 @@
+﻿#region Using directives
+
+//using BenchmarkDotNet.Environments;
+//using DJE.Base;
+using Ceres.Base;
+using Ceres.Base.Benchmarking;
+using Ceres.Chess.EncodedPositions.Basic;
+using Ceres.Chess.MoveGen.Converters;
+using Ceres.Chess.Textual.PgnFileTools;
+using Microsoft.FSharp.Data.UnitSystems.SI.UnitNames;
+using SharpCompress.Common;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+
+
+#endregion
+
+#region License
+/*
+
+MIT License
+
+Copyright(c) 2016-2017 Judd Niemann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#endregion
+
+using BitBoard = System.UInt64;
+//typedef uint64_t BitBoard;
+// typedef uint64_t HashKey;
+
+
+namespace Ceres.Chess.MoveGen.Test
+{
+
+  public static class MGMoveGenTest
+  {
+
+#if NOT
+    	// see https://chessprogramming.wikispaces.com/perft+Results
+
+#endif
+    static int RAND = 33;
+
+    // --------------------------------------------------------------------------------------------
+    public static ulong CalcPerftOnPosition(string fen, int depth)
+    {
+      MGPosition chessPos = MGChessPositionConverter.MGChessPositionFromFEN(fen);
+
+      ulong moveCount = 0;
+      Perft(chessPos, depth, 1, null, ref moveCount);
+      return moveCount;
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    public static double RunPerftWithStatsOnPosition(string fen, int depth, ulong correctCount)
+    {
+      Console.Write("\r\n" + fen);
+      MGPosition chessPos = MGChessPositionConverter.MGChessPositionFromFEN(fen);
+      ulong moveCount = 0;
+      ulong castleCount = 0;
+      ulong captures = 0;
+      //add primitive timing with stopwatch
+      var sw = new Stopwatch();
+      sw.Start();
+      using (new TimingBlock("\n", TimingBlock.LoggingType.Console))
+      {
+        moveCount = 0;
+        castleCount = 0;
+        captures = 0;
+        PerftCollect(chessPos, depth, 1, null, ref moveCount, ref castleCount, ref captures);
+      }
+      sw.Stop();
+      var ms = sw.ElapsedMilliseconds;
+      //sw.Reset();
+      var secs = ms / 1000.0; //nodes per second
+      var nps = moveCount / secs;
+      var cc = Console.ForegroundColor; //get current console color
+      string msg = $"NPS = {nps.ToString("N0")}, Nodes = {moveCount.ToString("N0")} with {castleCount.ToString("N0")} castles and {captures.ToString("N0")} captures\n";
+      if (moveCount != correctCount)
+      {
+        //write red color to console if failed
+        Console.ForegroundColor = ConsoleColor.Red;
+        var board = MGChessPositionConverter.MGChessPositionFromFEN(fen);
+        string asciBoard = board.BoardString;
+        Console.WriteLine(asciBoard);
+        Console.WriteLine(" " + moveCount.ToString("N0") + " FAIL ");
+        Console.WriteLine(msg);
+      }
+      else
+      {
+        Console.ForegroundColor = ConsoleColor.Green;
+        //Console.WriteLine(" " + moveCount.ToString("N0") + " SUCCESS ");
+        Console.WriteLine("\nSuccess: " + msg);
+      }
+      Console.ForegroundColor = cc;
+      return nps;
+    }
+
+    public static void RunPerftOnPosition(string fen, int depth, ulong correctCount)
+    {
+      Console.Write("\r\n" + fen);
+      MGPosition chessPos = MGChessPositionConverter.MGChessPositionFromFEN(fen);
+      //chessPos.Dump();      
+      ulong moveCount = 0;
+      var sw = new Stopwatch();
+      sw.Start();
+      using (new TimingBlock("Perft " + fen + " correct #" + correctCount))
+      {
+        moveCount = 0;
+        Perft(chessPos, depth, 1, null, ref moveCount);
+      }
+      sw.Stop();
+      var ms = sw.ElapsedMilliseconds;
+      //nodes per second
+      var secs = ms / 1000.0;
+      var nps = moveCount / secs;
+      //get current console color
+      var cc = Console.ForegroundColor;
+      if (moveCount != correctCount)
+      {
+        //write red color to console if failed
+        Console.ForegroundColor = ConsoleColor.Red;
+        var board = MGChessPositionConverter.MGChessPositionFromFEN(fen);
+        var asciBoard = board.BoardString;
+        Console.WriteLine(asciBoard);
+        Console.WriteLine(" " + moveCount + " FAIL");
+        Console.WriteLine(" " + nps.ToString("N0") + " NPS");
+      }
+      else
+      {
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine(" " + moveCount + " SUCCESS ");
+        Console.WriteLine(" " + nps.ToString("N0") + " NPS");
+      }
+      Console.ForegroundColor = cc;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    static void TestConvertPerformance()
+    {
+      Position posCompressedFromFEN = Position.FromFEN("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+
+      MGPosition mgPosFromPosCompressed = default;
+      using (new TimingBlock("FromPositionCompressed"))
+      {
+        for (int i = 0; i < 1_000_000; i++)
+        {
+          mgPosFromPosCompressed = MGPosition.FromPosition(in posCompressedFromFEN);
+        }
+      }
+
+      Position posCompressedFromMGPos1 = default;
+      using (new TimingBlock("AsPositionCompressed"))
+      {
+        for (int i = 0; i < 1_000_000; i++)
+        {
+          posCompressedFromMGPos1 = mgPosFromPosCompressed.ToPosition;
+        }
+      }
+
+#if NOT
+      using (new TimingBlock("PieceAt"))
+      {
+        for (int i = 0; i < 1_000_000; i++)
+        {
+          for (int j = 0; j < 64; j++)
+          {
+            var pa = MGChessPositionConverter.PieceAt(mgPosFromPosCompressed, j);
+            if ((byte)pa.Type > 222) throw new NotImplementedException();
+//            var pa1 = posCompressedFromMGPos1[new Square(j)];
+//            if ((byte)pa1.Kind > 222) throw new NotImplementedException();
+          }
+        }
+      }
+#endif
+
+
+    }
+
+
+    static ulong HASH_COLLISIONS = 0;
+    // --------------------------------------------------------------------------------------------
+    public class Chess960Record
+    {
+      public int PositionNumber { get; set; }
+      public string FEN { get; set; }
+      public long Depth1 { get; set; }
+      public long Depth2 { get; set; }
+      public long Depth3 { get; set; }
+      public long Depth4 { get; set; }
+      public long Depth5 { get; set; }
+      public long Depth6 { get; set; }
+    }
+
+    public static Chess960Record ParseChess960Record(string input)
+    {
+      //Console.WriteLine(input);
+      var parts = input.Split('\t');
+      var positionNumber = int.Parse(parts[0]);
+      var fen = parts[1];
+      var depth1 = long.Parse(parts[2]);
+      var depth2 = long.Parse(parts[3]);
+      var depth3 = long.Parse(parts[4]);
+      var depth4 = long.Parse(parts[5]);
+      var depth5 = long.Parse(parts[6]);
+      var depth6 = long.Parse(parts[7]);
+
+      return new Chess960Record
+      {
+        PositionNumber = positionNumber,
+        FEN = fen,
+        Depth1 = depth1,
+        Depth2 = depth2,
+        Depth3 = depth3,
+        Depth4 = depth4,
+        Depth5 = depth5,
+        Depth6 = depth6
+      };
+    }
+
+    public static Chess960Record[] ParseFile(string filePath)
+    {
+      var lines = System.IO.File.ReadAllLines(filePath).Skip(1).ToArray();
+      var records = lines.Select(ParseChess960Record).ToArray();
+      return records;
+    }
+
+    public static IEnumerable<Chess960Record> GetChess960Positions(int numberOfPositions)
+    {
+      var positions = CHESS960PERFT_POS.Split(Environment.NewLine).Skip(1).Take(numberOfPositions).ToArray();
+      foreach (var line in positions)
+      {
+        yield return ParseChess960Record(line);
+      }
+    }
+
+    public static long GetDepthValue(int depth, Chess960Record record)
+    {
+      return depth switch
+      {
+        1 => record.Depth1,
+        2 => record.Depth2,
+        3 => record.Depth3,
+        4 => record.Depth4,
+        5 => record.Depth5,
+        6 => record.Depth6,
+        _ => throw new NotImplementedException($"Depth {depth} is not implemented.")
+      };
+    }
+
+
+    public static void RunChess960Verification(int depth, int numberOfPositions = 960)
+    {
+      var records = GetChess960Positions(numberOfPositions); // tests.Skip(1).Select(ParseChess960Record).Take(numberOfPositions).ToArray();     
+      var ordered = records; //records.OrderBy(r => GetDepthValue(depth, r));
+      var npsStats = new List<double>();
+      //var nodeStats = new List<long>();
+      foreach (var record in ordered)
+      {
+        Console.WriteLine($"Position Number: {record.PositionNumber}");
+        var perftDepth = GetDepthValue(depth, record);
+        double nps = RunPerftWithStatsOnPosition(record.FEN, depth, (ulong)perftDepth);
+        npsStats.Add(nps);
+      }
+      var cc = Console.ForegroundColor;
+      string finalStatsForAllPerftPositions = $"\nAverage NPS perft speed for {numberOfPositions} Chess960 positions at depth {depth} = {npsStats.Average().ToString("N0")}";
+      Console.ForegroundColor = ConsoleColor.Green;
+      Console.WriteLine(finalStatsForAllPerftPositions);
+      Console.ForegroundColor = cc;
+    }
+
+    public static void RunChessPerftTestPositions()
+    {
+      RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 3, 8_902);        // Position 1: Initial Position
+      RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 5, 4_865_609);        // Position 1: Initial Position
+      RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 6, 119_060_324);        // Position 1: Initial Position
+      RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1", 5, 9_771_632);     // DJE test (initial position after e4, test en passant)
+      RunPerftWithStatsOnPosition("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8", 5, 89_941_194);       // Position 5
+      RunPerftWithStatsOnPosition("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", 6, 706_045_033);   // Position 4
+      RunPerftWithStatsOnPosition("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 25", 5, 193_690_690);  // Position 2: 'Kiwipete' position
+      RunPerftWithStatsOnPosition("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 0", 7, 178_633_661);                // Position 3
+      RunPerftWithStatsOnPosition("r2q1rk1/pP1p2pp/Q4n2/bbp1p3/Np6/1B3NBn/pPPP1PPP/R3K2R b KQ - 0 1", 6, 706_045_033);   // Position 4 Mirrored (should be same score as previous)
+      RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 7, 3_195_901_860);        // Position 1: Initial Position
+    }
+
+    public static void RunPerftSuite()
+    {
+      RunChess960Verification(4, 10);
+      Console.WriteLine("Running PERFT Test Suite\n\n");
+
+      if (false)
+      {
+        // These copied from QBB-Perft project on github
+        // which has very fast move generator.
+
+        //RunPerftOnPosition("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 6, 119060324); //Start Position
+        RunPerftOnPosition("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1", 2, 2039);
+        RunPerftOnPosition("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1", 7, 178633661);
+        RunPerftOnPosition("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", 6, 706045033);
+        RunPerftOnPosition("rnbqkb1r/pp1p1ppp/2p5/4P3/2B5/8/PPP1NnPP/RNBQK2R w KQkq - 0 6", 3, 53392);
+        RunPerftOnPosition("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", 5, 164075551);
+      }
+      //RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 3, 8_902);        // Position 1: Initial Position
+      //RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 5, 4_865_609);        // Position 1: Initial Position
+      //RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 6, 119_060_324);        // Position 1: Initial Position
+      //RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1", 5, 9_771_632);     // DJE test (initial position after e4, test en passant)
+
+      //RunPerftWithStatsOnPosition("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8", 5, 89_941_194);       // Position 5
+      //RunPerftWithStatsOnPosition("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", 6, 706_045_033);   // Position 4
+      //RunPerftWithStatsOnPosition("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 25", 5, 193_690_690);  // Position 2: 'Kiwipete' position
+      //RunPerftWithStatsOnPosition("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 0", 7, 178_633_661);                // Position 3
+      //System.Environment.Exit(3);
+
+      //RunPerftWithStatsOnPosition("r2q1rk1/pP1p2pp/Q4n2/bbp1p3/Np6/1B3NBn/pPPP1PPP/R3K2R b KQ - 0 1", 6, 706_045_033);   // Position 4 Mirrored (should be same score as previous)
+      //RunPerftWithStatsOnPosition("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 7, 3_195_901_860);        // Position 1: Initial Position
+      // too slow dumpPerftScoreFfromFEN("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", 7, 287188994746); // Position 6 28/1/2016: Correct (took 8_454_195 ms)
+
+    }
+
+    // --------------------------------------------------------------------------------------------
+    static void MovegenTest()
+    {
+      // NOTE: speed seems about 1,000,000 per second per CPU
+      const int NUM_POS = 100_000;
+      MGPosition mp = MGChessPositionConverter.MGChessPositionFromFEN(Position.StartPosition.FEN);
+
+      MGMoveList moves = new MGMoveList();
+      using (new TimingBlock("GenerateMoves " + NUM_POS))
+      {
+        for (int i = 0; i < NUM_POS; i++)
+        {
+          moves.Clear();
+          MGMoveGen.GenerateMoves(mp, moves);
+          //        if (MGMoveGen.IsInCheck(mp, false))
+          //          throw new Exception("bad");
+        }
+      }
+
+    }
+
+
+    // --------------------------------------------------------------------------------------------
+    // Single core, June 2019
+    // 3_195_901_860 perft(7) in 150 seconds
+    //   119_060_324 perft(6) in 6 seconds
+    //     4_865_609 perft(5) in 0.24 seconds
+    public static void Test()
+    {
+      RunPerftSuite();
+      return;
+
+      TestConvertPerformance();
+      TestConvertPerformance();
+      TestConvertPerformance();
+      System.Environment.Exit(3);
+
+      string pgnName = @"Z:\chess\data\pgn\raw\ficsgamesdb_2011_standard_nomovetimes_1506667.pgn"; // 9GB
+#if NOT
+      string[] fens = PGNEnumerator.GetFENSOfFirstMatchingPositionInGame(pgnName, 1000, p => true);
+
+      int count = 0;
+      DateTime lastTime = default;
+      PGNEnumerator.ProcessGamesFromFile(pgnName,
+   ( gameIndex, plyWithinGame,  totalPlyCount,   posSF) =>
+   {
+     // TO DO: See FENFromBitboard for ideas of how to do reverse operation
+     //Console.WriteLine(pos.BoardPicture);
+
+     string inFEN = posSF.fen();
+     string outFEN = null;
+
+     PositionCompressed pos;
+     try
+     {
+       count++;
+       pos = MGChessPositionConverter.PositionCompressedFromMGChessPosition(MGChessPositionConverter.MGChessPositionFromFEN(inFEN));
+       outFEN = FENGenerator.GetFEN(pos);
+       if (++count % 10_000 == 0)
+       {
+         if (lastTime != default(DateTime))
+           Console.WriteLine($" {inFEN} {count} {(DateTime.Now - lastTime).TotalSeconds} {System.GC.CollectionCount(0) } { System.GC.GetAllocatedBytesForCurrentThread() / 1_000_000}");
+         lastTime = DateTime.Now;
+       }
+     }
+     catch (Exception e)
+     {
+       Console.WriteLine(e);
+     }
+     if (inFEN != outFEN)
+     {
+       Console.WriteLine();
+       Console.WriteLine(inFEN);
+       Console.WriteLine(outFEN);
+     }
+//     else
+//       Console.Write('.');
+     return false; // do not exit
+
+   }
+  );
+#endif
+      return;
+
+
+      // DOCUMENTATION STRUCTS
+      // https://docs.microsoft.com/en-us/dotnet/csharp/write-safe-efficient-code
+
+      System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.AboveNormal;
+      MGPosition startpos = new MGPosition();
+      startpos.A = 5404038077867949898;
+      startpos.B = 4323455642275676220;
+      startpos.C = 15780613094306218203;
+      startpos.D = 18446462598732840960;
+      startpos.Flags = (MGPosition.FlagsEnum)30;
+      startpos.MoveNumber = 1;
+      //startpos.HalfMoves = 0;
+      //startpos.material = 0;
+
+      if (true)
+      {
+        const int DEPTH = 5; // was 6 (or 5)
+        ulong moveCount = 0;
+        Perft(startpos, DEPTH, 1, null, ref moveCount);
+        using (new TimingBlock("Perft"))
+        {
+          if (false)
+          {
+            moveCount = 0;
+            Perft(startpos, DEPTH, 1, null, ref moveCount);
+            moveCount = 0;
+            Perft(startpos, DEPTH, 1, null, ref moveCount);
+          }
+          moveCount = 0;
+          Perft(startpos, DEPTH, 1, null, ref moveCount);
+          Console.WriteLine(moveCount);
+        }
+        return;
+      }
+
+
+      MGPosition bug = new MGPosition();
+      bug.A = 5404038077868277576;
+      bug.B = 4323455642275676220;
+      bug.C = 15780613094306545881;
+      bug.D = 18446462598732840960;
+      bug.Flags = (MGPosition.FlagsEnum)30;
+      bug.Dump();
+
+      const int MOVELIST_SIZE = 128;
+
+      MGMoveList moves = new MGMoveList(128);
+
+      for (int j = 0; j < 2; j++)
+        using (new TimingBlock("ChessMove"))
+        {
+          for (int i = 0; i < 1_000_000; i++)
+          {
+            moves.NumMovesUsed = 0;
+            moves.MovesArray[0].Flags = 0;
+
+            MGMoveGen.GenerateMoves(bug, moves);
+          }
+        }
+
+      Console.WriteLine("Num generated: " + moves.NumMovesUsed);
+
+      for (int i = 0; i < moves.NumMovesUsed; i++)
+        Console.WriteLine(i + ": " + moves.MovesArray[i].MoveStr(MGMoveNotationStyle.CoOrdinate) + " " + moves.MovesArray[i].FromSquareIndex + " " + moves.MovesArray[i].ToSquareIndex + " " + moves.MovesArray[i].Flags);
+      System.Environment.Exit(3);
+
+
+
+      MGPosition moveBlack = new MGPosition();
+      moveBlack.A = 351289571361211392;
+      moveBlack.B = 1441714830716174624;
+      moveBlack.C = 1441151949483016224;
+      moveBlack.D = 1504765229790396416;
+      moveBlack.BlackToMove = true;
+
+      MGPosition promoteBlack = new MGPosition();
+      promoteBlack.A = 351289571361211904;
+      promoteBlack.B = 1441714830716174624;
+      promoteBlack.C = 1441151949483016224;
+      promoteBlack.D = 1504765229790396928;
+      promoteBlack.BlackToMove = true;
+
+
+      RAND = new Random().Next();
+
+      BitBoard bax1 = (ulong)RAND;
+      BitBoard bax2 = (ulong)new Random().Next();
+      BitBoard bax0 = (ulong)new Random().Next();
+
+      // This takes 2.5 seconds for 100,000,000 in C++
+      // Takes about 3.0 seconds in C#
+      // ChessPositionMoveGen.isWhiteInCheck(startpos))
+
+      if (false)
+      {
+        int zz = 0;
+        for (int j = 0; j < 2; j++)
+          using (new TimingBlock("ChessMove"))
+          {
+            for (int i = 0; i < 100_000_000; i++)
+            {
+              //              if (ChessPositionMoveGen.isWhiteInCheck(startpos)) return;
+#if NOT
+              ChessMove cdd = new ChessMove();
+              cdd.Piece = 3;
+              cdd.Castle = true;
+              cdd.MoveCount = 12;
+              Funky(cdd);
+              if ((cdd.Castle ? 1 : 0) + cdd.Piece + cdd.MoveCount != RAND) zz++;
+              if (!cdd.Castle) return;
+              if (cdd.MoveCount == 4) return;
+#endif
+            }
+            //Console.WriteLine(zz);
+            //Debug.Assert((int)cdd.Flags == 204472352);
+          }
+      }
+
+      return;
+
+      //      Debug.Assert(!ChessPositionMoveGen.isWhiteInCheck(startpos));
+      //      Debug.Assert(!ChessPositionMoveGen.isBlackInCheck(startpos));
+
+    }
+
+    static Dictionary<ulong, MGPosition> hashtable = new Dictionary<ulong, MGPosition>();
+
+    const bool TRACK_HASH = true;
+
+    static void PerftCollect(in MGPosition P, int maxdepth, int depth, MGMoveList movesThisDepth, ref ulong nodeCount, ref ulong castleCount, ref ulong captures)
+    {
+      if (movesThisDepth == null) movesThisDepth = new MGMoveList(128);
+      movesThisDepth.NumMovesUsed = 0;
+
+      MGMoveGen.GenerateMoves(in P, movesThisDepth);
+
+      if (depth == maxdepth)
+      {
+        nodeCount += (ulong)movesThisDepth.NumMovesUsed;
+        for (int i = 0; i < movesThisDepth.NumMovesUsed; i++)
+        {
+          var m = movesThisDepth.MovesArray[i];
+          if (m.IsCastle)
+            castleCount++;
+          if (m.Capture)
+            captures++;
+          if (m.EnPassantCapture)
+            captures++;
+        }
+      }
+      else if (depth < maxdepth)
+      {
+        MGMoveList movesNextDepth = new MGMoveList(128);
+        for (int i = 0; i < movesThisDepth.NumMovesUsed; i++)
+        {
+          MGMove m = movesThisDepth.MovesArray[i];
+          MGPosition Q = new MGPosition(P);
+          Q.MakeMove(m);
+          PerftCollect(in Q, maxdepth, depth + 1, movesNextDepth, ref nodeCount, ref castleCount, ref captures);
+        }
+      }
+    }
+
+    static ulong Perft(in MGPosition P, int maxdepth, int depth, MGMoveList movesThisDepth, ref ulong nodecount)
+    {
+      if (movesThisDepth == null) movesThisDepth = new MGMoveList(128);
+      movesThisDepth.NumMovesUsed = 0;
+
+
+      MGMoveGen.GenerateMoves(in P, movesThisDepth);
+      if (false)
+      {
+        Console.WriteLine(depth + " " + movesThisDepth.NumMovesUsed);
+        P.Dump();
+        Console.WriteLine(" " + P.A);
+        Console.WriteLine(" " + P.B);
+        Console.WriteLine(" " + P.C);
+        Console.WriteLine(" " + P.D);
+        Console.WriteLine(" " + P.Flags);
+        Console.WriteLine();
+      }
+
+      if (depth == maxdepth)
+      {
+        nodecount += (ulong)movesThisDepth.NumMovesUsed;
+#if MG_USE_HASH
+        if (TRACK_HASH)
+        {
+          if (hashtable.ContainsKey(P.HK))
+          {
+            if (hashtable[P.HK] != P)
+              HASH_COLLISIONS++;
+          }
+          hashtable[P.HK] = P;
+        }
+#endif
+      }
+      else
+      {
+        MGMoveList movesNextDepth = new MGMoveList(128);
+        //nodecount += (ulong)movesThisDepth.NumMovesUsed;
+        for (int i = 0; i < movesThisDepth.NumMovesUsed; i++)
+        {
+          MGPosition Q = new MGPosition(P);
+          var m = movesThisDepth.MovesArray[i];
+          Q.MakeMove(m);
+
+#if MG_USE_HASH
+          if (false)
+          {
+//            if (i == 0) Console.WriteLine();
+            //// ---------------------------------------------------
+            //// Do this to trap bugs with incremental Hash updates:
+            MGChessPosition Q2 = Q;
+            Q2.CalculateHash();
+
+            if (Q2.HK != Q.HK)
+            {
+              Console.WriteLine("\r\nbad " + movesThisDepth.MovesArray[i]);
+              Q.Dump();
+              Q2.Dump();
+              Console.WriteLine();
+            }
+//            else
+//              Console.WriteLine("ok " + movesThisDepth.Moves[i].MoveStr());
+            //// ---------------------------------------------------
+          }
+#endif
+
+          Perft(in Q, maxdepth, depth + 1, movesNextDepth, ref nodecount);//, pI);
+        }
+        //Q = P; // unmake move
+      }
+
+      return nodecount;
+    }
+
+    // Standard Chess960 test positions.
+    static readonly string CHESS960PERFT_POS = """
+       #	Position	Shredder-FEN	Depth1	Depth2	Depth3	Depth4	Depth5	Depth6
+       1	bqnb1rkr/pp3ppp/3ppn2/2p5/5P2/P2P4/NPP1P1PP/BQ1BNRKR w HFhf - 2 9	21	528	12189	326672	8146062	227689589
+       2	2nnrbkr/p1qppppp/8/1ppb4/6PP/3PP3/PPP2P2/BQNNRBKR w HEhe - 1 9	21	807	18002	667366	16253601	590751109
+       3	b1q1rrkb/pppppppp/3nn3/8/P7/1PPP4/4PPPP/BQNNRKRB w GE - 1 9	20	479	10471	273318	6417013	177654692
+       4	qbbnnrkr/2pp2pp/p7/1p2pp2/8/P3PP2/1PPP1KPP/QBBNNR1R w hf - 0 9	22	593	13440	382958	9183776	274103539
+       5	1nbbnrkr/p1p1ppp1/3p4/1p3P1p/3Pq2P/8/PPP1P1P1/QNBBNRKR w HFhf - 0 9	28	1120	31058	1171749	34030312	1250970898
+       6	qnbnr1kr/ppp1b1pp/4p3/3p1p2/8/2NPP3/PPP1BPPP/QNB1R1KR w HEhe - 1 9	29	899	26578	824055	24851983	775718317
+       7	q1bnrkr1/ppppp2p/2n2p2/4b1p1/2NP4/8/PPP1PPPP/QNB1RRKB w ge - 1 9	30	860	24566	732757	21093346	649209803
+       8	qbn1brkr/ppp1p1p1/2n4p/3p1p2/P7/6PP/QPPPPP2/1BNNBRKR w HFhf - 0 9	25	635	17054	465806	13203304	377184252
+       9	qnnbbrkr/1p2ppp1/2pp3p/p7/1P5P/2NP4/P1P1PPP1/Q1NBBRKR w HFhf - 0 9	24	572	15243	384260	11110203	293989890
+       10	qn1rbbkr/ppp2p1p/1n1pp1p1/8/3P4/P6P/1PP1PPPK/QNNRBB1R w hd - 2 9	28	811	23175	679699	19836606	594527992
+       11	qnr1bkrb/pppp2pp/3np3/5p2/8/P2P2P1/NPP1PP1P/QN1RBKRB w GDg - 3 9	33	823	26895	713420	23114629	646390782
+       12	qb1nrkbr/1pppp1p1/1n3p2/p1B4p/8/3P1P1P/PPP1P1P1/QBNNRK1R w HEhe - 0 9	31	855	25620	735703	21796206	651054626
+       13	qnnbrk1r/1p1ppbpp/2p5/p4p2/2NP3P/8/PPP1PPP1/Q1NBRKBR w HEhe - 0 9	26	790	21238	642367	17819770	544866674
+       14	1qnrkbbr/1pppppp1/p1n4p/8/P7/1P1N1P2/2PPP1PP/QN1RKBBR w HDhd - 0 9	37	883	32187	815535	29370838	783201510
+       15	qn1rkrbb/pp1p1ppp/2p1p3/3n4/4P2P/2NP4/PPP2PP1/Q1NRKRBB w FDfd - 1 9	24	585	14769	356950	9482310	233468620
+       16	bb1qnrkr/pp1p1pp1/1np1p3/4N2p/8/1P4P1/P1PPPP1P/BBNQ1RKR w HFhf - 0 9	29	864	25747	799727	24219627	776836316
+       17	bnqbnr1r/p1p1ppkp/3p4/1p4p1/P7/3NP2P/1PPP1PP1/BNQB1RKR w HF - 0 9	26	889	24353	832956	23701014	809194268
+       18	bnqnrbkr/1pp2pp1/p7/3pP2p/4P1P1/8/PPPP3P/BNQNRBKR w HEhe d6 0 9	31	984	28677	962591	29032175	1008880643
+       19	b1qnrrkb/ppp1pp1p/n2p1Pp1/8/8/P7/1PPPP1PP/BNQNRKRB w GE - 0 9	20	484	10532	281606	6718715	193594729
+       20	n1bqnrkr/pp1ppp1p/2p5/6p1/2P2b2/PN6/1PNPPPPP/1BBQ1RKR w HFhf - 2 9	23	732	17746	558191	14481581	457140569
+       21	n1bb1rkr/qpnppppp/2p5/p7/P1P5/5P2/1P1PPRPP/NQBBN1KR w Hhf - 1 9	27	697	18724	505089	14226907	400942568
+       22	nqb1rbkr/pppppp1p/4n3/6p1/4P3/1NP4P/PP1P1PP1/1QBNRBKR w HEhe - 1 9	28	641	18811	456916	13780398	354122358
+       23	n1bnrrkb/pp1pp2p/2p2p2/6p1/5B2/3P4/PPP1PPPP/NQ1NRKRB w GE - 2 9	28	606	16883	381646	10815324	254026570
+       24	nbqnbrkr/2ppp1p1/pp3p1p/8/4N2P/1N6/PPPPPPP1/1BQ1BRKR w HFhf - 0 9	26	626	17268	437525	12719546	339132046
+       25	nq1bbrkr/pp2nppp/2pp4/4p3/1PP1P3/1B6/P2P1PPP/NQN1BRKR w HFhf - 2 9	21	504	11812	302230	7697880	207028745
+       26	nqnrb1kr/2pp1ppp/1p1bp3/p1B5/5P2/3N4/PPPPP1PP/NQ1R1BKR w HDhd - 0 9	30	672	19307	465317	13454573	345445468
+       27	nqn2krb/p1prpppp/1pbp4/7P/5P2/8/PPPPPKP1/NQNRB1RB w g - 3 9	21	461	10608	248069	6194124	152861936
+       28	nb1n1kbr/ppp1rppp/3pq3/P3p3/8/4P3/1PPPRPPP/NBQN1KBR w Hh - 1 9	19	566	11786	358337	8047916	249171636
+       29	nqnbrkbr/1ppppp1p/p7/6p1/6P1/P6P/1PPPPP2/NQNBRKBR w HEhe - 1 9	20	382	8694	187263	4708975	112278808
+       30	nq1rkb1r/pp1pp1pp/1n2bp1B/2p5/8/5P1P/PPPPP1P1/NQNRKB1R w HDhd - 2 9	24	809	20090	673811	17647882	593457788
+       31	nqnrkrb1/pppppp2/7p/4b1p1/8/PN1NP3/1PPP1PPP/1Q1RKRBB w FDfd - 1 9	26	683	18102	473911	13055173	352398011
+       32	bb1nqrkr/1pp1ppp1/pn5p/3p4/8/P2NNP2/1PPPP1PP/BB2QRKR w HFhf - 0 9	29	695	21193	552634	17454857	483785639
+       33	bnn1qrkr/pp1ppp1p/2p5/b3Q1p1/8/5P1P/PPPPP1P1/BNNB1RKR w HFhf - 2 9	44	920	35830	795317	29742670	702867204
+       34	bnnqrbkr/pp1p2p1/2p1p2p/5p2/1P5P/1R6/P1PPPPP1/BNNQRBK1 w Ehe - 0 9	33	1022	32724	1024721	32898113	1047360456
+       35	b1nqrkrb/2pppppp/p7/1P6/1n6/P4P2/1P1PP1PP/BNNQRKRB w GEge - 0 9	23	638	15744	446539	11735969	344211589
+       36	n1bnqrkr/3ppppp/1p6/pNp1b3/2P3P1/8/PP1PPP1P/NBB1QRKR w HFhf - 1 9	29	728	20768	532084	15621236	415766465
+       37	n2bqrkr/p1p1pppp/1pn5/3p1b2/P6P/1NP5/1P1PPPP1/1NBBQRKR w HFhf - 3 9	20	533	12152	325059	8088751	223068417
+       38	nnbqrbkr/1pp1p1p1/p2p4/5p1p/2P1P3/N7/PPQP1PPP/N1B1RBKR w HEhe - 0 9	27	619	18098	444421	13755384	357222394
+       39	nnbqrkr1/pp1pp2p/2p2b2/5pp1/1P5P/4P1P1/P1PP1P2/NNBQRKRB w GEge - 1 9	32	1046	33721	1111186	36218182	1202830851
+       40	nb1qbrkr/p1pppp2/1p1n2pp/8/1P6/2PN3P/P2PPPP1/NB1QBRKR w HFhf - 0 9	25	521	14021	306427	8697700	201455191
+       41	nnq1brkr/pp1pppp1/8/2p4P/8/5K2/PPPbPP1P/NNQBBR1R w hf - 0 9	23	724	18263	571072	15338230	484638597
+       42	nnqrbb1r/pppppk2/5pp1/7p/1P6/3P2PP/P1P1PP2/NNQRBBKR w HD - 0 9	30	717	21945	547145	17166700	450069742
+       43	nnqr1krb/p1p1pppp/2bp4/8/1p1P4/4P3/PPP2PPP/NNQRBKRB w GDgd - 0 9	25	873	20796	728628	18162741	641708630
+       44	nbnqrkbr/p2ppp2/1p4p1/2p4p/3P3P/3N4/PPP1PPPR/NB1QRKB1 w Ehe - 0 9	24	589	15190	382317	10630667	279474189
+       45	n1qbrkbr/p1ppp2p/2n2pp1/1p6/1P6/2P3P1/P2PPP1P/NNQBRKBR w HEhe - 0 9	22	592	14269	401976	10356818	301583306
+       46	2qrkbbr/ppn1pppp/n1p5/3p4/5P2/P1PP4/1P2P1PP/NNQRKBBR w HDhd - 1 9	27	750	20584	605458	16819085	516796736
+       47	1nqr1rbb/pppkp1pp/1n3p2/3p4/1P6/5P1P/P1PPPKP1/NNQR1RBB w - - 1 9	24	623	15921	429446	11594634	322745925
+       48	bbn1rqkr/pp1pp2p/4npp1/2p5/1P6/2BPP3/P1P2PPP/1BNNRQKR w HEhe - 0 9	23	730	17743	565340	14496370	468608864
+       49	bn1brqkr/pppp2p1/3npp2/7p/PPP5/8/3PPPPP/BNNBRQKR w HEhe - 0 9	25	673	17835	513696	14284338	434008567
+       50	bn1rqbkr/ppp1ppp1/1n6/2p4p/7P/3P4/PPP1PPP1/BN1RQBKR w HDhd - 0 9	25	776	20562	660217	18486027	616653869
+       51	bnnr1krb/ppp2ppp/3p4/3Bp3/q1P3PP/8/PP1PPP2/BNNRQKR1 w GDgd - 0 9	29	1040	30772	1053113	31801525	1075147725
+       52	1bbnrqkr/pp1ppppp/8/2p5/n7/3PNPP1/PPP1P2P/NBB1RQKR w HEhe - 1 9	24	598	15673	409766	11394778	310589129
+       53	nnbbrqkr/p2ppp1p/1pp5/8/6p1/N1P5/PPBPPPPP/N1B1RQKR w HEhe - 0 9	26	530	14031	326312	8846766	229270702
+       54	nnbrqbkr/2p1p1pp/p4p2/1p1p4/8/NP6/P1PPPPPP/N1BRQBKR w HDhd - 0 9	17	496	10220	303310	7103549	217108001
+       55	nnbrqk1b/pp2pprp/2pp2p1/8/3PP1P1/8/PPP2P1P/NNBRQRKB w d - 1 9	33	820	27856	706784	24714401	645835197
+       56	1bnrbqkr/ppnpp1p1/2p2p1p/8/1P6/4PPP1/P1PP3P/NBNRBQKR w HDhd - 0 9	27	705	19760	548680	15964771	464662032
+       57	n1rbbqkr/pp1pppp1/7p/P1p5/1n6/2PP4/1P2PPPP/NNRBBQKR w HChc - 0 9	22	631	14978	431801	10911545	320838556
+       58	n1rqb1kr/p1pppp1p/1pn4b/3P2p1/P7/1P6/2P1PPPP/NNRQBBKR w HChc - 0 9	24	477	12506	263189	7419372	165945904
+       59	nnrqbkrb/pppp1pp1/7p/4p3/6P1/2N2B2/PPPPPP1P/NR1QBKR1 w Ggc - 2 9	29	658	19364	476620	14233587	373744834
+       60	n1nrqkbr/ppb2ppp/3pp3/2p5/2P3P1/5P2/PP1PPB1P/NBNRQK1R w HDhd - 1 9	32	801	25861	681428	22318948	619857455
+       61	2rbqkbr/p1pppppp/1nn5/1p6/7P/P4P2/1PPPP1PB/NNRBQK1R w HChc - 2 9	27	647	18030	458057	13189156	354689323
+       62	nn1qkbbr/pp2ppp1/2rp4/2p4p/P2P4/1N5P/1PP1PPP1/1NRQKBBR w HCh - 1 9	24	738	18916	586009	16420659	519075930
+       63	nnrqk1bb/p1ppp2p/5rp1/1p3p2/1P4P1/5P1P/P1PPP3/NNRQKRBB w FCc - 1 9	25	795	20510	648945	17342527	556144017
+       64	bb1nrkqr/ppppn2p/4ppp1/8/1P4P1/4P3/P1PPKP1P/BBNNR1QR w he - 0 9	29	664	20024	498376	15373803	406016364
+       65	bnnbrkqr/1p1ppp2/8/p1p3pp/1P6/N4P2/PBPPP1PP/2NBRKQR w HEhe - 0 9	31	770	24850	677212	22562080	662029574
+       66	1nnrkbqr/p1pp1ppp/4p3/1p6/1Pb1P3/6PB/P1PP1P1P/BNNRK1QR w HDhd - 0 9	27	776	22133	641002	19153245	562738257
+       67	bnr1kqrb/pppp1pp1/1n5p/4p3/P3P3/3P2P1/1PP2P1P/BNNRKQRB w GDg - 0 9	26	624	16411	435426	11906515	338092952
+       68	nbbnrkqr/p1ppp1pp/1p3p2/8/2P5/4P3/PP1P1PPP/NBBNRKQR w HEhe - 1 9	25	624	15561	419635	10817378	311138112
+       69	nn1brkqr/pp1bpppp/8/2pp4/P4P2/1PN5/2PPP1PP/N1BBRKQR w HEhe - 1 9	23	659	16958	476567	13242252	373557073
+       70	n1brkbqr/ppp1pp1p/6pB/3p4/2Pn4/8/PP2PPPP/NN1RKBQR w HDhd - 0 9	32	1026	30360	978278	29436320	957904151
+       71	nnbrkqrb/p2ppp2/Q5pp/1pp5/4PP2/2N5/PPPP2PP/N1BRK1RB w GDgd - 0 9	36	843	29017	715537	24321197	630396940
+       72	nbnrbk1r/pppppppq/8/7p/8/1N2QPP1/PPPPP2P/NB1RBK1R w HDhd - 2 9	36	973	35403	1018054	37143354	1124883780
+       73	nnrbbkqr/2pppp1p/p7/6p1/1p2P3/4QPP1/PPPP3P/NNRBBK1R w HChc - 0 9	36	649	22524	489526	16836636	416139320
+       74	nnrkbbqr/1p2pppp/p2p4/2p5/8/1N2P1P1/PPPP1P1P/1NKRBBQR w hc - 0 9	26	672	18136	477801	13342771	363074681
+       75	n1rkbqrb/pp1ppp2/2n3p1/2p4p/P5PP/1P6/2PPPP2/NNRKBQRB w GCgc - 0 9	24	804	20712	684001	18761475	617932151
+       76	nbkr1qbr/1pp1pppp/pn1p4/8/3P2P1/5R2/PPP1PP1P/NBN1KQBR w H - 2 9	30	627	18669	423329	12815016	312798696
+       77	nnr1kqbr/pp1pp1p1/2p5/b4p1p/P7/1PNP4/2P1PPPP/N1RBKQBR w HChc - 1 9	12	421	6530	227044	4266410	149176979
+       78	n1rkqbbr/p1pp1pp1/np2p2p/8/8/N4PP1/PPPPP1BP/N1RKQ1BR w HChc - 0 9	27	670	19119	494690	14708490	397268628
+       79	nnr1qrbb/p2kpppp/1p1p4/2p5/6P1/PP1P4/2P1PP1P/NNRKQRBB w FC - 0 9	27	604	17043	409665	11993332	308518181
+       80	bbnnrkrq/ppp1pp2/6p1/3p4/7p/7P/PPPPPPP1/BBNNRRKQ w ge - 0 9	20	559	12242	355326	8427161	252274233
+       81	bnnbrkr1/ppp2p1p/5q2/3pp1p1/4P3/1N4P1/PPPPRP1P/BN1B1KRQ w Gge - 0 9	26	1036	27228	1028084	28286576	1042120495
+       82	bn1rkbrq/1pppppp1/p6p/1n6/3P4/6PP/PPPRPP2/BNN1KBRQ w Ggd - 2 9	29	633	19278	455476	14333034	361900466
+       83	b1nrkrqb/1p1npppp/p2p4/2p5/5P2/4P2P/PPPP1RP1/BNNRK1QB w Dfd - 1 9	25	475	12603	270909	7545536	179579818
+       84	1bbnrkrq/ppppppp1/8/7p/1n4P1/1PN5/P1PPPP1P/NBBR1KRQ w Gge - 0 9	30	803	25473	709716	23443854	686365049
+       85	nnbbrkrq/2pp1pp1/1p5p/pP2p3/7P/N7/P1PPPPP1/N1BBRKRQ w GEge - 0 9	18	432	9638	242350	6131124	160393505
+       86	nnbrkbrq/1pppp1p1/p7/7p/1P2Pp2/BN6/P1PP1PPP/1N1RKBRQ w GDgd - 0 9	27	482	13441	282259	8084701	193484216
+       87	n1brkrqb/pppp3p/n3pp2/6p1/3P1P2/N1P5/PP2P1PP/N1BRKRQB w FDfd - 0 9	28	642	19005	471729	14529434	384837696
+       88	nbnrbk2/p1pppp1p/1p3qr1/6p1/1B1P4/1N6/PPP1PPPP/1BNR1RKQ w d - 2 9	30	796	22780	687302	20120565	641832725
+       89	nnrbbrkq/1pp2ppp/3p4/p3p3/3P1P2/1P2P3/P1P3PP/NNRBBKRQ w GC - 1 9	31	827	24538	663082	19979594	549437308
+       90	nnrkbbrq/1pp2p1p/p2pp1p1/2P5/8/8/PP1PPPPP/NNRKBBRQ w Ggc - 0 9	24	762	19283	624598	16838099	555230555
+       91	nnr1brqb/1ppkp1pp/8/p2p1p2/1P1P4/N1P5/P3PPPP/N1RKBRQB w FC - 1 9	23	640	15471	444905	11343507	334123513
+       92	nbnrkrbq/2ppp2p/p4p2/1P4p1/4PP2/8/1PPP2PP/NBNRKRBQ w FDfd - 0 9	31	826	26137	732175	23555139	686250413
+       93	1nrbkr1q/1pppp1pp/1n6/p4p2/N1b4P/8/PPPPPPPB/N1RBKR1Q w FCfc - 2 9	27	862	24141	755171	22027695	696353497
+       94	nnrkrbbq/pppp2pp/8/4pp2/4P3/P7/1PPPBPPP/NNKRR1BQ w c - 0 9	25	792	19883	636041	16473376	532214177
+       95	n1rk1qbb/pppprpp1/2n4p/4p3/2PP3P/8/PP2PPP1/NNRKRQBB w ECc - 1 9	25	622	16031	425247	11420973	321855685
+       96	bbq1rnkr/pnp1pp1p/1p1p4/6p1/2P5/2Q1P2P/PP1P1PP1/BB1NRNKR w HEhe - 2 9	36	870	30516	811047	28127620	799738334
+       97	bq1brnkr/1p1ppp1p/1np5/p5p1/8/1N5P/PPPPPPP1/BQ1BRNKR w HEhe - 0 9	22	588	13524	380068	9359618	273795898
+       98	bq1rn1kr/1pppppbp/Nn4p1/8/8/P7/1PPPPPPP/BQ1RNBKR w HDhd - 1 9	24	711	18197	542570	14692779	445827351
+       99	bqnr1kr1/pppppp1p/6p1/5n2/4B3/3N2PP/PbPPPP2/BQNR1KR1 w GDgd - 2 9	31	1132	36559	1261476	43256823	1456721391
+       100	qbb1rnkr/ppp3pp/4n3/3ppp2/1P3PP1/8/P1PPPN1P/QBB1RNKR w HEhe - 0 9	28	696	20502	541886	16492398	456983120
+       101	qnbbr1kr/pp1ppp1p/4n3/6p1/2p3P1/2PP1P2/PP2P2P/QNBBRNKR w HEhe - 0 9	25	655	16520	450189	11767038	335414976
+       102	1nbrnbkr/p1ppp1pp/1p6/5p2/4q1PP/3P4/PPP1PP2/QNBRNBKR w HDhd - 1 9	30	1162	33199	1217278	36048727	1290346802
+       103	q1brnkrb/p1pppppp/n7/1p6/P7/3P1P2/QPP1P1PP/1NBRNKRB w GDgd - 0 9	32	827	26106	718243	23143989	673147648
+       104	qbnrb1kr/ppp1pp1p/3p4/2n3p1/1P6/6N1/P1PPPPPP/QBNRB1KR w HDhd - 2 9	29	751	23132	610397	19555214	530475036
+       105	q1rbbnkr/pppp1p2/2n3pp/2P1p3/3P4/8/PP1NPPPP/Q1RBBNKR w HChc - 2 9	29	806	24540	687251	21694330	619907316
+       106	q1r1bbkr/pnpp1ppp/2n1p3/1p6/2P2P2/2N1N3/PP1PP1PP/Q1R1BBKR w HChc - 2 9	32	1017	32098	986028	31204371	958455898
+       107	2rnbkrb/pqppppp1/1pn5/7p/2P5/P1R5/QP1PPPPP/1N1NBKRB w Ggc - 4 9	26	625	16506	434635	11856964	336672890
+       108	qbnr1kbr/p2ppppp/2p5/1p6/4n2P/P4N2/1PPP1PP1/QBNR1KBR w HDhd - 0 9	27	885	23828	767273	21855658	706272554
+       109	qnrbnk1r/pp1pp2p/5p2/2pbP1p1/3P4/1P6/P1P2PPP/QNRBNKBR w HChc - 0 9	26	954	24832	892456	24415089	866744329
+       110	qnrnk1br/p1p2ppp/8/1pbpp3/8/PP2N3/1QPPPPPP/1NR1KBBR w HChc - 0 9	26	783	20828	634267	17477825	539674275
+       111	qnrnkrbb/Bpppp2p/6p1/5p2/5P2/3PP3/PPP3PP/QNRNKR1B w FCfc - 1 9	28	908	25730	861240	25251641	869525254
+       112	bbnqrn1r/ppppp2k/5p2/6pp/7P/1QP5/PP1PPPP1/B1N1RNKR w HE - 0 9	33	643	21790	487109	16693640	410115900
+       113	b1qbrnkr/ppp1pp2/2np4/6pp/4P3/2N4P/PPPP1PP1/BQ1BRNKR w HEhe - 0 9	28	837	24253	745617	22197063	696399065
+       114	bnqr1bkr/pp1ppppp/2p5/4N3/5P2/P7/1PPPPnPP/BNQR1BKR w HDhd - 3 9	25	579	13909	341444	8601011	225530258
+       115	b1qr1krb/pp1ppppp/n2n4/8/2p5/2P3P1/PP1PPP1P/BNQRNKRB w GDgd - 0 9	28	707	19721	549506	15583376	468399900
+       116	nbbqr1kr/1pppp1pp/8/p1n2p2/4P3/PN6/1PPPQPPP/1BB1RNKR w HEhe - 0 9	30	745	23416	597858	19478789	515473678
+       117	nqbbrn1r/p1pppp1k/1p4p1/7p/4P3/1R3B2/PPPP1PPP/NQB2NKR w H - 0 9	24	504	13512	317355	9002073	228726497
+       118	nqbr1bkr/p1p1ppp1/1p1n4/3pN2p/1P6/8/P1PPPPPP/NQBR1BKR w HDhd - 0 9	29	898	26532	809605	24703467	757166494
+       119	nqbrn1rb/pppp1kp1/5p1p/4p3/P4B2/3P2P1/1PP1PP1P/NQ1RNKRB w GD - 0 9	34	671	22332	473110	15556806	353235120
+       120	nb1r1nkr/ppp1ppp1/2bp4/7p/3P2qP/P6R/1PP1PPP1/NBQRBNK1 w Dhd - 1 9	38	1691	60060	2526992	88557078	3589649998
+       121	n1rbbnkr/1p1pp1pp/p7/2p1qp2/1B3P2/3P4/PPP1P1PP/NQRB1NKR w HChc - 0 9	24	913	21595	807544	19866918	737239330
+       122	nqrnbbkr/p2p1p1p/1pp5/1B2p1p1/1P3P2/4P3/P1PP2PP/NQRNB1KR w HChc - 0 9	33	913	30159	843874	28053260	804687975
+       123	nqr1bkrb/ppp1pp2/2np2p1/P6p/8/2P4P/1P1PPPP1/NQRNBKRB w GCgc - 0 9	24	623	16569	442531	12681936	351623879
+       124	nb1rnkbr/pqppppp1/1p5p/8/1PP4P/8/P2PPPP1/NBQRNKBR w HDhd - 1 9	31	798	24862	694386	22616076	666227466
+       125	nqrbnkbr/2p1p1pp/3p4/pp3p2/6PP/3P1N2/PPP1PP2/NQRB1KBR w HChc - 0 9	24	590	14409	383690	9698432	274064911
+       126	nqrnkbbr/pp1p1p1p/4p1p1/1p6/8/5P1P/P1PPP1P1/NQRNKBBR w HChc - 0 9	30	1032	31481	1098116	34914919	1233362066
+       127	nqrnkrbb/p2ppppp/1p6/2p5/2P3P1/5P2/PP1PPN1P/NQR1KRBB w FCfc - 1 9	30	775	23958	668000	21141738	621142773
+       128	bbnrqrk1/pp2pppp/4n3/2pp4/P7/1N5P/BPPPPPP1/B2RQNKR w HD - 2 9	23	708	17164	554089	14343443	481405144
+       129	bnr1qnkr/p1pp1p1p/1p4p1/4p1b1/2P1P3/1P6/PB1P1PPP/1NRBQNKR w HChc - 1 9	30	931	29249	921746	30026687	968109774
+       130	b1rqnbkr/ppp1ppp1/3p3p/2n5/P3P3/2NP4/1PP2PPP/B1RQNBKR w HChc - 0 9	24	596	15533	396123	11099382	294180723
+       131	bnrqnr1b/pp1pkppp/2p1p3/P7/2P5/7P/1P1PPPP1/BNRQNKRB w GC - 0 9	24	572	15293	390903	11208688	302955778
+       132	n1brq1kr/bppppppp/p7/8/4P1Pn/8/PPPP1P2/NBBRQNKR w HDhd - 0 9	20	570	13139	371247	9919113	284592289
+       133	1rbbqnkr/ppn1ppp1/3p3p/2p5/3P4/1N4P1/PPPBPP1P/1R1BQNKR w HBhb - 0 9	29	1009	29547	1040816	31059587	1111986835
+       134	nrbq2kr/ppppppb1/5n1p/5Pp1/8/P5P1/1PPPP2P/NRBQNBKR w HBhb - 1 9	20	520	11745	316332	7809837	216997152
+       135	nrb1nkrb/pp3ppp/1qBpp3/2p5/8/P5P1/1PPPPP1P/NRBQNKR1 w GBgb - 2 9	32	850	25642	734088	21981567	664886187
+       136	1br1bnkr/ppqppp1p/1np3p1/8/1PP4P/4N3/P2PPPP1/NBRQB1KR w HChc - 1 9	32	798	24765	691488	22076141	670296871
+       137	nrqbb1kr/1p1pp1pp/2p3n1/p4p2/3PP3/P5N1/1PP2PPP/NRQBB1KR w HBhb - 0 9	32	791	26213	684890	23239122	634260266
+       138	nrqn1bkr/ppppp1pp/4b3/8/4P1p1/5P2/PPPP3P/NRQNBBKR w HBhb - 0 9	29	687	20223	506088	15236287	398759980
+       139	nrqnbrkb/pppp1p2/4p2p/3B2p1/8/1P4P1/PQPPPP1P/NR1NBKR1 w GB - 0 9	37	764	27073	610950	21284835	514864869
+       140	nbrq1kbr/Bp3ppp/2pnp3/3p4/5P2/2P4P/PP1PP1P1/NBRQNK1R w HChc - 0 9	40	1271	48022	1547741	56588117	1850696281
+       141	nrqbnkbr/1p2ppp1/p1p4p/3p4/1P6/8/PQPPPPPP/1RNBNKBR w HBhb - 0 9	28	757	23135	668025	21427496	650939962
+       142	nrqn1bbr/2ppkppp/4p3/pB6/8/2P1P3/PP1P1PPP/NRQNK1BR w HB - 1 9	27	642	17096	442653	11872805	327545120
+       143	nrqnkrb1/p1ppp2p/1p4p1/4bp2/4PP1P/4N3/PPPP2P1/NRQ1KRBB w FBfb - 1 9	27	958	27397	960350	28520172	995356563
+       144	1bnrnqkr/pbpp2pp/8/1p2pp2/P6P/3P1N2/1PP1PPP1/BBNR1QKR w HDhd - 0 9	27	859	23475	773232	21581178	732696327
+       145	b1rbnqkr/1pp1ppp1/2n4p/p2p4/5P2/1PBP4/P1P1P1PP/1NRBNQKR w HChc - 0 9	26	545	14817	336470	9537260	233549184
+       146	1nrnqbkr/p1pppppp/1p6/8/2b2P2/P1N5/1PP1P1PP/BNR1QBKR w HChc - 2 9	24	668	17716	494866	14216070	406225409
+       147	1nrnqkrb/2ppp1pp/p7/1p3p2/5P2/N5K1/PPPPP2P/B1RNQ1RB w gc - 0 9	33	725	23572	559823	18547476	471443091
+       148	nbbr1qkr/p1pppppp/8/1p1n4/3P4/1N3PP1/PPP1P2P/1BBRNQKR w HDhd - 1 9	28	698	20527	539625	16555068	458045505
+       149	1rbbnqkr/1pnppp1p/p5p1/2p5/2P4P/5P2/PP1PP1PR/NRBBNQK1 w Bhb - 1 9	24	554	14221	362516	9863080	269284081
+       150	nrb1qbkr/2pppppp/2n5/p7/2p5/4P3/PPNP1PPP/1RBNQBKR w HBhb - 0 9	23	618	15572	443718	12044358	360311412
+       151	nrb1qkrb/2ppppp1/p3n3/1p1B3p/2P5/6P1/PP1PPPRP/NRBNQK2 w Bgb - 2 9	27	593	16770	401967	11806808	303338935
+       152	nbrn1qkr/ppp1pp2/3p2p1/3Q3P/b7/8/PPPPPP1P/NBRNB1KR w HChc - 2 9	39	1056	40157	1133446	42201531	1239888683
+       153	nr1bbqkr/pp1pp2p/1n3pp1/2p5/8/1P4P1/P1PPPPQP/NRNBBK1R w hb - 0 9	25	585	15719	406544	11582539	320997679
+       154	nr2bbkr/ppp1pppp/1n1p4/8/6PP/1NP4q/PP1PPP2/1RNQBBKR w HBhb - 1 9	22	742	15984	545231	13287051	457010195
+       155	1rnqbkrb/ppp1p1p1/1n3p2/3p3p/P6P/4P3/1PPP1PP1/NRNQBRKB w gb - 0 9	22	574	14044	379648	9968830	281344367
+       156	nb1rqkbr/1pppp1pp/4n3/p4p2/6PP/5P2/PPPPPN2/NBR1QKBR w HCh - 0 9	25	621	16789	462600	13378840	396575613
+       157	nrnbqkbr/2pp2pp/4pp2/pp6/8/1P3P2/P1PPPBPP/NRNBQ1KR w hb - 0 9	25	656	16951	466493	12525939	358763789
+       158	nrnqkbbr/ppppp1p1/7p/5p2/8/P4PP1/NPPPP2P/NR1QKBBR w HBhb - 0 9	28	723	20621	547522	15952533	439046803
+       159	1rnqkr1b/ppppp2p/1n3pp1/8/2P3P1/Pb1N4/1P1PPP1P/NR1QKRBB w FBfb - 0 9	26	713	19671	548875	15865528	454532806
+       160	bbnrnkqr/1pppp1pp/5p2/p7/7P/1P6/PBPPPPPR/1BNRNKQ1 w D - 2 9	26	649	17834	502279	14375839	435585252
+       161	bnrbk1qr/1ppp1ppp/p2np3/8/P7/2N2P2/1PPPP1PP/B1RBNKQR w HC - 0 9	26	621	17569	451452	13514201	364421088
+       162	br1nkbqr/ppppppp1/8/n6p/8/N1P2PP1/PP1PP2P/B1RNKBQR w HCh - 1 9	29	664	20182	512316	16125924	442508159
+       163	bnr1kqrb/pp1pppp1/2n5/2p5/1P4Pp/4N3/P1PPPP1P/BNKR1QRB w gc - 0 9	36	888	31630	789863	27792175	719015345
+       164	1bbrnkqr/pp1p1ppp/2p1p3/1n6/5P2/3Q4/PPPPP1PP/NBBRNK1R w HDhd - 2 9	36	891	31075	781792	26998966	702903862
+       165	nrbbnk1r/pp2pppq/8/2pp3p/3P2P1/1N6/PPP1PP1P/1RBBNKQR w HBhb - 0 9	29	1036	31344	1139166	35627310	1310683359
+       166	nr1nkbqr/ppp3pp/5p2/3pp3/6b1/3PP3/PPP2PPP/NRBNKBQR w hb - 0 9	18	664	13306	483892	10658989	386307449
+       167	nrbnk1rb/ppp1pq1p/3p4/5pp1/2P1P3/1N6/PP1PKPPP/1RBN1QRB w gb - 2 9	25	966	24026	920345	23957242	913710194
+       168	1brnbkqr/pppppp2/6p1/7p/1Pn5/P1NP4/2P1PPPP/NBR1BKQR w HChc - 0 9	22	627	13760	395829	9627826	285900573
+       169	nrnbbk1r/p1pppppq/8/7p/1p6/P5PP/1PPPPPQ1/NRNBBK1R w HBhb - 2 9	29	888	26742	874270	27229468	930799376
+       170	n1nkb1qr/prppppbp/6p1/1p6/2P2P2/P7/1P1PP1PP/NRNKBBQR w HBh - 1 9	29	804	24701	688520	21952444	623156747
+       171	nr2bqrb/ppkpp1pp/1np5/5p1P/5P2/2P5/PP1PP1P1/NRNKBQRB w GB - 0 9	22	530	13055	347657	9244693	264088392
+       172	nbr1kqbr/p3pppp/2ppn3/1p4P1/4P3/1P6/P1PP1P1P/NBRNKQBR w HChc - 1 9	23	555	14291	350917	9692630	247479180
+       173	nr1bkqbr/1p1pp1pp/pnp2p2/8/6P1/P1PP4/1P2PP1P/NRNBKQBR w HBhb - 0 9	22	565	13343	365663	9305533	268612479
+       174	nr1kqbbr/np2pppp/p1p5/1B1p1P2/8/4P3/PPPP2PP/NRNKQ1BR w HBhb - 0 9	32	730	23391	556995	18103280	454569900
+       175	nrnk1rbb/p1p2ppp/3pq3/Qp2p3/1P1P4/8/P1P1PPPP/NRN1KRBB w fb - 2 9	28	873	25683	791823	23868737	747991356
+       176	bbnrnkrq/pp1ppp1p/6p1/2p5/6P1/P5RP/1PPPPP2/BBNRNK1Q w Dgd - 3 9	37	1260	45060	1542086	54843403	1898432768
+       177	bnrb1rkq/ppnpppp1/3Q4/2p4p/7P/N7/PPPPPPP1/B1RBNKR1 w GC - 2 9	38	878	31944	800440	28784300	784569826
+       178	bnrnkbrq/p1ppppp1/1p5p/8/P2PP3/5P2/1PP3PP/BNRNKBRQ w GCgc - 1 9	26	617	16992	419099	11965544	311309576
+       179	bnrnkrqb/pp2p2p/2pp1pp1/8/P7/2PP1P2/1P2P1PP/BNRNKRQB w FCfc - 0 9	26	721	19726	560824	15966934	467132503
+       180	nbbrnkr1/1pppp1p1/p6q/P4p1p/8/5P2/1PPPP1PP/NBBRNRKQ w gd - 2 9	18	556	10484	316634	6629293	202528241
+       181	nrb1nkrq/2pp1ppp/p4b2/1p2p3/P4B2/3P4/1PP1PPPP/NR1BNRKQ w gb - 0 9	24	562	14017	355433	9227883	247634489
+       182	nrbnkbrq/p3p1pp/1p6/2pp1P2/8/3PP3/PPP2P1P/NRBNKBRQ w GBgb - 0 9	31	746	24819	608523	21019301	542954168
+       183	nrbnkrqb/pppp1p1p/4p1p1/8/7P/2P1P3/PPNP1PP1/1RBNKRQB w FBfb - 0 9	20	459	9998	242762	5760165	146614723
+       184	nbrn1krq/ppp1p2p/6b1/3p1pp1/8/4N1PP/PPPPPP2/NBR1BRKQ w gc - 1 9	27	835	23632	766397	22667987	760795567
+       185	nrnbbkrq/p1pp2pp/5p2/1p6/2P1pP1B/1P6/P2PP1PP/NRNB1KRQ w GBgb - 0 9	24	646	16102	444472	11489727	324948755
+       186	nrn1bbrq/1ppkppp1/p2p3p/8/1P3N2/4P3/P1PP1PPP/NR1KBBRQ w GB - 2 9	32	591	18722	381683	12069159	269922838
+       187	n1krbrqb/1ppppppp/p7/8/4n3/P4P1P/1PPPPQP1/NRNKBR1B w FB - 2 9	26	639	16988	417190	12167153	312633873
+       188	n1rnkrbq/1p1ppp1p/8/p1p1b1p1/3PQ1P1/4N3/PPP1PP1P/NBR1KRB1 w FCfc - 0 9	35	1027	35731	1040417	35738410	1060661628
+       189	nrnbkrbq/2pp1pp1/pp6/4p2p/P7/5PPP/1PPPP3/NRNBKRBQ w FBfb - 0 9	26	628	16731	436075	11920087	331498921
+       190	1rnkrbbq/pp1p2pp/1n3p2/1Bp1p3/1P6/1N2P3/P1PP1PPP/1RNKR1BQ w EBeb - 0 9	33	992	32244	983481	31703749	980306735
+       191	nr1krqbb/p1ppppp1/8/1p5p/1Pn5/5P2/P1PPP1PP/NRNKRQBB w EBeb - 0 9	24	670	15985	445492	11371067	325556465
+       192	bbq1rkr1/1ppppppp/p1n2n2/8/2P2P2/1P6/PQ1PP1PP/BB1NRKNR w HEe - 3 9	32	794	26846	689334	24085223	645633370
+       193	b1nbrknr/1qppp1pp/p4p2/1p6/6P1/P2NP3/1PPP1P1P/BQ1BRKNR w HEhe - 1 9	25	663	17138	482994	13157826	389603029
+       194	bqnrk1nr/pp2ppbp/6p1/2pp4/2P5/5P2/PPQPP1PP/B1NRKBNR w HDhd - 0 9	26	850	22876	759768	21341087	719712622
+       195	bqnrknrb/1ppp1p1p/p7/6p1/1P2p3/P1PN4/3PPPPP/BQ1RKNRB w GDgd - 0 9	25	721	19290	581913	16391601	511725087
+       196	q1b1rknr/pp1pppp1/4n2p/2p1b3/1PP5/4P3/PQ1P1PPP/1BBNRKNR w HEhe - 1 9	32	975	32566	955493	32649943	962536105
+       197	qnbbrknr/1p1ppppp/8/p1p5/5P2/PP1P4/2P1P1PP/QNBBRKNR w HEhe - 0 9	27	573	16331	391656	11562434	301166330
+       198	q1brkb1r/p1pppppp/np3B2/8/6n1/1P5N/P1PPPPPP/QN1RKB1R w HDhd - 0 9	32	984	31549	1007217	32597704	1075429389
+       199	qn1rk1rb/p1pppppp/1p2n3/8/2b5/4NPP1/PPPPP1RP/QNBRK2B w Dgd - 4 9	22	802	19156	697722	17761431	650603534
+       200	qbnrbknr/ppp2p1p/8/3pp1p1/1PP1B3/5N2/P2PPPPP/Q1NRBK1R w HDhd - 0 9	34	943	32506	930619	32523099	955802240
+       201	qnrbb1nr/pp1p1ppp/2p2k2/4p3/4P3/5PPP/PPPP4/QNRBBKNR w HC - 0 9	20	460	10287	241640	5846781	140714047
+       202	qnr1bbnr/ppk1p1pp/3p4/2p2p2/8/2P5/PP1PPPPP/QNKRBBNR w - - 1 9	19	572	11834	357340	7994547	243724815
+       203	qnrkbnrb/1p1p1ppp/2p5/4p3/p7/N1BP4/PPP1PPPP/Q1R1KNRB w gc - 0 9	27	579	16233	375168	10845146	268229097
+       204	qbnrkn1r/1pppp1p1/p3bp2/2BN3p/8/5P2/PPPPP1PP/QBNRK2R w HDhd - 0 9	40	1027	38728	1059229	38511307	1104094381
+       205	qnrbknbr/1pp2ppp/4p3/p6N/2p5/8/PPPPPPPP/Q1RBK1BR w HChc - 0 9	22	510	11844	300180	7403327	200581103
+       206	1qkrnbbr/p1pppppp/2n5/1p6/8/5NP1/PPPPPP1P/QNRK1BBR w HC - 4 9	24	549	13987	352037	9396521	255676649
+       207	q1rknr1b/1ppppppb/2n5/p2B3p/8/1PN3P1/P1PPPP1P/Q1RKNRB1 w FCfc - 3 9	31	924	28520	861944	27463479	847726572
+       208	bbnqrk1r/pp1pppp1/2p4p/8/6n1/1N1P1P2/PPP1P1PP/BBQ1RKNR w HEhe - 4 9	24	804	20147	666341	18024195	595947631
+       209	bn1brknr/ppp1p1pp/5p2/3p4/6qQ/3P3P/PPP1PPP1/BN1BRKNR w HEhe - 4 9	25	854	22991	704173	20290974	600195008
+       210	1nqrkbnr/2pp1ppp/pp2p3/3b4/2P5/N7/PP1PPPPP/B1QRKBNR w HDhd - 0 9	22	651	16173	479152	13133439	390886040
+       211	bnqrk1rb/1pp1pppp/p2p4/4n3/2PPP3/8/PP3PPP/BNQRKNRB w GDgd - 1 9	30	950	28169	889687	27610213	880739164
+       212	nbb1rknr/1ppq1ppp/3p4/p3p3/4P3/1N2R3/PPPP1PPP/1BBQ1KNR w Hhe - 2 9	33	988	31293	967575	30894863	985384035
+       213	nqbbrknr/2ppp2p/pp4p1/5p2/7P/3P1P2/PPPBP1P1/NQ1BRKNR w HEhe - 0 9	27	492	13266	276569	7583292	175376176
+       214	1qbrkb1r/pppppppp/8/3n4/4P1n1/PN6/1PPP1P1P/1QBRKBNR w HDhd - 3 9	28	800	21982	630374	17313279	507140861
+       215	1qbrknrb/1p1ppppp/1np5/8/p4P1P/4P1N1/PPPP2P1/NQBRK1RB w GDgd - 0 9	21	482	10581	267935	6218644	168704845
+       216	nbqrbkr1/ppp1pppp/8/3p4/6n1/2P2PPN/PP1PP2P/NBQRBK1R w HDd - 1 9	29	921	25748	840262	24138518	806554650
+       217	nqrb1knr/1ppbpp1p/p7/3p2p1/2P3P1/5P1P/PP1PP3/NQRBBKNR w HChc - 1 9	31	803	25857	665799	21998733	583349773
+       218	1qrkbbr1/pppp1ppp/1n3n2/4p3/5P2/1N6/PPPPP1PP/1QRKBBNR w HCc - 0 9	25	715	19118	556325	15514933	459533767
+       219	nqrkb1rb/pp2pppp/2p1n3/3p4/3PP1N1/8/PPP2PPP/NQRKB1RB w GCgc - 0 9	26	795	21752	679387	19185851	616508881
+       220	nb1rknbr/pp2ppp1/8/2Bp3p/6P1/2P2P1q/PP1PP2P/NBQRKN1R w HDhd - 0 9	35	1391	43025	1726888	53033675	2139267832
+       221	nqrbkn1r/pp1pp1pp/8/2p2p2/5P2/P3B2P/1PbPP1P1/NQRBKN1R w HChc - 0 9	23	758	19439	653854	18296195	628403401
+       222	nqrknbbr/pp1pppp1/7p/2p5/7P/1P1N4/P1PPPPPB/NQRK1B1R w HChc - 2 9	29	824	23137	683686	19429491	595493802
+       223	1qrknrbb/B1p1pppp/8/1p1p4/2n2P2/1P6/P1PPP1PP/NQRKNR1B w FCfc - 0 9	28	771	20237	581721	16065378	483037840
+       224	bbnrqk1r/1ppppppp/8/7n/1p6/P6P/1BPPPPP1/1BNRQKNR w HDhd - 0 9	25	601	15471	396661	10697065	289472497
+       225	bnrbqknr/ppp3p1/3ppp1Q/7p/3P4/1P6/P1P1PPPP/BNRB1KNR w HChc - 0 9	32	845	26876	742888	23717883	682154649
+       226	bn1qkb1r/pprppppp/8/2p5/2PPP1n1/8/PPR2PPP/BN1QKBNR w Hh - 1 9	32	856	27829	768595	25245957	727424329
+       227	1nrqknrb/p1pp1ppp/1p2p3/3N4/5P1P/5b2/PPPPP3/B1RQKNRB w GCgc - 2 9	33	873	27685	779473	25128076	745401024
+       228	nbbrqrk1/pppppppp/8/2N1n3/P7/6P1/1PPPPP1P/1BBRQKNR w HD - 3 9	25	555	14339	342296	9153089	234841945
+       229	1rbbqknr/1ppp1pp1/1n2p3/p6p/4P1P1/P6N/1PPP1P1P/NRBBQK1R w HBhb - 0 9	25	693	18652	528070	15133381	439344945
+       230	nrq1kbnr/p1pbpppp/3p4/1p6/6P1/1N3N2/PPPPPP1P/1RBQKB1R w HBhb - 4 9	24	648	16640	471192	12871967	380436777
+       231	nr1qknr1/p1pppp1p/b5p1/1p6/8/P4PP1/1bPPP1RP/NRBQKN1B w Bgb - 0 9	18	533	11215	331243	7777833	234905172
+       232	nbrqbknr/1ppp2pp/8/4pp2/p2PP1P1/7N/PPP2P1P/NBRQBK1R w HChc - 0 9	29	803	24416	706648	22305910	672322762
+       233	nr1b1k1r/ppp1pppp/2bp1n2/6P1/2P3q1/5P2/PP1PP2P/NRQBBKNR w HBhb - 1 9	27	1199	30908	1296241	35121759	1418677099
+       234	nrqkbbnr/2pppp1p/p7/1p6/2P1Pp2/8/PPNP2PP/1RQKBBNR w HBhb - 0 9	28	613	17874	432750	13097064	345294379
+       235	1rqkbnrb/pp1ppp1p/1n4p1/B1p5/3PP3/4N3/PPP2PPP/NRQK2RB w GBgb - 0 9	33	723	23991	590970	19715083	535650233
+       236	nbrqkn1r/1pppp2p/5pp1/p2b4/5P2/P2PN3/1PP1P1PP/NBRQK1BR w HChc - 2 9	23	607	15482	400970	11026383	290708878
+       237	nrqbknbr/pp1pppp1/8/2p4p/P3PP2/8/1PPP2PP/NRQBKNBR w HBhb - 1 9	26	700	19371	556026	16058815	485460242
+       238	nrqknbbr/p2pppp1/1pp5/6Qp/3P4/1P3P2/P1P1P1PP/NR1KNBBR w HBhb - 0 9	40	905	32932	829746	29263502	791963709
+       239	nrqknrbb/1p3ppp/p2p4/2p1p3/1P6/3PP1P1/P1P2P1P/NRQKNRBB w FBfb - 0 9	29	780	22643	654495	19532077	593181101
+       240	1bnrkqnr/p1pppp2/7p/1p4p1/4b3/7N/PPPP1PPP/BBNRKQ1R w HDhd - 0 9	25	725	19808	565006	16661676	487354613
+       241	bnrbkq1r/pp2p1pp/5n2/2pp1p2/P7/N1PP4/1P2PPPP/B1RBKQNR w HChc - 1 9	24	745	18494	584015	15079602	488924040
+       242	2rkqbnr/p1pppppp/2b5/1pn5/1P3P1Q/2B5/P1PPP1PP/1NRK1BNR w HChc - 3 9	33	904	30111	840025	28194726	801757709
+       243	bnrkqnrb/2pppp2/8/pp4pp/1P5P/6P1/P1PPPPB1/BNRKQNR1 w GCgc - 0 9	34	1059	34090	1054311	33195397	1036498304
+       244	1bbrkq1r/pppp2pp/1n2pp1n/8/2PP4/1N4P1/PP2PP1P/1BBRKQNR w HDhd - 1 9	33	891	28907	814247	26970098	788040469
+       245	nrbbkqnr/1p2pp1p/p1p3p1/3p4/8/1PP5/P2PPPPP/NRBBKQNR w HBhb - 0 9	21	567	13212	376487	9539687	284426039
+       246	1rbkqbr1/ppp1pppp/1n5n/3p4/3P4/1PP3P1/P3PP1P/NRBKQBNR w HBb - 1 9	27	752	20686	606783	16986290	521817800
+       247	nrbkq1rb/1ppp1pp1/4p1n1/p6p/2PP4/5P2/PPK1P1PP/NRB1QNRB w gb - 0 9	35	697	23678	505836	16906409	390324794
+       248	nbrkbqnr/p2pp1p1/5p2/1pp4p/7P/3P2P1/PPP1PP2/NBKRBQNR w hc - 0 9	25	679	17223	484921	12879258	376652259
+       249	nrkb1qnr/ppppp1p1/6bp/5p2/1PP1P1P1/8/P2P1P1P/NRKBBQNR w HBhb - 1 9	32	761	24586	632916	20671433	568524724
+       250	nrk1bbnr/p1q1pppp/1ppp4/8/3P3P/4K3/PPP1PPP1/NR1QBBNR w hb - 0 9	30	719	21683	541389	16278120	423649784
+       251	nrkqbr1b/1pppp1pp/5pn1/p6N/1P3P2/8/P1PPP1PP/NRKQB1RB w GBb - 0 9	26	494	13815	296170	8763742	206993496
+       252	nbrkq2r/pppp1bpp/4p1n1/5p2/7P/2P3N1/PP1PPPP1/NBKRQ1BR w hc - 0 9	27	701	19536	535052	15394667	443506342
+       253	nrkbqnbr/2ppp2p/pp6/5pp1/P1P5/8/1P1PPPPP/NRKBQNBR w HBhb - 0 9	21	487	11341	285387	7218486	193586674
+       254	nr1qnbbr/pk1pppp1/1pp4p/8/3P4/5P1P/PPP1P1P1/NRKQNBBR w HB - 0 9	22	546	13615	352855	9587439	259830255
+       255	nrkq1rbb/pp1ppp1p/2pn4/8/PP3Pp1/7P/2PPP1P1/NRKQNRBB w FBfb - 0 9	26	839	22075	723845	19867117	658535326
+       256	b2rknqr/pp1ppppp/8/2P5/n7/P7/1PPNPPPb/BBNRK1QR w HDhd - 2 9	24	699	19523	575172	17734818	535094237
+       257	bnrbknqr/pp2p2p/2p3p1/3p1p2/8/3P4/PPPNPPPP/B1RBKNQR w HChc - 0 9	23	580	14320	385917	10133092	288041554
+       258	bnrknb1r/pppp2pp/8/4pp2/6P1/3P3P/qPP1PPQ1/BNRKNB1R w HChc - 0 9	28	1100	31813	1217514	36142423	1361341249
+       259	b1rknqrb/ppp1p1p1/2np1p1p/8/4N3/6PQ/PPPPPP1P/B1RKN1RB w GCgc - 0 9	36	629	23082	453064	16897544	367503974
+       260	nb1rknqr/pbppp2p/6p1/1p3p2/5P2/3KP3/PPPP2PP/NBBR1NQR w hd - 2 9	18	557	9779	300744	5822387	180936551
+       261	nr1bknqr/1ppb1ppp/p7/3pp3/B7/2P3NP/PP1PPPP1/NRB1K1QR w HBhb - 2 9	28	688	19541	519785	15153092	425149249
+       262	nrbkn2r/pppp1pqp/4p1p1/8/3P2P1/P3B3/P1P1PP1P/NR1KNBQR w HBhb - 1 9	32	808	25578	676525	22094260	609377239
+       263	nrbknqrb/2p1ppp1/1p6/p2p2Bp/1P6/3P1P2/P1P1P1PP/NR1KNQRB w GBgb - 0 9	30	625	18288	418895	12225742	301834282
+       264	nbr1knqr/1pp1p1pp/3p1pb1/8/7P/5P2/PPPPPQP1/NBRKBN1R w HC - 2 9	29	863	25767	800239	24965592	799182442
+       265	n1kbbnqr/prp2ppp/1p1p4/4p3/1P2P3/3P1B2/P1P2PPP/NRK1BNQR w HBh - 2 9	26	653	17020	449719	12187583	336872952
+       266	nrknbbqr/pp3p1p/B3p1p1/2pp4/4P3/2N3P1/PPPP1P1P/NRK1B1QR w HBhb - 0 9	29	683	19755	501807	14684565	394951291
+       267	n1knbqrb/pr1p1ppp/Qp6/2p1p3/4P3/6P1/PPPP1P1P/NRKNB1RB w GBg - 2 9	31	552	17197	371343	11663330	283583340
+       268	nbrknqbr/p3p1pp/1p1p1p2/2p5/2Q1PP2/8/PPPP2PP/NBRKN1BR w HChc - 0 9	37	913	32470	825748	28899548	759875563
+       269	nrkb1qbr/pp1pppp1/5n2/7p/2p5/1N1NPP2/PPPP2PP/1RKB1QBR w HBhb - 0 9	25	712	18813	543870	15045589	445074372
+       270	nrk2bbr/pppqpppp/3p4/8/1P3nP1/3P4/P1P1PP1P/NRKNQBBR w HBhb - 1 9	24	814	19954	670162	17603960	592121050
+       271	nrknqrbb/1p2ppp1/2pp4/Q6p/P2P3P/8/1PP1PPP1/NRKN1RBB w FBfb - 0 9	34	513	16111	303908	9569590	206509331
+       272	bbnrk1rq/pp2p1pp/2ppn3/5p2/8/3NNP1P/PPPPP1P1/BB1RK1RQ w GDgd - 1 9	28	697	20141	517917	15301879	410843713
+       273	bnrbknrq/ppppp2p/6p1/5p2/4QPP1/8/PPPPP2P/BNRBKNR1 w GCgc - 0 9	37	901	32612	877372	31385912	903831981
+       274	bnkrnbrq/ppppp1p1/B6p/5p2/8/4P3/PPPP1PPP/BNKRN1RQ w - - 0 9	26	417	11124	217095	5980981	133080499
+       275	bnrk1rqb/2pppp1p/3n4/pp4p1/3Q1P2/2N3P1/PPPPP2P/B1RKNR1B w FCfc - 0 9	49	1655	74590	2512003	107234294	3651608327
+       276	nbbrk1rq/pp2pppp/2pp4/8/2P2n2/6N1/PP1PP1PP/NBBRKR1Q w Dgd - 0 9	28	960	26841	884237	26083252	846682836
+       277	nrbb2rq/pppk1ppp/4p1n1/3p4/6P1/1BP5/PP1PPPQP/NRB1KNR1 w GB - 0 9	28	735	22048	593839	18588316	512048946
+       278	nrbk1brq/p1ppppp1/7p/1p6/4P1nP/P7/1PPP1PP1/NRBKNBRQ w GBgb - 0 9	22	572	12739	351494	8525056	247615348
+       279	nrbk1rqb/1pp2ppp/5n2/p2pp3/5B2/1N1P2P1/PPP1PP1P/1R1KNRQB w FBfb - 0 9	35	927	31559	849932	28465693	783048748
+       280	nbrkb1rq/p1pp1ppp/4n3/4p3/Pp6/6N1/1PPPPPPP/NBRKBRQ1 w Cgc - 0 9	20	456	10271	247733	6124625	154766108
+       281	nrkb1nrq/p2pp1pp/1pp2p2/7b/6PP/5P2/PPPPP2N/NRKBB1RQ w GBgb - 0 9	21	479	11152	264493	6696458	165253524
+       282	nr1nbbr1/pppkpp1p/6p1/3p4/P6P/1P6/1RPPPPP1/N1KNBBRQ w G - 1 9	20	498	11304	288813	7197322	188021682
+       283	nrknbrqb/3p1ppp/ppN1p3/8/6P1/8/PPPPPP1P/1RKNBRQB w FBfb - 0 9	32	526	17267	319836	10755190	220058991
+       284	nbrkn1bq/p1pppr1p/1p6/5pp1/8/1N2PP2/PPPP2PP/1BKRNRBQ w c - 1 9	19	491	10090	277313	6230616	180748649
+       285	nrkbnrbq/ppppppp1/8/8/7p/PP3P2/2PPPRPP/NRKBN1BQ w Bfb - 0 9	16	353	6189	156002	3008668	82706705
+       286	nrknrbbq/p4ppp/2p1p3/1p1p4/1P2P3/2P5/P1NP1PPP/1RKNRBBQ w EBeb - 0 9	29	728	21915	587668	18231199	511686397
+       287	nrknr1bb/pppp1p2/7p/2qPp1p1/8/1P5P/P1P1PPP1/NRKNRQBB w EBeb - 0 9	20	714	14336	500458	11132758	386064577
+       288	bbqnrrkn/ppp2p1p/3pp1p1/8/1PP5/2Q5/P1BPPPPP/B2NRKRN w GE - 0 9	39	593	23446	424799	16764576	346185058
+       289	bqn1rkrn/p1p2ppp/1p1p4/4p3/3PP2b/8/PPP2PPP/BQNBRKRN w GEge - 2 9	25	773	20042	616817	16632403	515838333
+       290	bqnrkb1n/p1p1pprp/3p4/1p2P1p1/2PP4/8/PP3PPP/BQNRKBRN w GDd - 1 9	31	860	28102	810379	27233018	813751250
+       291	bqr1krnb/ppppppp1/7p/3n4/1P4P1/P4N2/2PPPP1P/BQNRKR1B w FDf - 3 9	31	709	22936	559830	18608857	480498340
+       292	qbbn1krn/pp3ppp/4r3/2ppp3/P1P4P/8/1P1PPPP1/QBBNRKRN w GEg - 1 9	26	775	21100	649673	18476807	582542257
+       293	qnbbrkrn/1p1pp2p/p7/2p2pp1/8/4P2P/PPPP1PPK/QNBBRR1N w ge - 0 9	25	599	15139	389104	10260500	279222412
+       294	qnbrkbrn/1ppp2p1/p3p2p/5p2/P4P2/1P6/2PPP1PP/QNBRKBRN w GDgd - 0 9	27	588	16735	394829	11640416	293541380
+       295	1nbrkrnb/p1pppp1p/1pq3p1/8/4P3/P1P4N/1P1P1PPP/QNBRKR1B w FDfd - 1 9	18	609	11789	406831	8604788	299491047
+       296	qb1r1krn/pppp2pp/1n2ppb1/4P3/7P/8/PPPP1PP1/QBNRBKRN w GDgd - 0 9	20	578	12205	349453	7939483	229142178
+       297	qnr1bkrn/p3pppp/1bpp4/1p6/2P2PP1/8/PP1PPN1P/QNRBBKR1 w GCgc - 0 9	30	865	26617	771705	24475596	719842237
+       298	1nkrbbrn/qppppppp/8/8/p2P4/1P5P/P1P1PPP1/QNKRBBRN w - - 0 9	27	672	18371	505278	14065717	410130412
+       299	1qrkbrnb/ppp1p1pp/n2p4/5p2/4N3/8/PPPPPPPP/Q1RKBRNB w Ffc - 2 9	25	718	18573	536771	14404324	424279467
+       300	q1nrkrbn/pp1pppp1/2p4p/8/P7/5Pb1/BPPPPNPP/Q1NRKRB1 w FDfd - 0 9	22	558	12911	336042	8516966	228074630
+       301	qnrbkrbn/1p1p1pp1/p1p5/4p2p/8/3P1P2/PPP1P1PP/QNRBKRBN w FCfc - 0 9	28	669	17713	440930	12055174	313276304
+       302	qnrkr1bn/p1pp1ppp/8/1p2p3/3P1P2/bP4P1/P1P1P2P/QNRKRBBN w ECec - 1 9	23	845	20973	759778	19939053	718075943
+       303	q1krrnbb/p1p1pppp/2np4/1pB5/5P2/8/PPPPP1PP/QNRKRN1B w EC - 0 9	29	776	21966	631941	18110831	549019739
+       304	bbn1rkrn/pp1p1ppp/8/2p1p1q1/6P1/P7/BPPPPP1P/B1NQRKRN w GEge - 0 9	26	936	25177	906801	24984621	901444251
+       305	bn1brkrn/pp1qpp1p/2p3p1/3p4/1PPP4/P7/4PPPP/BNQBRKRN w GEge - 1 9	29	755	22858	645963	20128587	600207069
+       306	b2rkbrn/p1pppppp/qp6/8/1n6/2B2P2/P1PPP1PP/1NQRKBRN w GDgd - 0 9	24	878	21440	791007	20840078	775795187
+       307	b2rkrnb/pqp1pppp/n7/1p1p4/P7/N1P2N2/1P1PPPPP/B1QRKR1B w FDfd - 4 9	26	724	19558	571891	16109522	492933398
+       308	1bbqrkrn/ppppp1p1/8/5p1p/P1n3P1/3P4/1PP1PP1P/NBBQRRKN w ge - 1 9	25	678	17351	461211	12173245	329661421
+       309	nqb1rrkn/ppp1bppp/3pp3/8/3P4/1P6/PQP1PPPP/N1BBRRKN w - - 1 9	23	503	12465	290341	7626054	188215608
+       310	nqbrkbr1/p1pppppp/1p6/2N2n2/2P5/5P2/PP1PP1PP/1QBRKBRN w GDgd - 1 9	29	688	20289	506302	15167248	399015237
+       311	nqbrkrn1/1ppppp2/6pp/p7/1P6/2Q5/P1PPPPPP/N1BRKRNB w FDfd - 0 9	36	602	20985	397340	13706856	291708797
+       312	nbqrbrkn/pp1p1pp1/2p5/4p2p/2P3P1/1P3P2/P2PP2P/NBQRBKRN w GD - 0 9	34	655	22581	474396	16613630	379344541
+       313	nqrbbrkn/1p1pppp1/8/p1p4p/4P2P/1N4P1/PPPP1P2/1QRBBKRN w GC - 0 9	23	597	14468	400357	10096863	294900903
+       314	nqrkbbrn/2p1p1pp/pp1p1p2/8/P2N4/2P5/1P1PPPPP/1QRKBBRN w GCgc - 0 9	32	744	23310	550728	17597164	428786656
+       315	n1krbrnb/q1pppppp/p7/1p6/3Q4/2P2P2/PP1PP1PP/N1RKBRNB w FC - 1 9	43	1038	41327	1074450	40918952	1126603824
+       316	nb1rkrbn/p1pp1p1p/qp6/4p1p1/5PP1/P7/1PPPPB1P/NBQRKR1N w FDfd - 2 9	26	645	16463	445464	11911314	342563372
+       317	nqr1krbn/pppp1ppp/8/8/3pP3/5P2/PPPb1NPP/NQRBKRB1 w FCfc - 3 9	2	51	1047	27743	612305	17040200
+       318	n1rkrbbn/pqppppp1/7p/1p6/8/1NPP4/PP1KPPPP/1QR1RBBN w ec - 0 9	25	674	17553	505337	13421727	403551903
+       319	1qrkrnbb/1p1p1ppp/pnp1p3/8/3PP3/P6P/1PP2PP1/NQRKRNBB w ECec - 0 9	24	688	17342	511444	13322502	403441498
+       320	1bnrqkrn/2ppppp1/p7/1p1b3p/3PP1P1/8/PPPQ1P1P/BBNR1KRN w GDgd - 1 9	35	925	32238	857060	30458921	824344087
+       321	bnrbqkr1/ppp2pp1/6n1/3pp2p/1P6/2N3N1/P1PPPPPP/B1RBQRK1 w gc - 0 9	23	704	17345	539587	14154852	450893738
+       322	1nrqkbrn/p1pppppp/8/1p1b4/P6P/5P2/1PPPP1P1/BNRQKBRN w GCgc - 1 9	19	505	10619	281422	6450025	175593967
+       323	b1rqkrnb/ppppppp1/8/6p1/3n4/NP6/P1PPPP1P/B1RQKRNB w FCfc - 0 9	25	614	15578	377660	10391021	259629603
+       324	nbbrqkrn/ppp3p1/3pp3/5p1p/1P2P3/P7/2PPQPPP/NBBR1KRN w GDgd - 0 9	30	833	25719	717713	22873901	649556666
+       325	nr1bqrk1/ppp1pppp/6n1/3pP3/8/5PQb/PPPP2PP/NRBB1KRN w GB - 3 9	26	734	20161	582591	17199594	512134836
+       326	1rbqkbr1/ppppp1pp/1n6/4np2/3P1P2/6P1/PPPQP2P/NRB1KBRN w GBgb - 1 9	27	662	17897	447464	13038519	338365642
+       327	nr1qkr1b/ppp1pp1p/4bn2/3p2p1/4P3/1Q6/PPPP1PPP/NRB1KRNB w FBfb - 4 9	33	939	30923	942138	30995969	991509814
+       328	nb1qbkrn/pprp1pp1/7p/2p1pB2/Q1PP4/8/PP2PPPP/N1R1BKRN w GCg - 2 9	47	1128	50723	1306753	56747878	1560584212
+       329	nrqb1rkn/pp2pppp/2bp4/2p5/6P1/2P3N1/PP1PPP1P/NRQBBRK1 w - - 3 9	24	828	21148	723705	19506135	668969549
+       330	nrq1bbrn/ppkpp2p/2p3p1/P4p2/8/4P1N1/1PPP1PPP/NRQKBBR1 w GB - 0 9	25	525	13533	309994	8250997	201795680
+       331	Br1kbrn1/pqpppp2/8/6pp/3b2P1/1N6/PPPPPP1P/1RQKBRN1 w FBfb - 3 9	20	790	18175	695905	17735648	669854148
+       332	nbrqkrbn/2p1p1pp/p7/1p1p1p2/4P1P1/5P2/PPPP3P/NBRQKRBN w FCfc - 0 9	29	771	22489	647106	19192982	591335970
+       333	1rqbkrbn/1ppppp1p/1n6/p1N3p1/8/2P4P/PP1PPPP1/1RQBKRBN w FBfb - 0 9	29	502	14569	287739	8652810	191762235
+       334	1rqkrbbn/ppnpp1pp/8/2p5/6p1/3P4/PPP1PPPP/NRK1RBBN w eb - 0 9	19	531	10812	300384	6506674	184309316
+       335	nrqkrnbb/p1pp2pp/5p2/4P3/2p5/4N3/PP1PP1PP/NRQKR1BB w EBeb - 0 9	26	800	23256	756695	23952941	809841274
+       336	bbnrkqrn/pp3pp1/4p2p/2pp4/4P1P1/1PB5/P1PP1P1P/1BNRKQRN w GDgd - 0 9	33	915	30536	878648	29602610	881898159
+       337	bnrbkqr1/1p2pppp/6n1/p1pp4/7P/P3P3/1PPPKPP1/BNRB1QRN w gc - 0 9	19	457	9332	238944	5356253	144653627
+       338	b1rkqbrn/pp1p2pp/2n1p3/2p2p2/3P2PP/8/PPP1PP2/BNKRQBRN w gc - 0 9	30	985	30831	1011700	32684185	1080607773
+       339	b1rkqrnb/2ppppp1/np6/p6p/1P6/P2P3P/2P1PPP1/BNRKQRNB w FCfc - 0 9	26	692	18732	517703	14561181	413226841
+       340	nbbrkqrn/1ppp1p2/p6p/4p1p1/5P2/1P5P/P1PPPNP1/NBBRKQR1 w GDgd - 0 9	22	561	13222	367487	9307003	273928315
+       341	nrbbkqrn/p1pppppp/8/1p6/4P3/7Q/PPPP1PPP/NRBBK1RN w GBgb - 0 9	38	769	28418	632310	23091070	560139600
+       342	nrbkqbrn/1pppp2p/8/p4pp1/P4PQ1/8/1PPPP1PP/NRBK1BRN w GBgb - 0 9	23	507	13067	321423	8887567	237475184
+       343	nr1kqr1b/pp2pppp/5n2/2pp4/P5b1/5P2/1PPPPRPP/NRBK1QNB w Bfb - 2 9	18	626	12386	434138	9465555	335004239
+       344	nbkrbqrn/1pppppp1/8/4P2p/pP6/P7/2PP1PPP/NBRKBQRN w GC - 0 9	22	329	8475	148351	4160034	82875306
+       345	nrkb1qrn/pp1pp1pp/8/5p1b/P1p4P/6N1/1PPPPPP1/NRKBBQR1 w GBgb - 2 9	16	479	9037	275354	5862341	184959796
+       346	1rkq1brn/ppppp1pp/1n6/3b1p2/3N3P/5P2/PPPPP1P1/1RKQBBRN w GBgb - 3 9	23	614	15324	418395	11090645	313526088
+       347	nrk1brnb/pp1ppppp/2p5/3q4/5P2/PP6/1KPPP1PP/NR1QBRNB w fb - 1 9	25	942	21765	792179	19318837	685549171
+       348	nbrkqr1n/1pppp2p/p4pp1/2Bb4/5P2/6P1/PPPPP2P/NBRKQ1RN w Cfc - 2 9	30	841	24775	677876	20145765	557578726
+       349	n1kbqrbn/2p1pppp/1r6/pp1p4/P7/3P4/1PP1PPPP/NRKBQRBN w FBf - 2 9	21	591	14101	394289	10295086	292131422
+       350	nrkqrbb1/ppp1pppp/3p4/8/4P3/2Pn1P2/PP4PP/NRKQRBBN w EBeb - 0 9	4	88	3090	73414	2640555	66958031
+       351	nrkqrnbb/ppppp1p1/7p/1P3p2/3P4/2P5/P3PPPP/NRKQRNBB w EBeb - 0 9	29	689	21091	508789	16226660	408570219
+       352	bbnr1rqn/pp2pkpp/2pp1p2/8/4P1P1/8/PPPP1P1P/BBNRKRQN w FD - 0 9	21	463	11135	256244	6826249	165025370
+       353	bnrbk1qn/1pppprpp/8/p4p1P/6P1/3P4/PPP1PP2/BNRBKRQN w FCc - 0 9	22	459	11447	268157	7371098	190583454
+       354	1nrkrbqn/p1pp1ppp/4p3/1p6/1PP5/6PB/P2PPPbP/BNRKR1QN w ECec - 0 9	30	931	29012	887414	28412902	869228014
+       355	b1rkr1nb/pppppqp1/n4B2/7p/8/1P4P1/P1PPPP1P/1NKRRQNB w ec - 1 9	36	934	31790	930926	30392925	952871799
+       356	nbbrkrqn/p1ppp1p1/8/1p3p1p/2P3PP/8/PP1PPPQ1/NBBRKR1N w FDfd - 0 9	34	938	31848	921716	31185844	944483246
+       357	1rbbkrqn/ppp1pp2/1n1p2p1/7p/P3P1P1/3P4/1PP2P1P/NRBBKRQN w FBfb - 0 9	26	646	18083	472744	14006203	384101783
+       358	nrbkrbq1/Qpppp1pp/2n5/5p2/P4P2/6N1/1PPPP1PP/NRBKRB2 w EBeb - 1 9	27	619	16713	421845	11718463	313794027
+       359	1rbkr1nb/pppp1qpp/1n6/4pp2/1PP1P3/8/PB1P1PPP/NR1KRQNB w EBeb - 1 9	32	1029	32970	1080977	35483796	1181835398
+       360	nbrk1rqn/p1ppp2p/1p6/5ppb/8/1N2P2P/PPPP1PP1/1BKRBRQN w fc - 0 9	18	594	12350	408544	9329122	315021712
+       361	nrkbbrqn/3pppp1/7p/ppp5/P7/1N5P/1PPPPPP1/1RKBBRQN w FBfb - 0 9	19	417	9026	218513	5236331	137024458
+       362	nrkr1bqn/ppp1pppp/3p4/1b6/7P/P7/1PPPPPP1/NRKRBBQN w DBdb - 1 9	17	457	9083	243872	5503579	150091997
+       363	nrkrbqnb/p4ppp/1p2p3/2pp4/6P1/2P2N2/PPNPPP1P/1RKRBQ1B w DBdb - 0 9	27	755	21012	620093	17883987	547233320
+       364	nbkrr1bn/ppB2ppp/4p3/2qp4/4P3/5P2/PPPP2PP/NBRKRQ1N w EC - 1 9	37	1473	51939	1956521	68070015	2490912491
+       365	n1kbrqbn/p1pp1pp1/4p2p/2B5/1r3P2/8/PPPPP1PP/NRKBRQ1N w EBe - 2 9	30	1029	30874	1053163	32318550	1106487743
+       366	nrkrqbbn/2pppp1p/8/pp6/1P1P2p1/P5P1/2P1PP1P/NRKRQBBN w DBdb - 0 9	22	421	10034	221927	5754555	141245633
+       367	nrkr1nbb/1ppp2pp/p3q3/4pp2/2P5/P3P3/1PKP1PPP/NR1RQNBB w db - 0 9	22	619	13953	411392	9905109	301403003
+       368	bbnrkrnq/1pp1p2p/6p1/p2p1p2/8/1P2P3/P1PP1PPP/BBNRKRNQ w FDfd - 0 9	27	805	21915	688224	19133881	620749189
+       369	bnrbkrn1/pp1ppp2/2p3pp/8/2Pq4/P4PP1/1P1PP2P/BNRBKRNQ w FCfc - 1 9	20	770	16593	577980	13581691	456736500
+       370	b1rkrbnq/1pp1pppp/2np4/p5N1/8/1P2P3/P1PP1PPP/BNRKRB1Q w ECec - 0 9	37	740	27073	581744	21156664	485803600
+       371	b1krrnqb/pp1ppp1p/n1p3p1/2N5/6P1/8/PPPPPP1P/B1RKRNQB w EC - 0 9	34	850	28494	752350	25360295	698159474
+       372	1bbr1rnq/ppppkppp/8/3np3/4P3/3P4/PPP1KPPP/NBBRR1NQ w - - 1 9	27	704	18290	480474	12817011	341026662
+       373	nrbbk1nq/p1p1prpp/1p6/N2p1p2/P7/8/1PPPPPPP/R1BBKRNQ w Fb - 2 9	23	552	13710	348593	9236564	248469879
+       374	1rbkrb1q/1pppp1pp/1n5n/p4p2/P3P3/1P6/2PPNPPP/NRBKRB1Q w EBeb - 1 9	22	415	10198	217224	5735644	135295774
+       375	nrbkr1qb/1pp1pppp/6n1/p2p4/2P1P3/1N4N1/PP1P1PPP/1RBKR1QB w EBeb - 0 9	27	709	19126	506214	14192779	380516508
+       376	nbrkbrnq/p3p1pp/1pp2p2/3p4/1PP5/4P3/P1KP1PPP/NBR1BRNQ w fc - 0 9	24	715	18009	535054	14322279	427269976
+       377	nrk1brnq/pp1p1pp1/7p/b1p1p3/1P6/6P1/P1PPPPQP/NRKBBRN1 w FBfb - 2 9	29	675	20352	492124	15316285	389051744
+       378	nrkr1bnq/1p2pppp/p2p4/1bp5/PP6/1R5N/2PPPPPP/N1KRBB1Q w Ddb - 2 9	27	744	20494	571209	16188945	458900901
+       379	nrk1b1qb/pppn1ppp/3rp3/3p4/2P3P1/3P4/PPN1PP1P/1RKRBNQB w DBb - 3 9	35	941	33203	935791	33150360	968024386
+       380	nb1rrnbq/ppkp1ppp/8/2p1p3/P7/1N2P3/1PPP1PPP/1BKRRNBQ w - - 1 9	19	451	9655	235472	5506897	139436165
+       381	nrkbrnbq/4pppp/1ppp4/p7/2P1P3/3P2N1/PP3PPP/NRKBR1BQ w EBeb - 0 9	29	591	17132	384358	11245508	270967202
+       382	nrkrnbbq/3p1ppp/1p6/p1p1p3/3P2P1/P4Q2/1PP1PP1P/NRKRNBB1 w DBdb - 0 9	38	792	28597	640961	22654797	540864616
+       383	nr1rnqbb/ppp1pp1p/3k2p1/3p4/1P5P/3P1N2/P1P1PPP1/NRKR1QBB w DB - 1 9	25	758	18547	543643	13890077	402109399
+       384	bbqrnnkr/1ppp1p1p/5p2/p5p1/P7/1P4P1/2PPPP1P/1BQRNNKR w HDhd - 0 9	20	322	7224	145818	3588435	82754650
+       385	bqrb2k1/pppppppr/5nnp/8/3P1P2/4P1N1/PPP3PP/BQRBN1KR w HCc - 1 9	25	597	15872	397970	11162476	295682250
+       386	bqrnn1kr/1pppbppp/8/4p3/1p6/2P1N2P/P2PPPP1/BQR1NBKR w HChc - 1 9	34	921	31695	864023	30126510	850296236
+       387	bqr1nkr1/pppppp2/2n3p1/7p/1P1b1P2/8/PQP1P1PP/B1RNNKRB w GCgc - 0 9	23	788	21539	686795	20849374	645694580
+       388	qbbrnn1r/1pppp1pk/p7/5p1p/P2P3P/3N4/1PP1PPP1/QBBR1NKR w HD - 0 9	34	713	24475	562189	19494094	482645160
+       389	qrbb2kr/p1pppppp/1p1n4/8/1P3n2/P7/Q1PPP1PP/1RBBNNKR w HBhb - 0 9	28	977	26955	949925	27802999	992109168
+       390	qrb2bkr/1pp1pppp/2np1n2/pN6/3P4/4B3/PPP1PPPP/QR2NBKR w HBhb - 0 9	27	730	20534	585091	17005916	507008968
+       391	qrbnnkrb/pp2pp1p/8/2pp2p1/7P/P1P5/QP1PPPP1/1RBNNKRB w GBgb - 0 9	24	813	21142	707925	19615756	655850285
+       392	1brnb1kr/p1pppppp/1p6/8/4q2n/1P2P1P1/PNPP1P1P/QBR1BNKR w HChc - 3 9	17	734	13462	530809	11032633	416356876
+       393	1rnbbnkr/1pp1pppp/1q1p4/p7/4P3/5PN1/PPPP1BPP/QRNB2KR w HBhb - 1 9	26	809	21764	706677	20292750	675408811
+       394	qrnnbb1Q/ppp1pk1p/3p2p1/5p2/PP6/5P2/2PPP1PP/1RNNBBKR w HB - 0 9	37	751	27902	603931	22443036	515122176
+       395	qrnnbkrb/p3p1pp/3p1p2/1pp5/PP2P3/8/2PP1PPP/QRNNBRKB w gb - 0 9	30	906	27955	872526	27658191	890966633
+       396	qbrnnkbr/1p2pp1p/p1p3p1/3p4/6P1/P1N4P/1PPPPP2/QBR1NKBR w HChc - 0 9	26	701	18930	521377	14733245	416881799
+       397	qr1b1kbr/1p1ppppp/1n1n4/p1p5/4P3/5NPP/PPPP1P2/QRNB1KBR w HBhb - 1 9	26	649	17235	451997	12367604	342165821
+       398	qrnnkb1r/1pppppp1/7p/p4b2/4P3/5P1P/PPPP2PR/QRNNKBB1 w Bhb - 1 9	34	941	31720	901240	30307554	888709821
+       399	qr1nkrbb/p2ppppp/1pp5/8/3Pn3/1NP3P1/PP2PP1P/QR1NKRBB w FBfb - 1 9	19	505	11107	294251	7046501	190414579
+       400	bbrqn1kr/1pppp1pp/4n3/5p2/p5P1/3P4/PPP1PPKP/BBRQNN1R w hc - 0 9	24	573	12963	335845	8191054	227555387
+       401	brqb1nkr/pppppp1p/8/4N1pn/5P2/6P1/PPPPP2P/BRQB1NKR w HBhb - 0 9	26	550	14338	331666	8903754	223437427
+       402	brqnn1kr/pp3ppp/2pbp3/3p4/8/2NPP3/PPP1BPPP/BRQ1N1KR w HBhb - 0 9	27	780	20760	589328	16243731	463883447
+       403	brq1nkrb/ppp2ppp/8/n2pp2P/P7/4P3/1PPP1PP1/BRQNNKRB w GBgb - 1 9	17	426	8295	235162	5048497	153986034
+       404	rbbqn1kr/pp2p1pp/6n1/2pp1p2/2P4P/P7/BP1PPPP1/R1BQNNKR w HAha - 0 9	27	916	25798	890435	26302461	924181432
+       405	1qbbn1kr/1ppppppp/r3n3/8/p1P5/P7/1P1PPPPP/RQBBNNKR w HAh - 1 9	29	817	24530	720277	22147642	670707652
+       406	rqbnnbkr/ppp1ppp1/7p/3p4/PP6/7P/1NPPPPP1/RQB1NBKR w HAa - 1 9	23	572	14509	381474	10416981	288064942
+       407	r1bnnkrb/q1ppp1pp/p7/1p3pB1/2P1P3/3P4/PP3PPP/RQ1NNKRB w GAga - 2 9	31	925	27776	860969	26316355	843078864
+       408	rbqnb1kr/ppppp1pp/5p2/5N2/7P/1n3P2/PPPPP1P1/RBQNB1KR w HAha - 1 9	32	864	27633	766551	24738875	707188107
+       409	rqnbbn1r/ppppppp1/6k1/8/6Pp/2PN4/PP1PPPKP/RQ1BBN1R w - - 0 9	27	566	15367	347059	9714509	234622128
+       410	rqnnbbkr/p1p2pp1/1p1p3p/4p3/4NP2/6P1/PPPPP2P/RQN1BBKR w HAha - 0 9	27	631	17923	452734	13307890	356279813
+       411	1qnnbrkb/rppp1ppp/p3p3/8/4P3/2PP1P2/PP4PP/RQNNBKRB w GA - 1 9	24	479	12135	271469	7204345	175460841
+       412	rbqnn1br/p1pppk1p/1p4p1/5p2/8/P1P2P2/1PBPP1PP/R1QNNKBR w HA - 0 9	31	756	23877	625194	20036784	554292502
+       413	rqnbnkbr/1ppppp2/p5p1/8/1P4p1/4PP2/P1PP3P/RQNBNKBR w HAha - 0 9	24	715	18536	575589	16013189	515078271
+       414	rq1nkbbr/1p2pppp/p2n4/2pp4/1P4P1/P2N4/2PPPP1P/RQ1NKBBR w HAha - 1 9	27	694	19840	552904	16685687	494574415
+       415	r1nnkrbb/pp1pppp1/2p3q1/7p/8/1PPP3P/P3PPP1/RQNNKRBB w FAfa - 1 9	18	520	10808	329085	7508201	235103697
+       416	bbrnqk1r/pppp3p/6p1/4pp2/3P2P1/8/PPP1PP1P/BBRN1NKR w HC - 0 9	22	566	12965	362624	8721079	259069471
+       417	brnb1nkr/pppqpp2/3p2pp/8/3PP3/1P6/PBP2PPP/1RNBQNKR w HBhb - 0 9	32	859	28517	817464	27734108	829785474
+       418	brnq1b1r/ppp1ppkp/3p1np1/8/8/5P1P/PPPPPKPR/BRNQNB2 w - - 0 9	21	511	10951	273756	6372681	167139732
+       419	brnq1rkb/1pppppp1/3n3p/p7/8/P4NP1/1PPPPPRP/BRNQ1K1B w B - 0 9	25	548	14049	341208	9015901	235249649
+       420	rbb1qnkr/p1ppp1pp/1p3p2/6n1/8/1PN1P2P/P1PP1PP1/RBB1QNKR w HAha - 0 9	25	673	16412	467660	12099119	361714466
+       421	rnbb1nkr/1ppp1ppp/4p3/p5q1/6P1/1PP5/PB1PPP1P/RN1BQNKR w HAha - 1 9	19	663	14149	489653	11491355	399135495
+       422	rnbqnbkr/1pp1p2p/3p1p2/p5p1/5PP1/2P5/PPNPP2P/RNBQ1BKR w HAha - 0 9	24	647	16679	461931	12649636	361157611
+       423	rnb2krb/pppqppnp/8/3p2p1/1P4P1/7P/P1PPPPB1/RNBQNKR1 w GAga - 1 9	24	722	18749	605229	16609220	563558512
+       424	rbnqb1kr/pppn1pp1/3p3p/4p3/1P6/P7/R1PPPPPP/1BNQBNKR w Hha - 1 9	20	538	12277	345704	8687621	255304141
+       425	rnqb1nkr/p1pbp1pp/8/1pPp1p2/P2P4/8/1P2PPPP/RNQBBNKR w HAha - 1 9	35	764	26952	632796	22592380	564255328
+       426	rnq1bbkr/1p1ppp1p/4n3/p1p3p1/P1PP4/8/RP2PPPP/1NQNBBKR w Hha - 0 9	29	709	21296	570580	17597398	506140370
+       427	1nqnbkrb/1pppp2p/r7/p4pp1/3P4/8/PPPBPPPP/RNQNK1RB w g - 0 9	27	1028	28534	1050834	30251988	1096869832
+       428	rbnqnkbr/p1pp1p1p/8/1p2p3/3P2pP/2P5/PP2PPP1/RBNQNKBR w HAha - 0 9	32	832	27120	750336	24945574	724171581
+       429	rnq1nkbr/1p1p1ppp/2p1pb2/p7/7P/2P5/PPNPPPPB/RNQB1K1R w HAha - 2 9	31	779	24010	638640	19919434	551494771
+       430	rnqnk1br/p1ppp1bp/1p3p2/6p1/4N3/P5P1/1PPPPP1P/R1QNKBBR w HAha - 2 9	25	717	19396	576577	16525239	507175842
+       431	rnq1krbb/p1p1pppp/8/1p1p4/1n5B/2N2P2/PPPPP1PP/RNQ1KR1B w FAfa - 0 9	28	867	24029	735686	21112751	654808184
+       432	bbrnnqkr/1pp1pppp/3p4/p7/P3P3/7P/1PPP1PP1/BBRNNQKR w HChc - 0 9	24	405	11025	210557	6196438	131401224
+       433	brnbnqkr/p1ppp3/1p5p/5Pp1/5P2/3N4/PPPPP2P/BRNB1QKR w HBhb g6 0 9	25	785	21402	698331	20687969	695850727
+       434	br1nqbkr/1ppppp2/pn6/6pp/2PP4/1N4P1/PP2PP1P/BR1NQBKR w HBhb - 0 9	25	596	16220	421882	12185361	337805606
+       435	1rnnqkrb/p2ppp1p/1pp5/2N3p1/8/1P6/P1PPPPKP/BR1NQ1RB w gb - 0 9	38	960	34831	913665	32490040	880403591
+       436	rbbnnqkr/pp3pp1/2p1p3/3p3p/3P3P/1PP5/P3PPP1/RBBNNQKR w HAha - 0 9	30	785	23079	656618	19885037	599219582
+       437	rn1bnqkr/p1ppppp1/8/1p5p/P4P1P/3N4/1PPPP1b1/RNBB1QKR w HAha - 0 9	27	752	21735	613194	18862234	547415271
+       438	1nbnqbkr/1p1p1ppp/r3p3/p1p5/P3P3/3Q4/1PPP1PPP/RNBN1BKR w HAh - 2 9	33	721	24278	572535	19648535	496023732
+       439	rnbnqkrb/2pppppp/1p6/p7/1PP5/4N2P/P2PPPP1/RNB1QKRB w GAg - 0 9	23	570	14225	374196	10022614	279545007
+       440	rbnnbq1r/ppppppkp/6p1/N7/4P3/P7/1PPP1PPP/RB1NBQKR w HA - 5 9	27	620	18371	440594	13909432	349478320
+       441	r1nbbqkr/pppppp1p/8/8/1n3Pp1/3N1QP1/PPPPP2P/RN1BB1KR w HAha - 0 9	31	791	25431	682579	22408813	636779732
+       442	rnq1bbkr/pp1p1ppp/2pnp3/8/7P/1QP5/PP1PPPPR/RNN1BBK1 w Aha - 2 9	28	559	16838	390887	12242780	315431511
+       443	rnnqbrkb/2ppppp1/1p1N4/p6p/4P3/8/PPPP1PPP/R1NQBKRB w GA - 0 9	32	638	20591	438792	14395828	331782223
+       444	rbnnq1br/pppp1kp1/4pp2/7p/PP6/2PP4/4PPPP/RBNNQKBR w HA - 0 9	21	521	12201	320429	8239159	227346638
+       445	rnnbqkbr/p2ppp2/7p/1pp3p1/2P2N2/8/PP1PPPPP/RN1BQKBR w HAha - 0 9	25	528	13896	326094	9079829	232750602
+       446	rnn1kbbr/ppppqp2/6p1/2N1p2p/P7/2P5/1P1PPPPP/RN1QKBBR w HAha - 2 9	27	801	22088	707078	20334071	682580976
+       447	rnnqkrbb/p1p1p1pp/1p3p2/8/3p2Q1/P1P1P3/1P1P1PPP/RNN1KRBB w FAfa - 0 9	37	1014	34735	998999	32921537	988770109
+       448	bbrnk1qr/1pppppp1/p4n1p/8/P2P2N1/8/1PP1PPPP/BBR1NKQR w HC - 1 9	21	481	11213	279993	7015419	187564853
+       449	brnbnkqr/1pp1p1p1/p2p1p2/7p/1P4PP/8/PBPPPP2/1RNBNKQR w HBhb - 0 9	31	743	24260	660177	22391185	653721389
+       450	br2kbqr/ppppp1pp/3n1p2/3P4/3n3P/3N4/PPP1PPP1/BR1NKBQR w HBhb - 3 9	25	872	22039	748726	20281962	685749952
+       451	br1nkqrb/ppppppp1/8/7p/4P3/n1P2PP1/PP1P3P/BRNNKQRB w GBgb - 0 9	28	607	16934	396483	11607818	294181806
+       452	rbbn1kqr/pp1pp1p1/2pn3p/5p2/5P2/1P1N4/PNPPP1PP/RBB2KQR w HAha - 1 9	27	725	21543	616082	19239812	581716972
+       453	rnbbnk1r/pp1ppp1p/6q1/2p5/PP4p1/4P3/2PP1PPP/RNBBNKQR w HAha - 1 9	25	1072	26898	1088978	28469879	1122703887
+       454	rnbnkbqr/1pp3pp/3p4/p3pp2/3P2P1/2N1N3/PPP1PP1P/R1B1KBQR w HAha - 0 9	31	1028	32907	1095472	36025223	1211187800
+       455	r1bnkqrb/1ppppppp/p3n3/8/6P1/4N3/PPPPPPRP/RNB1KQ1B w Aga - 1 9	23	457	11416	250551	6666787	159759052
+       456	rbn1bkqr/p1pp1pp1/1pn5/4p2p/7P/1PBP4/P1P1PPP1/RBNN1KQR w HAha - 0 9	23	470	11649	264274	6963287	172833738
+       457	rnnbbkqr/3ppppp/p7/1pp5/P6P/6P1/1PPPPP2/RNNBBKQR w HAha - 0 9	26	569	15733	375556	11008114	284485303
+       458	r1nk1bqr/1pppp1pp/2n5/p4p1b/5P2/1N4B1/PPPPP1PP/RN1K1BQR w HAha - 2 9	25	824	21983	738366	20904119	716170771
+       459	r1nkbqrb/p2pppp1/npp4p/8/4PP2/2N4P/PPPP2P1/R1NKBQRB w GAga - 0 9	31	548	17480	349633	11469548	255067638
+       460	rbnnkqbr/ppppp2p/5p2/6p1/2P1B3/P6P/1P1PPPP1/R1NNKQBR w HAha - 1 9	31	809	24956	680747	21247414	606221516
+       461	1r1bkqbr/pppp1ppp/2nnp3/8/2P5/N4P2/PP1PP1PP/1RNBKQBR w Hh - 0 9	28	810	22844	694599	20188622	636748147
+       462	rn1kqbbr/p1pppp1p/1p4p1/1n6/1P2P3/4Q2P/P1PP1PP1/RNNK1BBR w HAha - 1 9	39	848	30100	724426	25594662	659615710
+       463	rn1kqrbb/pppppppp/8/8/2nP2P1/1P2P3/P1P2P1P/RNNKQRBB w FAfa - 1 9	29	766	21701	567971	16944425	456898648
+       464	b1rnnkrq/bpppppp1/7p/8/1p6/2B5/PNPPPPPP/1BR1NKRQ w GCgc - 2 9	25	667	17253	472678	12865247	365621294
+       465	brnb1krq/pppppppp/8/5P2/2P1n2P/8/PP1PP1P1/BRNBNKRQ w GBgb - 1 9	23	620	14882	402561	10776855	300125003
+       466	b1nnkbrq/pr1pppp1/1p5p/2p5/P2N1P2/8/1PPPP1PP/BR1NKBRQ w GBg - 0 9	24	472	12181	267398	7370758	178605165
+       467	br1nkrqb/p1p1p1pp/3n4/1p1p1p2/5N1P/4P3/PPPP1PP1/BR1NKRQB w FBfb - 0 9	24	775	19398	624309	16429837	539767605
+       468	rbbnnkrq/p2pp1pp/2p5/5p2/1pPP1B2/P7/1P2PPPP/RB1NNKRQ w GAga - 0 9	34	921	30474	849933	28095833	806446436
+       469	rnbbnkr1/1p1ppp1p/2p3p1/p7/2Pq4/1P1P4/P2BPPPP/RN1BNKRQ w GAga - 2 9	26	1139	29847	1204863	32825932	1281760240
+       470	1rbnkbrq/pppppp2/n5pp/2P5/P7/4N3/1P1PPPPP/RNB1KBRQ w GAg - 2 9	23	574	14146	391413	10203438	301874034
+       471	1nbnkr1b/rppppppq/p7/7p/1P5P/3P2P1/P1P1PP2/RNBNKRQB w FAf - 1 9	33	823	26696	724828	23266182	672294132
+       472	rbn1bkrq/ppppp3/4n2p/5pp1/1PN5/2P5/P2PPPPP/RBN1BKRQ w GAga - 0 9	27	859	24090	796482	23075785	789152120
+       473	r1nbbkrq/1ppp2pp/2n2p2/p3p3/5P2/1N4BP/PPPPP1P1/RN1B1KRQ w GAga - 0 9	25	774	20141	618805	16718577	515864053
+       474	rnnkbbrq/1pppp1p1/5p2/7p/p6P/3N1P2/PPPPP1PQ/RN1KBBR1 w GAga - 0 9	29	673	20098	504715	15545590	416359581
+       475	r1nkbrqb/pppp1p2/n3p1p1/7p/2P2P2/1P6/P2PPQPP/RNNKBR1B w FAfa - 0 9	27	722	21397	593762	18742426	537750982
+       476	rbnnkr1q/1ppp2pp/p4p2/P2bp3/4P2P/8/1PPP1PP1/RBNNKRBQ w FAfa - 1 9	26	848	23387	741674	21591790	675163653
+       477	rn1bkrb1/1ppppp1p/pn4p1/8/P2q3P/3P4/NPP1PPP1/RN1BKRBQ w FAfa - 1 9	22	803	18322	632920	15847763	536419559
+       478	rn1krbbq/pppp1npp/4pp2/8/4P2P/3P2P1/PPP2P2/RNNKRBBQ w EAea - 1 9	29	810	23968	670500	20361517	575069358
+       479	rnn1rqbb/ppkp1pp1/2p1p2p/2P5/8/3P1P2/PP2P1PP/RNNKRQBB w EA - 0 9	22	506	11973	292344	7287368	189865944
+       480	bbqr1knr/pppppp1p/8/4n1p1/2P1P3/6P1/PPQP1P1P/BB1RNKNR w HDhd - 0 9	26	650	18253	481200	14301029	394943978
+       481	bq1bnknr/pprppp1p/8/2p3p1/4PPP1/8/PPPP3P/BQRBNKNR w HCh - 0 9	24	548	14021	347611	9374021	250988458
+       482	bqrnkb1r/1p2pppp/p1pp3n/5Q2/2P4P/5N2/PP1PPPP1/B1RNKB1R w HChc - 0 9	46	823	33347	673905	26130444	582880996
+       483	bq1rknrb/pppppp1p/4n3/6p1/4P1P1/3P1P2/PPP4P/BQRNKNRB w GCg - 0 9	23	618	14815	419474	10606831	315124518
+       484	q1brnknr/pp1pp1p1/8/2p2p1p/5b2/P4N2/1PPPP1PP/QBBRK1NR w hd - 0 9	22	675	15778	473994	12077228	368479752
+       485	qrbbnknr/1p1ppp1p/p1p5/8/1P2P1p1/3P1B2/P1P2PPP/QRB1NKNR w HBhb - 0 9	32	722	24049	569905	19584539	484814878
+       486	qrb1kbnr/p3pppp/2n5/1ppp4/7P/3P1P2/PPP1P1PR/QRBNKBN1 w Bhb - 0 9	26	831	22606	724505	20500804	662608969
+       487	qrbnknrb/ppp1pp2/6p1/7p/PPNp4/8/2PPPPPP/QRB1KNRB w GBgb - 0 9	31	840	26762	742772	24422614	701363800
+       488	qbrnbknr/pp1pp1pp/8/2p2p2/3Q4/PP6/2PPPPPP/1BRNBKNR w HChc - 0 9	38	1121	39472	1198438	41108769	1285503872
+       489	qr1bbk1r/pppppp1p/1n6/5np1/4B3/1PP5/P2PPPPP/QRN1BKNR w HBhb - 0 9	25	694	16938	472950	12164609	345122090
+       490	qrnkbbnr/1p1pp2p/p7/2p1Npp1/6P1/7P/PPPPPP2/QR1KBBNR w HBhb - 0 9	27	586	16348	393391	11409633	298054792
+       491	qrnkbnrb/pp1p1p2/2p1p1pp/4N3/P4P2/8/1PPPP1PP/QR1KBNRB w GBgb - 0 9	32	645	20737	460319	15037464	358531599
+       492	qbrnknbr/1pppppp1/p6p/8/1P6/3PP3/PQP2PPP/1BRNKNBR w HChc - 3 9	26	595	16755	415022	12214768	323518628
+       493	qrnbk1br/1ppppp1p/p5p1/8/4Pn2/4K1P1/PPPP1P1P/QRNB1NBR w hb - 0 9	24	609	13776	359415	8538539	230364479
+       494	qrnk1bbr/1pnp1ppp/p1p1p3/8/3Q4/1P1N3P/P1PPPPP1/1RNK1BBR w HBhb - 0 9	43	1106	42898	1123080	41695761	1113836402
+       495	qrnknrb1/pppppp2/8/6pp/4P2P/3P1P2/PbP3P1/QRNKNRBB w FBfb - 0 9	24	658	17965	488373	14457245	400971226
+       496	bbrqnrk1/ppp2ppp/7n/3pp3/8/P4N1N/1PPPPPPP/BBRQ1RK1 w - - 1 9	22	503	12078	310760	8080951	224960353
+       497	brqbnk1r/1ppp1ppp/8/p3pn2/8/2PP1P2/PP2PKPP/BRQBN1NR w hb - 1 9	25	745	19387	570459	15520298	460840861
+       498	brqnkbnr/pp2pp1p/3p4/2p5/5p2/3P3P/PPP1PPP1/B1RNKBNR w Hhb - 0 9	19	516	10755	312996	6995034	214340699
+       499	brq1kn1b/1ppppprp/2n3p1/p7/P1N5/6P1/1PPPPP1P/BRQNK1RB w GBb - 2 9	29	557	16739	352277	10840256	249999654
+       500	rbbq1k1r/ppp1pppp/7n/1n1p4/5P2/P2P4/1PPBP1PP/RB1QNKNR w HAha - 1 9	25	769	20110	638340	17438715	570893953
+       501	r1bbnk1r/qpp1pppp/p6n/3p4/1P6/5N1P/P1PPPPP1/RQBBK1NR w ha - 0 9	23	728	18209	587364	16053564	529082811
+       502	rqbnkbnr/1pp2p1p/3p4/p3p1p1/8/2P2P2/PP1PPNPP/RQBNKB1R w HAha - 0 9	26	772	21903	653704	19571559	593915677
+       503	r1bnknrb/pqppp1p1/1p5p/5p2/7P/3P2N1/PPP1PPP1/RQBNK1RB w GAga - 2 9	27	748	20291	597105	16324542	506453626
+       504	rbqnbknr/pp1pppp1/8/2p5/3P3p/5N1P/PPP1PPPR/RBQNBK2 w Aha - 0 9	30	859	26785	819631	26363334	842796987
+       505	rqnbbrk1/ppppppp1/8/5n1p/3P3P/2B3P1/PPP1PP2/RQNB1KNR w HA - 0 9	22	505	11452	283464	7055215	186760784
+       506	rqnkbbnr/pp2p1p1/8/2pp1p1p/3PPP2/8/PPP1N1PP/RQNKBB1R w HAha - 0 9	28	832	23142	722857	20429246	663183060
+       507	rqnkbnr1/pppp2bp/6p1/4pp2/1P2P3/3NN3/P1PP1PPP/RQ1KB1RB w GAga - 0 9	28	641	18835	459993	14038570	364210162
+       508	rbq2kbr/pppppppp/2n5/P7/3P1n2/2P5/1P2PPPP/RBQNKNBR w HA - 1 9	31	889	27028	766181	24299415	692180754
+       509	rq1bkn1r/ppppp2p/3n4/5pp1/2b3P1/1N1P1P2/PPP1P2P/RQ1BKNBR w HAha - 1 9	28	810	22667	657520	18719949	556282676
+       510	r1nknbbr/p2ppp1p/1pp3p1/8/1P6/4P3/P1PPNPPq/R1QKNBBR w HAha - 0 9	24	797	22144	719069	21862776	716521139
+       511	rqnknrbb/ppp1p3/5ppp/2Np4/2P5/4P3/PP1P1PPP/RQNK1RBB w FAfa - 0 9	34	686	23277	515541	17664543	423574794
+       512	1brnqknr/2p1pppp/p2p4/1P6/6P1/4Nb2/PP1PPP1P/BBR1QKNR w HChc - 1 9	34	1019	32982	1003103	33322477	1043293394
+       513	brn1qknr/1p1pppp1/pb5p/Q1p5/3P3P/8/PPP1PPPR/BRNB1KN1 w Bhb - 2 9	32	642	20952	464895	15454749	371861782
+       514	brnqkbnr/pppppp2/8/6pp/6P1/P2P1P2/1PP1P2P/BRNQKBNR w HBhb - 0 9	20	441	9782	240220	5770284	153051835
+       515	2nqknrb/1rpppppp/5B2/pp6/1PP1b3/3P4/P3PPPP/1RNQKNRB w GBg - 1 9	35	1042	36238	1101159	38505058	1202668717
+       516	rb1nqknr/1pp1pppp/8/3p4/p2P4/6PN/PPPQPP1P/RBBN1K1R w HAha - 0 9	29	692	21237	555018	17820605	497251206
+       517	rnbbqknr/pppp4/5p2/4p1pp/P7/2N2PP1/1PPPP2P/R1BBQKNR w HAha - 0 9	23	595	14651	415772	10881112	329010121
+       518	rn1qkbnr/p1p1pp1p/bp4p1/3p4/1P6/4P3/P1PP1PPP/RNBQKBNR w HAha - 0 9	30	794	24319	690811	21657601	647745807
+       519	r1bqk1rb/pppnpppp/5n2/3p4/2P3PP/2N5/PP1PPP2/R1BQKNRB w GAga - 1 9	32	821	27121	733155	24923473	710765657
+       520	rbnqbknr/1p1ppp1p/6p1/p1p5/7P/3P4/PPP1PPP1/RBNQBKNR w HAha - 0 9	24	720	18842	575027	15992882	501093456
+       521	r1qbbk1r/pp1ppppp/n1p5/5n2/B1P3P1/8/PP1PPP1P/RNQ1BKNR w HAha - 0 9	27	831	22293	698986	19948650	637973209
+       522	rnqkbb1r/p1pppppp/8/8/1p4n1/PP4PP/2PPPP2/RNQKBBNR w HAha - 0 9	18	463	9519	256152	6065231	172734380
+       523	rnqk1nrb/pppbpp2/7p/3p2p1/4B3/2N1N1P1/PPPPPP1P/R1QKB1R1 w GAga - 0 9	34	1171	38128	1318217	42109356	1465473753
+       524	rbnqknbr/1pp1ppp1/3p4/7p/p2P2PP/2P5/PP2PP2/RBNQKNBR w HAha - 0 9	32	867	28342	798722	26632459	781067145
+       525	rn1bknbr/pq2pppp/1p6/2pp4/P7/1P1P4/2PNPPPP/RNQBK1BR w HAha - 0 9	24	627	16652	462942	13200921	385193532
+       526	r1qk1bbr/ppp1pp1p/2np1n2/6p1/2PP4/3BP3/PP3PPP/RNQKN1BR w HAha - 2 9	31	992	30213	986631	30397368	1011631987
+       527	r1qknrbb/pppp1p2/2n3p1/4p2p/8/QPP5/P1NPPPPP/RN1K1RBB w FAfa - 2 9	30	702	21563	532939	16813114	438096194
+       528	bbkr1qnr/2pppppp/2n5/pp6/8/PPN5/1BPPPPPP/1BR1KQNR w HC - 2 9	25	573	15183	380910	10554668	283975400
+       529	1rnbkqnr/1bpppppp/1p6/7P/p2P4/5P2/PPP1P1P1/BRNBKQNR w HBhb - 0 9	21	503	11790	301084	7679979	207799378
+       530	brnkqbnr/2p1pppp/1p6/3p4/1pP5/P6P/3PPPP1/BRNKQBNR w HBhb - 0 9	28	743	21054	587192	17354516	507176753
+       531	br1kqnrb/npp1pppp/8/3p4/p4N2/PP6/2PPPPPP/BR1KQNRB w GBgb - 0 9	31	808	25585	698475	22376575	640362920
+       532	rbbnkq1r/pppppp1p/7n/6p1/P5P1/2P2N2/1P1PPP1P/RBBNKQ1R w HAha - 1 9	29	580	17585	404831	12730970	325226128
+       533	rnbbk1nr/pp2qppp/2ppp3/8/3P4/P1N4N/1PP1PPPP/R1BBKQ1R w HAha - 0 9	29	838	24197	721884	21100580	646624429
+       534	rnbk1b1r/ppppn1pp/4pp2/7q/7P/P5PB/1PPPPP2/RNBKQ1NR w HAha - 3 9	20	729	16633	576199	14507076	498621813
+       535	r2kqnrb/pbppppp1/np5p/8/4Q1P1/3P4/PPP1PP1P/RNBK1NRB w GAga - 2 9	47	1219	55009	1486353	65239153	1834391369
+       536	rbnkbq1r/p1p2ppp/1p2pn2/3p4/P3P3/3P4/1PP1KPPP/RBN1BQNR w ha - 2 9	29	923	27179	883866	26202752	868565895
+       537	rk1bb1nr/ppppqppp/n7/1N2p3/6P1/7N/PPPPPP1P/R1KBBQ1R w HA - 6 9	27	703	19478	559525	16049807	492966455
+       538	rnkqbbnr/p1ppp2p/1p4p1/8/1B3p1P/2NP4/PPP1PPP1/R1KQ1BNR w HAha - 0 9	29	610	18855	438277	14020041	355083962
+       539	rnkqb1rb/pp1p1ppp/4p3/2P3n1/8/1PP5/P3PPPP/RNKQBNRB w GAga - 0 9	29	675	20699	535821	17000613	476598337
+       540	rb1kqnbr/pp1pp1p1/1np2p2/7p/P1P3PP/8/1P1PPP2/RBNKQNBR w HAha - 0 9	31	1077	33661	1183381	37415304	1328374620
+       541	rnkbq1br/ppp2ppp/3p4/Q3p1n1/5P2/3P2P1/PPP1P2P/RNKB1NBR w HAha - 0 9	41	1201	46472	1420367	52991625	1675608008
+       542	rn1qnbbr/pp2pppp/2ppk3/8/2PP4/3Q1N2/PP2PPPP/RNK2BBR w HA - 1 9	34	666	22474	472299	15860369	353831792
+       543	rnkqnr1b/ppppp1pp/5p2/8/Q1P2P2/8/PP1P2PP/RbK1NRBB w FAfa - 0 9	36	876	31987	788580	29022529	736717252
+       544	bbrn1nqr/ppp1k1pp/5p2/3pp3/7P/3PN3/PPP1PPP1/BBRK1NQR w - - 1 9	24	583	15063	383532	10522064	280707118
+       545	brnbkn1r/1pppp1p1/4q3/p4p1p/7P/1N3P2/PPPPP1PQ/BR1BKN1R w HBhb - 2 9	27	935	26120	885699	26000648	873063158
+       546	br1knbqr/pp2p1pp/1n6/2pp1p2/6P1/2P4B/PP1PPPQP/BRNKN2R w HBhb - 0 9	27	681	19202	510687	14954779	415624943
+       547	brnk1qrb/p1ppppp1/1p5p/8/P3n3/1N4P1/1PPPPPRP/BR1KNQ1B w Bgb - 0 9	22	638	13991	412346	9760752	293499724
+       548	rbbnknqr/pppp3p/5pp1/8/1P1pP3/7P/P1P2PP1/RBBNKNQR w HAha - 0 9	29	756	21616	614074	17602252	528140595
+       549	1nbbknqr/rpp1ppp1/1Q1p3p/p7/2P2PP1/8/PP1PP2P/RNBBKN1R w HAh - 2 9	37	977	34977	944867	33695089	940198007
+       550	rnb2bqr/ppkpppp1/3n3p/2p5/6PP/2N2P2/PPPPP3/R1BKNBQR w HA - 2 9	30	647	20365	467780	15115531	369257622
+       551	rn1k1qrb/p1pppppp/bp6/8/4n3/P4BPP/1PPPPP2/RNBKNQR1 w GAga - 2 9	22	670	14998	451517	11199653	339919682
+       552	rb2bnqr/nppkpppp/3p4/p7/1P6/P2N2P1/2PPPP1P/RB1KBNQR w HA - 3 9	22	479	11475	264739	6831555	167329117
+       553	r1kbb1qr/2pppppp/np2n3/p7/2P3P1/8/PP1PPPQP/RNKBBN1R w HAha - 1 9	32	723	23953	581832	19472074	504622114
+       554	rnknbb1r/p1ppp1pp/8/1p1P1p1q/8/P1P5/1P2PPPP/RNKNBBQR w HAha - 1 9	19	607	12733	417451	9753617	325177085
+       555	rnkn1qrb/pp1bp1pp/2p5/1N1p1p2/8/2P5/PPKPPPPP/R2NBQRB w ga - 2 9	27	533	14549	330747	9206957	232664675
+       556	r1nknqbr/pp2p1pp/2p2p2/3p4/6P1/PP1P4/2P1PP1b/RBNKNQBR w HAha - 0 9	20	582	13777	409166	10708639	326565393
+       557	rnkb1qbr/p1pp1p1p/1p2pn2/1Q4p1/4P3/N4P2/PPPP2PP/R1KBN1BR w HAha - 0 9	40	1038	39356	1051441	39145902	1079612614
+       558	rn2qbbr/1pkppp1p/p3n1p1/8/8/2P2P2/PP1PP1PP/RNKN1BBR w HA - 0 9	24	605	14888	385964	9687507	260874068
+       559	rn1nqrbb/p1kppp1p/8/1pp3p1/1P6/2N1P3/P1PP1PPP/RK1NQRBB w - - 0 9	21	540	12489	337997	8436136	237525904
+       560	bbrnknrq/1pp3pp/p2p1p2/4p3/P7/1P2N3/2PPPPPP/BBRN1RKQ w gc - 0 9	24	527	13900	326175	9139962	226253685
+       561	brnb1nrq/pppp1kpp/4p3/8/5p1P/P1P3P1/1P1PPP2/BRNBKNRQ w GB - 1 9	29	773	23904	638768	20503775	560338709
+       562	br1k1brq/ppppp2p/1n1n1pp1/8/P1P5/3P2P1/1P2PP1P/BRNKNBRQ w GBgb - 0 9	28	811	23550	664880	19913758	565143976
+       563	1r1knrqb/n1pppppp/p1b5/1p6/8/3N1P2/PPPPP1PP/BRNK1RQB w fb - 3 9	29	753	23210	620019	20044474	558383603
+       564	rbbnk1rq/pppppppp/8/3Pn3/8/4P1P1/PPP2P1P/RBBNKNRQ w GAga - 1 9	22	551	12619	324608	8204171	217689974
+       565	rnbbk1rq/2pppp1p/p3n1p1/1p6/P3N3/8/1PPPPPPP/RNBB1KRQ w ga - 0 9	26	742	20061	599527	16787080	525678162
+       566	rnbkn1rq/ppppppb1/6p1/7p/2B2P2/1P2P3/P1PP2PP/RNBKN1RQ w GAga - 1 9	28	799	23210	689436	20755098	639632905
+       567	rn1knrqb/p2pppp1/b1p5/1p5p/2P2P2/1P6/P2PP1PP/RNBKNRQB w FAfa - 1 9	30	579	18481	397545	13257198	311282465
+       568	rbnkbnrq/pp2p1Np/2p2p2/8/3p4/8/PPPPPPPP/RBNKBR1Q w Aga - 0 9	23	670	16435	501883	13012378	411860744
+       569	rk1bbnrq/ppp1pppp/n7/3p4/5P2/3P2NP/PPP1P1P1/RNKBB1RQ w GA - 0 9	26	597	16238	402506	11269462	296701249
+       570	r1knbbrq/pppp2p1/2n1p2p/5p2/4P3/P1PP4/1P3PPP/RNKNBBRQ w GAga - 1 9	20	596	13091	399069	9416862	293659781
+       571	rnknbrqb/p1p1pp1p/3p4/1p1N2p1/8/N7/PPPPPPPP/1RK1BRQB w Ffa - 0 9	26	724	18942	552040	15257204	461293885
+       572	rbnknrb1/1p1ppp1p/p1p3p1/8/1P3P2/1R6/PqPPP1PP/RBNKN1BQ w Afa - 0 9	31	1183	34723	1289502	38722152	1421492227
+       573	rnkbnrbq/2p1ppp1/p7/1p1p3p/3P4/1P4P1/P1P1PP1P/RNKBNRBQ w FAfa - 0 9	24	506	12748	301464	8086100	207129256
+       574	r1knrbbq/pp1ppppp/2p1n3/8/2P3P1/P7/1PKPPP1P/RN1NRBBQ w ea - 0 9	28	570	16037	352471	10278695	242592363
+       575	rnknrq1b/ppp1p1p1/4b3/3p1p1p/6P1/P4P2/1PPPPQ1P/RNKNR1BB w EAea - 2 9	30	739	23124	594962	19252739	521629794
+       576	bbqr1krn/pppp1p1p/5n2/4p1p1/3P4/P3QP2/1PP1P1PP/BB1RNKRN w GDgd - 0 9	31	799	25627	674913	22172123	609277274
+       577	bq1b1krn/pp1ppppp/3n4/2r5/3p3N/6N1/PPP1PPPP/BQRB1KR1 w GCg - 2 9	21	798	18571	688429	17546069	647165916
+       578	bqrnkbrn/2pp1pp1/p7/1p2p2p/1P6/4N3/P1PPPPPP/BQR1KBRN w GCgc - 0 9	27	783	22327	670798	20059741	624462073
+       579	bqr1krnb/1np1pppp/8/pp1p4/8/2P2N2/PP1PPPPP/BQRNKR1B w FCfc - 0 9	28	636	18874	461104	14237097	372181570
+       580	qbb1rkrn/1ppppppp/p7/7n/8/P2P4/1PP1PPPP/QBBRNKRN w Gg - 0 9	25	547	13837	332918	8849383	229112926
+       581	1rbbnkrn/p1p1pp1p/2q5/1p1p2p1/8/2P3P1/PP1PPP1P/QRBBNKRN w GBgb - 2 9	24	1010	24370	983770	24328258	961371180
+       582	qrb1kbrn/ppp1p2p/4npp1/3p4/8/1PP4P/PR1PPPP1/Q1BNKBRN w Ggb - 1 9	18	451	9291	247310	5568106	155744022
+       583	qr2krnb/p1p1pppp/b1np4/1p6/3NP3/7P/PPPP1PP1/QRBNKR1B w FBfb - 2 9	25	667	17081	476030	12458875	361495148
+       584	qbrnbkrn/ppp3pp/3p4/5p2/2P1pP2/6PP/PP1PP3/QBRNBKRN w GCgc - 0 9	24	650	16835	445263	12187382	326834539
+       585	qrnb1krn/ppp1p1pp/5p2/2Np4/b2P4/2P5/PP2PPPP/QR1BBKRN w GBgb - 0 9	27	641	17490	432041	12103076	310695797
+       586	qrnkbbrn/pp2pp2/8/2pp2pp/6PP/3P4/PPPKPP2/QRN1BBRN w gb - 0 9	22	554	13116	357404	9014737	258925091
+       587	qrnkbrnb/p1p1ppp1/1p6/3p4/3P3p/5N1P/PPP1PPP1/QRNKBR1B w FBfb - 0 9	24	529	13205	318722	8295874	213856651
+       588	qbr1krbn/1pppp1pp/p7/5pn1/2PP4/8/PPB1PPPP/Q1RNKRBN w FCfc - 0 9	26	831	21651	696830	18961456	621884383
+       589	1rnbkrbn/1qp1pppp/3p4/pp6/4P3/1NP4P/PP1P1PP1/QR1BKRBN w FBfb - 0 9	24	597	15089	404761	10832084	307793179
+       590	q1rkrbbn/ppp1pppp/8/3p4/1PnP4/P7/1RP1PPPP/Q1NKRBBN w Ee - 1 9	20	520	10769	278067	6452205	170268300
+       591	qrnkrn1b/ppppp1pp/4b3/7P/6p1/P7/1PPPPP2/QRNKRNBB w EBeb - 0 9	26	566	15623	381312	10940750	287987207
+       592	bbr1nkrn/ppp1pppp/3q4/3p4/8/P7/1PPPPPPP/BBRQNRKN w gc - 5 9	19	661	13895	460396	10870247	356399665
+       593	brqbnkrn/pp1pp2p/5pp1/2p5/4P3/P2P1N2/1PP2PPP/BRQB1KRN w GBgb - 0 9	27	679	19916	527306	16391730	455940859
+       594	2qnkbrn/p1pppppp/8/1r6/1p2bP2/7N/PPPPP1PP/BR1QKBRN w GBg - 4 9	18	774	15713	635461	14371755	559579332
+       595	r1qnkr1b/p1pppppp/7n/1p6/8/1P3b1N/PRPPPPPP/B1QNK1RB w f - 5 9	21	677	15437	501520	12463801	410795298
+       596	rbbqn1rn/pppp1pp1/3k4/4p2Q/2PPP3/8/PP3PPP/RBB1NKRN w GA - 1 9	40	742	28757	579833	21852196	471452088
+       597	rqbbnkrn/3pppp1/p1p4p/1p6/5P2/P2N4/1PPPP1PP/RQBBK1RN w ga - 0 9	23	665	16400	492544	12794736	396640086
+       598	r2nkbrn/pp2pppp/8/2ppqb2/2P3P1/5P2/PP1PPN1P/RQB1KBRN w GAga - 3 9	28	1108	31164	1194581	34780853	1292405738
+       599	rqbnk1nb/p1pppr1p/5p2/1p4p1/1PP1P3/8/P2P1PPP/RQBNKRNB w FAa - 1 9	26	650	18208	491403	14565370	416833400
+       600	rbqnb1rn/p1pp1kpp/1p2pp2/8/4P2P/P5P1/1PPP1P2/RBQNBKRN w GA - 0 9	20	437	9423	222154	5282124	132309824
+       601	rqnbbkrn/p1p1pppp/3p4/1p5B/8/1P1NP3/P1PP1PPP/RQ2BKRN w GAga - 0 9	30	606	18382	422491	12989786	326601372
+       602	rqnkbbr1/ppppp1pp/5p2/7n/8/2PNP2P/PP1P1PP1/RQ1KBBRN w GAga - 1 9	23	482	12506	297869	8430874	217797292
+       603	r1nkbrnb/2ppppp1/1q6/pp5p/1P6/P3P3/2PPKPPP/RQN1BRNB w fa - 2 9	25	827	21518	701071	19290675	632892337
+       604	rbqnkrbn/p1ppppp1/7p/1p6/7P/2N1P3/PPPP1PPB/RBQ1KR1N w FAfa - 1 9	30	627	18566	440217	12976682	337377291
+       605	r1nbkrbn/p1qp1ppp/8/1pp1p3/2P1P3/6P1/PP1PBP1P/RQN1KRBN w FAfa - 2 9	22	616	14503	431199	10850952	335943324
+       606	rqnkr1bn/ppp1ppb1/3p2pp/8/P7/2P2P2/1PKPP1PP/RQN1RBBN w ea - 1 9	31	679	21365	493500	15661072	379844460
+       607	r2krnbb/qppp1ppp/1n6/p3p3/PP6/4N3/N1PPPPPP/RQ1KR1BB w EAea - 4 9	24	645	17054	487028	13837270	416239106
+       608	bbr1qk1n/1ppppp1p/2n5/p7/P7/1P2P3/2PP1PrP/1BRNQKRN w GCc - 0 9	18	520	10680	304462	7215306	207612575
+       609	brnbq1rn/2ppppkp/p5p1/1p6/8/1BP3P1/PP1PPP1P/BRN1QRKN w - - 0 9	21	625	13989	419667	9929336	300902534
+       610	brn1kbrn/pp2p1pp/3p4/q1p2p2/2P4P/6P1/PP1PPP2/BRNQKBRN w GBgb - 1 9	18	477	10205	273925	6720181	187205941
+       611	brn1krnb/p3pppp/1qpp4/1p6/2P3P1/1P6/P2PPP1P/BRNQKRNB w FBfb - 1 9	30	835	24761	716151	21806428	654487872
+       612	r1b1qkrn/1p1ppppp/p1p1n3/8/4P3/1PN5/P1PPQPPb/RBB2KRN w GAga - 0 9	28	825	24536	716585	22079005	647939781
+       613	r1bbqk1n/p1pppprp/n7/1p4p1/5P2/2N3N1/PPPPP1PP/1RBBQKR1 w Ga - 4 9	25	545	14657	358854	10271111	273864588
+       614	rnbqkbrn/p1pp1pp1/4p3/7p/2p4P/2P5/PP1PPPP1/R1BQKBRN w GAga - 0 9	17	445	9076	255098	5918310	174733195
+       615	rnbqkrnb/1p1pp1p1/2p4p/p4p2/3P2P1/7N/PPPBPP1P/RN1QKR1B w FAfa - 0 9	34	746	25319	623133	21285553	569141201
+       616	rbnqbkr1/1ppppp2/p5n1/6pp/4P3/1N6/PPPP1PPP/RBQ1BRKN w ga - 2 9	18	466	9683	260864	6051500	170135726
+       617	rnqb1krn/ppppp1p1/7p/7b/P1P2pPP/8/1P1PPP2/RNQBBKRN w GAga - 0 9	24	575	15400	385825	11039042	291243811
+       618	rnqkbbr1/p1pp1ppp/4p3/1p6/P3P2n/5P2/1PPP1NPP/RNQKBBR1 w GAga - 2 9	27	803	22883	694449	20666099	638696065
+       619	rn1kbrnb/1qppp1pp/1p6/p4p2/1B1P4/1P5N/P1P1PPPP/RNQK1R1B w FAfa - 0 9	37	1209	43015	1425600	49748034	1671593862
+       620	rbnqkrbn/Bppp1p2/p5pp/4p3/5P2/6PP/PPPPP3/RBNQKR1N w FAfa - 0 9	29	720	20434	534148	15384362	421343249
+       621	rnqbkr1n/1p1ppbpp/3p1p2/p7/8/1P6/P1PPPPPP/R1QBKRBN w FAfa - 0 9	20	657	14424	492678	11843134	413965054
+       622	rnqkrb1n/ppppp3/6p1/5p1p/2b2P2/P1N5/1PPPP1PP/RQ1KRBBN w EAea - 1 9	28	749	20684	543151	15379233	417191461
+       623	rnqk1nbb/1pp2ppp/3pr3/p3p3/3P1P2/2N3N1/PPP1P1PP/R1QKR1BB w EAa - 1 9	29	883	26412	815098	25144295	789705382
+       624	bbr1kqrn/p1p1ppp1/1p2n2p/3p4/1P1P4/2N5/P1P1PPPP/BBR1KQRN w GCgc - 0 9	22	485	11475	271271	6825123	171793012
+       625	brnbkq1n/ppp1ppr1/7p/3p2p1/2P3PP/8/PPBPPP2/BRN1KQRN w GBb - 2 9	30	634	19017	442537	13674310	345386924
+       626	brnkqbr1/1pppp1pp/5p2/p7/P1P1P2n/8/1P1P1PP1/BRNKQBRN w GBgb - 0 9	21	504	11672	305184	7778289	217596497
+       627	b1rkqrnb/p1ppp1pp/1p1n4/5p2/5P2/PN5P/1PPPP1P1/BR1KQRNB w FBf - 0 9	23	688	17259	531592	14228372	451842354
+       628	1bbnkqrn/rppppp2/p5p1/7p/7P/P1P1P3/1P1P1PP1/RBBNKQRN w GAg - 1 9	25	450	12391	263946	7752404	185393913
+       629	rnbbkqr1/1pppppp1/7p/p3n3/PP5P/8/1BPPPPP1/RN1BKQRN w GAga - 0 9	23	543	12224	305812	7549008	199883770
+       630	r1bkqbrn/ppppp1pp/8/5p2/3nPP2/1P4N1/P1PP2PP/RNBKQBR1 w GAga - 1 9	27	751	21158	600417	17989920	527273615
+       631	rnbkqr1b/1p1pp1pp/p4p1n/2p5/1P5P/N4P2/P1PPP1P1/R1BKQRNB w FAfa - 0 9	21	498	11738	302278	7808375	216224115
+       632	rbnkbqrn/p1p3pp/1p1p4/B3pp2/3P2P1/6N1/PPP1PP1P/RBNK1QR1 w GAga - 0 9	34	977	33464	961128	33318567	978991050
+       633	r1kbbqrn/ppp3pp/2np1p2/1P2p3/3P1P2/8/P1P1P1PP/RNKBBQRN w GAga - 0 9	32	920	28916	844881	26763259	797524786
+       634	rk1qbbrn/p2npppp/1p6/2p4Q/8/4P3/PPPP1PPP/RNK1B1RN w GA - 2 9	35	657	22359	495406	16662477	419496845
+       635	rnk1brnb/pp1p1pp1/8/q1p1p2p/5P2/NP6/P1PPP1PP/R1KQBRNB w FAfa - 1 9	26	774	20215	610661	16987110	523437649
+       636	rb1kqrbn/npp1ppp1/p7/3P3p/2PP4/8/PP3PPP/RBNKQRBN w FAfa - 0 9	35	775	27395	661118	23983464	625669222
+       637	rnkb1rbn/pp1p2pp/8/2p1pp1q/P6P/1PN5/2PPPPP1/R1KBQRBN w FAfa - 1 9	22	899	21188	850597	21518343	857951339
+       638	rnkqrbbn/1pppp1p1/8/p2N1p1p/2P4P/8/PP1PPPP1/R1KQRBBN w EAea - 0 9	29	585	17571	393221	12238776	299752383
+       639	rnk1r1bb/pp1ppppp/1q4n1/2p5/5P1P/3PP3/PPP3P1/RNKQRNBB w EAea - 1 9	27	884	24613	811915	23698701	790239502
+       640	bbrnkrqn/1ppp1p2/6pp/p3p3/5PP1/2PB4/PP1PP2P/B1RNKRQN w FCfc - 0 9	37	693	25425	550527	20138432	481498664
+       641	b1rbkrqn/ppp2ppp/1n2p3/3p4/6P1/2PP4/PP2PP1P/BRNBKRQN w FBf - 1 9	21	463	10610	253204	6307276	159025909
+       642	brnkrb1n/1pp1p1pp/3p4/p1Nq1p2/2P5/8/PP1PPPPP/BRK1RBQN w eb - 2 9	27	725	17842	496072	12604078	362747791
+       643	brn1r1nb/ppppkppp/4p3/8/2PP1P2/8/PP1KP1PP/BRN1RQNB w - - 1 9	25	623	16874	426659	12290985	317097424
+       644	rbb1krqn/1pp1pp1p/p3n1p1/3pP3/8/1PN5/P1PP1PPP/RBB1KRQN w FAfa d6 0 9	23	529	12641	310277	7861413	202594556
+       645	r1bbkrqn/p1pppppp/8/4n3/1p5P/P2P2P1/1PP1PP2/RNBBKRQN w FAfa - 0 9	23	571	13133	346793	8699448	243460643
+       646	rnbkrbqn/p1pp1ppp/4p3/1p6/8/BPN3P1/P1PPPP1P/R2KRBQN w EAea - 2 9	29	692	20014	500375	14904192	386694739
+       647	rnbkrqn1/pppppp2/8/1Q2b1pp/P3P3/5P2/1PPP2PP/RNBKR1NB w EAea - 0 9	37	1001	36440	987842	35626426	993747544
+       648	rbnkbrqn/p1pppp2/7p/1p4pP/3P1P2/8/PPP1P1P1/RBNKBRQN w FAfa - 0 9	30	564	17143	381364	11859538	293703269
+       649	1nkbbrqn/3ppppp/r1p5/pp6/8/4PP2/PPPPN1PP/RNKBBRQ1 w FAf - 2 9	26	546	14641	344592	9556962	245137199
+       650	rnkrbbq1/pppppnp1/7p/8/1B1Q1p2/3P1P2/PPP1P1PP/RNKR1B1N w DAda - 2 9	43	887	36240	846858	33185346	851927292
+       651	1rkrbqnb/pppppp2/2n3p1/7p/3P3P/P4N2/1PP1PPP1/RNKRBQ1B w DAd - 0 9	26	622	16049	403921	10786140	285233838
+       652	rbnkr1bn/pp1pqp1p/2p1p3/6p1/3P4/7P/PPP1PPP1/RBNKRQBN w EAea - 0 9	19	566	12257	381197	9107175	293397389
+       653	r1kbrqb1/pppp2pp/2n1p1n1/5p1B/4PP2/P7/1PPP2PP/RNK1RQBN w EAea - 2 9	39	1359	53626	1876028	73871486	2633945690
+       654	rnkrqbbn/p1p3pp/1p1ppp2/8/1P6/3P2P1/PKP1PP1P/RN1RQBBN w da - 0 9	26	776	20735	611907	16884013	503561996
+       655	rnkrqnbb/ppp2p1p/3p4/4p1p1/3P3P/N1Q5/PPP1PPP1/R1KR1NBB w DAda - 0 9	40	1175	45637	1375884	52620163	1633655838
+       656	bbrnkrn1/p1pppp2/1p6/6pp/3q4/1P3QP1/P1PPPP1P/BBRNKRN1 w FCfc - 0 9	34	1398	45749	1712950	57268492	2059942014
+       657	br1bkrnq/1p2pppp/pnp5/3p4/P1P5/5P2/1P1PPKPP/BRNB1RNQ w fb - 2 9	24	501	12237	284936	7049659	177940764
+       658	brnkrbn1/pppppp1q/B6p/6p1/8/1P2PP2/P1PP2PP/BRNKR1NQ w EBeb - 0 9	34	815	25868	700970	22006883	639803952
+       659	br1krnqb/pppppp1p/1n4p1/8/8/P2NN3/2PPPPPP/BR1K1RQB w Beb - 2 9	37	1029	36748	1025712	36214583	1026195877
+       660	rbbnkr1q/p1p2ppp/1p1ppn2/8/1PP4P/8/P2PPPP1/RBBNKRNQ w FAfa - 0 9	28	755	22623	605106	18972778	513486101
+       661	r1b1krnq/pp2pppp/1bn5/2pp4/4N3/5P2/PPPPPRPP/R1BBK1NQ w Afa - 0 9	24	705	17427	532521	13532966	426443376
+       662	1nbkrbn1/rpppppqp/p7/6p1/4P3/3P2P1/PPP1KP1P/RNB1RBNQ w e - 1 9	31	800	24748	693366	21193292	625757852
+       663	r1bkrnqb/pp3ppp/n1ppp3/8/1P5P/P7/R1PPPPP1/1NBKRNQB w Eea - 0 9	21	482	11417	275339	7112890	180378139
+       664	rbnkbrnq/ppp1p2p/5p2/3p2p1/1B1P4/1N4P1/PPP1PP1P/RB1K1RNQ w FAfa - 0 9	33	780	25532	628945	20756770	535497008
+       665	rnk1brnq/pp1ppppp/2p5/b7/8/1P2P2P/P1PP1PPQ/RNKBBRN1 w FAfa - 3 9	29	648	19043	449637	13722785	341389148
+       666	rnkrbbnq/p1p3pp/5p2/1p1pp3/P7/1PN2P2/2PPP1PP/R1KRBBNQ w DAda - 0 9	26	827	21865	683167	18916370	589161126
+       667	r1krbnqb/p1pp1ppp/2n1p3/8/1p4P1/PPP5/3PPP1P/RNKRBNQB w DAda - 1 9	25	540	14709	331332	9491817	225389422
+       668	rbnkrnbq/ppp1pp2/3p2p1/2N5/P6p/2P5/1P1PPPPP/RB1KRNBQ w EAea - 0 9	32	790	25107	661207	20906017	578332225
+       669	rnkbrn1q/1ppppppb/8/p4N1p/8/P1N5/1PPPPPPP/R1KBR1BQ w EAea - 0 9	31	691	20813	510665	15308408	404129987
+       670	rnkrnbbq/p1p2ppp/3pp3/1p6/6P1/4PQ1B/PPPP1P1P/RNKRN1B1 w DAda - 0 9	29	558	16800	352887	10825379	246965507
+       671	rnkrnqbb/pp2p1p1/3p3p/2p2p2/5P2/1P1N4/P1PPPQPP/RNKR2BB w DAda - 0 9	29	762	23210	644936	20522675	596067005
+       672	bb1rknnr/ppqppppp/8/2p5/3P1N2/1P6/P1P1PPPP/BBQRKN1R w HDhd - 1 9	33	963	32279	1000890	34552118	1124738493
+       673	bqrbknnr/ppp1p2p/8/3p1p2/5p2/P3N2P/1PPPP1P1/BQRBK1NR w HChc - 0 9	20	398	9009	194859	4834319	113660536
+       674	b1rk1bnr/qpp1pppp/p4n2/3p4/3PPP2/7N/PPP3PP/BQRKNB1R w HChc - 1 9	25	648	16587	455720	12200870	351766307
+       675	bqkrnnrb/pppp2p1/4pp2/4P2p/6P1/7P/PPPP1P2/BQRKNNRB w GC - 1 9	30	493	15118	280726	8786998	181492621
+       676	q1brknnr/1p1ppppp/p7/2p5/8/1PPP4/P2RPPPP/QBB1KNNR w Hhd - 0 9	25	501	13206	290463	7982978	192717198
+       677	qrb1k1nr/ppppb1pp/6n1/4ppN1/3P4/4N3/PPP1PPPP/QRBBK2R w HBhb - 2 9	31	872	26191	739276	22493014	646855304
+       678	1rbknbnr/1ppp1pp1/q6p/p3p3/5P2/2PPB3/PP2P1PP/QR1KNBNR w HBhb - 0 9	28	1020	28147	984000	27484692	947786800
+       679	qrbk2rb/1ppp1ppp/5nn1/p3p3/1N6/P7/1PPPPPPP/QRB1KNRB w gb - 0 9	23	592	14398	395716	10098215	293988585
+       680	qbrk1nnr/1pp1pppp/2b5/p2p4/P2P2P1/8/1PP1PP1P/QBKRBNNR w hc - 1 9	26	654	18103	471653	13740891	373081138
+       681	qrkbbnnr/ppp2p1p/4p3/3p2p1/P7/2PP4/1P2PPPP/QRKBBNNR w HBhb - 0 9	25	626	16616	431634	12079406	324006164
+       682	qr1kbbnr/ppp1pp1p/4n1p1/2Pp4/6P1/4N3/PP1PPP1P/QRK1BBNR w HB d6 0 9	26	699	18068	497152	13353359	375702908
+       683	qrk1b1rb/p1pppppp/3nnQ2/1p6/1P3P2/3P4/P1P1P1PP/1RKNBNRB w GBgb - 3 9	43	1369	55463	1831200	71514365	2427477375
+       684	qbrk1nbr/pppp3p/5n2/4ppp1/3P1P2/4N3/PPP1P1PP/QBKRN1BR w hc - 0 9	25	752	20165	615263	17493373	543180234
+       685	qrkb1nbr/1pppppQp/3n4/p7/5p2/1P1N4/P1PPP1PP/1RKB1NBR w HBhb - 0 9	45	946	40100	966903	39736157	1051910977
+       686	qrk1nbbr/ppp1p1p1/4n2p/3p1p2/1P5P/3P2P1/P1P1PP2/QRKNNBBR w HBhb - 1 9	32	770	25367	646977	21717615	577979364
+       687	qrkn1rbb/pp2pppp/2p5/3p4/P2Qn1P1/1P6/2PPPP1P/1RKNNRBB w FBfb - 0 9	38	943	35335	868165	31909835	798405123
+       688	bbrqknnr/ppp4p/3pp3/5pp1/4PP2/5Q2/PPPP2PP/BBR1KNNR w HChc - 0 9	36	843	29974	758528	26828059	723306114
+       689	1rqbkn1r/p1p1pppp/1p5n/P2p4/3Pb1P1/8/1PP1PP1P/BRQBKNNR w HBhb - 0 9	23	778	19482	649789	17337683	579112676
+       690	br1knbnr/1qp1pppp/pp1p4/8/8/PP6/2PPPPPP/BRQKNBNR w HBhb - 2 9	26	697	18835	546622	15280079	473071890
+       691	brqk2rb/ppppp1pp/4np2/8/2n5/3P1Q2/PP2PPPP/BR1KNNRB w GBgb - 0 9	32	948	30434	885713	29821322	874251866
+       692	r1bqknnr/pp1pp1p1/5p1p/2p1b2N/2P5/8/PPQPPPPP/RBB1K1NR w HAha - 0 9	31	785	25549	659952	22244193	592797491
+       693	rqbbknnr/ppppp2p/5pp1/8/8/1P3PP1/PQPPP2P/R1BBKNNR w HAha - 0 9	23	391	10163	198450	5576671	121267576
+       694	rqbknbnr/1pp1p2p/p7/3p1pp1/7N/1PP5/P2PPPPP/RQBK1BNR w HAha - 0 9	27	676	19606	522428	15955388	448477218
+       695	rqb1nnrb/2ppkppp/1p2p3/p7/2PPP3/1P6/P4PPP/RQBKNNRB w GA - 1 9	31	727	22895	570647	18361051	483248153
+       696	rb1kbn1r/p1ppppp1/qp5n/7p/P7/RPP5/3PPPPP/1BQKBNNR w Hha - 2 9	29	837	23815	730083	21279560	682863811
+       697	rqkbb1nr/p1p2ppp/1p1p2n1/3Np3/4P3/5N2/PPPP1PPP/RQKBB2R w HAha - 0 9	28	717	20663	550987	16347343	453153783
+       698	rqknbbr1/p1pppp1p/1p3np1/8/4P3/2P2P1P/PP1P2P1/RQKNBBNR w HAa - 0 9	27	650	18231	475303	13847463	383256006
+       699	r1k1bnrb/1qpppppp/1p2n3/p7/1P5P/6P1/P1PPPP2/RQKNBNR1 w GAga - 1 9	24	806	20693	713220	19382263	686009788
+       700	rb1knnbr/1pp1ppp1/p2p3p/5q2/3B2P1/3P1P2/PPP1P2P/RBQKNN1R w HAha - 0 9	34	1360	44096	1605706	51973672	1837704407
+       701	rqkb1nbr/p1p1ppp1/1p3n1p/2Qp4/8/2P5/PP1PPPPP/R1KBNNBR w HAha - 2 9	39	983	38218	940989	36347815	918801645
+       702	rqknnbbr/2pppp2/pp5p/6p1/1P1P4/4PP2/P1P3PP/RQKNNBBR w HAha - 0 9	26	628	17638	464924	13787303	386125234
+       703	rqkn1rbb/1pp1pppp/p7/3p4/3Pn3/2P1PP2/PP4PP/RQKNNRBB w FAfa - 1 9	20	527	12216	321533	8082183	219311659
+       704	bbrkqn1r/1pppppp1/5n2/p7/1PP2P1p/7N/P2PP1PP/BBRKQN1R w HChc - 1 9	36	963	35291	973839	35907489	1034223364
+       705	brkbqn1r/p2ppppp/7n/1p6/P1p3PP/8/1PPPPP1N/BRKBQ1NR w HBhb - 0 9	18	583	11790	394603	8858385	304339862
+       706	brkq1bnr/pp1ppp1p/8/2p2np1/P7/8/1PPPPPPP/BRKQNBNR w HBhb - 0 9	19	552	11811	354260	8432183	262293169
+       707	brkqnnrb/1ppppppp/8/8/p3P3/5N2/PPPP1PPP/BRKQ1NRB w GBgb - 3 9	21	397	9653	204350	5489836	128389738
+       708	rbbkq1nr/1p2pppp/p1p3nB/3p4/1Q1P4/6N1/PPP1PPPP/RB1K2NR w HAha - 0 9	40	1132	43404	1260470	47425783	1415578783
+       709	rkbbq1nr/1pppp1p1/4np2/p6p/8/PP3P2/1KPPP1PP/R1BBQNNR w ha - 0 9	24	596	15220	402121	10822049	302056813
+       710	r1bqn1nr/pkpppp1p/1p4pb/8/PN6/R7/1PPPPPPP/1KBQ1BNR w H - 2 9	33	794	25450	649150	20919309	561073410
+       711	rkb1nnrb/1pppq1pp/p4p2/4p3/5P2/1P1PB3/P1P1P1PP/RK1QNNRB w GAga - 0 9	26	625	17050	442036	12515042	342967558
+       712	rbkqbn1r/pppp1p1p/2n1p1p1/8/8/1P1PP1N1/P1P2PPP/RBKQB1NR w HAha - 1 9	30	660	20308	492714	15348335	403323883
+       713	rkqbb1n1/pppppppr/8/6np/5P2/8/PPPPP1PP/RKQBBNNR w HAa - 6 9	23	500	12154	292936	7519117	196524441
+       714	rkqnbbnr/ppppppp1/8/7p/3N4/6PP/PPPPPP2/RKQNBB1R w HAa - 0 9	24	484	12495	284570	7775173	193947530
+       715	rkqnb1rb/p1p1pppp/1p1p4/2n5/3P4/2P1N1N1/PP2PPPP/RKQ1B1RB w GAga - 0 9	28	1020	29124	1027904	30515456	1073711823
+       716	rbk1nnbr/1ppq1ppp/p2p4/4p3/P3B2P/2P5/1P1PPPP1/R1KQNNBR w HAha - 2 9	38	998	37265	1047592	38552638	1139322479
+       717	r1qbn1br/k1pppppp/6n1/pp6/5P1P/P7/1PPPP1PB/RKQBNN1R w HA - 1 9	22	549	12867	348574	8725809	251613569
+       718	rkqnn1br/pppp3p/4p1pb/5p2/P2P4/7P/1PP1PPPB/RKQNNB1R w HAha - 1 9	32	659	21249	469701	15434721	365761521
+       719	rk1nnrbb/p1p1pppp/1p6/3p1q2/P3P3/2NN4/1PPP1PPP/RKQ2RBB w FAfa - 3 9	29	989	29087	980477	29643404	998848556
+       720	bbrk1q1r/ppppppp1/3n4/7p/3Pn3/6PN/PPP1PPNP/BBRK1Q1R w HChc - 2 9	23	712	16551	516177	12995202	411077508
+       721	brkbnq1r/p1ppp2p/5ppn/1p6/5P2/1P1P2P1/P1P1P2P/BRKBNQNR w HBhb - 0 9	28	856	24984	780503	23529352	754501112
+       722	br1k1bnr/ppppp1pp/4np2/1B2P2q/3P4/8/PPP2PPP/BRKNQ1NR w HB - 3 9	36	1214	40615	1328331	45096834	1470987023
+       723	brk1qnrb/pnppp1p1/1p6/5p1p/8/5PPP/PPPPP1R1/BRKNQN1B w Bgb - 0 9	22	551	13111	353317	9040545	259643605
+       724	rbbkn1nr/1ppp2pp/p3p3/2q2p2/3P4/6P1/PPPBPP1P/RB1KNQNR w HAha - 0 9	31	1060	31332	1015099	30314172	976268967
+       725	rkbbn1nr/ppppp1pp/8/6N1/5p2/1q6/P1PPPPPP/RKBBN1QR w HAha - 0 9	3	72	1919	50827	1400832	39654253
+       726	rkb2bnr/pp2pppp/2p1n3/3p4/q2P4/5NP1/PPP1PP1P/RKBNQBR1 w Aha - 0 9	29	861	24504	763454	22763215	731511256
+       727	rkbq1nrb/ppppppp1/7p/8/1P1n4/P4P1P/2PPP1P1/RKBNQNRB w GAga - 0 9	25	672	17631	473864	12954224	361237536
+       728	rbknb1nr/ppp1qp1p/6p1/3pp3/3P3P/2B1P3/PPP2PP1/RBKN1QNR w HAha - 1 9	27	857	24688	792538	23790033	768247869
+       729	rknbbq1r/p1pppppp/1p2N3/8/3n4/2P5/PP1PPPPP/RK1BBQNR w HAha - 4 9	29	763	22138	574054	16926075	447896703
+       730	r1nqbbnr/1pppp1pp/1k6/p4p2/8/4P3/PPPP1PPP/RKN1BBNR w HA - 0 9	26	658	17302	464039	12380488	349047256
+       731	rkn2qrb/ppp1pppp/6n1/1b1p4/1P6/4PPB1/P1PP2PP/RKNQ1NRB w GAga - 3 9	23	574	14070	370324	9501401	263870337
+       732	rbkn2br/ppppp1p1/4np1p/1P5q/8/2P1N3/P2PPPPP/RBK1QNBR w HAha - 1 9	29	992	29506	999564	30148787	1045942540
+       733	1knbqnbr/1ppppp1p/r5p1/p7/7P/2PN2P1/PP1PPP2/RK1BQNBR w HAh - 2 9	26	698	19395	512023	14848229	402599313
+       734	rk1qnbbr/pnpppp1p/6p1/1p6/3P4/1P6/P1P1PPPP/RKNQNBBR w HAha - 1 9	20	480	11159	287539	7425917	203194521
+       735	rknqnrbb/pp1p2p1/5p1p/2p1p3/2P1P3/P2P4/1P3PPP/RKNQNRBB w FAfa - 0 9	26	679	18116	494953	13790137	392629571
+       736	bbrk2qr/pp1p1ppp/3n2n1/2p1p3/3P1P2/6N1/PPP1P1PP/BBRKN1QR w HChc - 0 9	26	790	21521	673269	19259490	617563700
+       737	b1krnnqr/1p1ppppp/p1p5/b6B/P7/4P1N1/1PPP1PPP/BRK1N1QR w HB - 2 9	26	625	16451	415452	11490615	304805107
+       738	1rknnbqr/3ppppp/p7/1pp5/4b2P/P4P2/1PPPP1PR/BRKNNBQ1 w Bhb - 1 9	24	757	19746	618777	17275100	544309489
+       739	br1nn1rb/pppkpqpp/3p1p2/8/PP6/4N3/1KPPPPPP/BR2NQRB w - - 3 9	24	682	17129	482711	13057308	375033550
+       740	rbbkn1qr/pppp2p1/6np/4pp2/7N/7P/PPPPPPPR/RBBK1NQ1 w Aha - 0 9	22	586	14158	409891	10607781	324452612
+       741	rk1bn1qr/pppbpppp/4n3/4p3/4P3/5P2/PPPP2PP/RKBB1NQR w HAha - 1 9	22	530	13440	348004	9514787	259898748
+       742	rkbnnbqr/1ppp1ppp/p7/4p3/8/QP3P2/P1PPP1PP/RKBNNB1R w HAha - 0 9	29	705	21511	551042	17524731	472356665
+       743	1kbnnqrb/1pp1p1pp/r4p2/p2p4/N4P2/3P4/PPP1P1PP/RKB1NQRB w GAg - 2 9	21	623	14979	437554	11601134	343214006
+       744	rbknbn1r/pppp1p1p/4p1q1/8/P1P3Pp/8/1P1PPP2/RBKNBNQR w HAha - 0 9	30	813	24959	708454	23379040	692576573
+       745	rk1bb1qr/2pppppp/p2nn3/1p4P1/6QP/8/PPPPPP2/RKNBBN1R w HAha - 2 9	36	857	30124	757524	26485812	696999449
+       746	rkn1bbqr/p2ppppp/2p1n3/1p6/4PP2/6PP/PPPP4/RKNNBBQR w HAha - 0 9	33	687	22744	511018	17101732	412778368
+       747	rkn1bqrb/pnp1pppp/3p4/8/Pp6/1N2NP2/1PPPP1PP/RK2BQRB w GAga - 0 9	28	591	17174	406025	12182448	312575205
+       748	rbk1n1br/ppp1ppqp/2n5/2Np2p1/8/2P5/PPBPPPPP/R1KN1QBR w HAha - 4 9	35	930	30663	844433	27160490	780616047
+       749	rknbn1br/1ppp1ppp/p3p3/8/1q6/2P2N1P/P2PPPP1/RKNB1QBR w HAha - 0 9	4	157	3697	138102	3454704	125373395
+       750	rkn1qbbr/pp3ppp/4n3/2ppp3/4P1P1/P2P4/1PP2P1P/RKNNQBBR w HAha - 0 9	28	840	24437	771328	23200961	756489357
+       751	rkn1qrbb/pp1ppp2/2p1n1p1/7p/2P2P1P/6P1/PP1PP3/RKNNQRBB w FAfa - 1 9	32	867	27595	757836	24485663	688115847
+       752	b1rknnrq/bpppp1p1/p6p/5p1P/6P1/4N3/PPPPPP2/BBRKN1RQ w GCgc - 1 9	33	851	28888	763967	26686205	731944177
+       753	brkb1nr1/pppppp2/3n2pp/3B4/1P6/4P3/PqPP1PPP/BRK1NNRQ w GBgb - 2 9	4	98	2965	76143	2352530	64251468
+       754	brk1nbrq/1ppppn1p/6p1/p4p2/P5P1/5R2/1PPPPP1P/BRKNNB1Q w Bgb - 0 9	29	922	27709	879527	27463717	888881062
+       755	brkn1rqb/1p1ppppp/3n4/p1p5/1P3P2/8/PNPPP1PP/BR1KNRQB w fb - 1 9	29	633	19399	469818	15076198	396737074
+       756	rb1k1nrq/pbp1pppp/1p1p1n2/8/5P2/4NN1P/PPPPP1P1/RBBK2RQ w GAga - 2 9	28	841	24056	710751	20772996	613798447
+       757	rkbbnnrq/p1pp3p/4p1p1/1p3p2/P6P/1P6/1BPPPPP1/RK1BNNRQ w GAga - 0 9	33	957	30668	907217	29735654	903933626
+       758	rk2nbrq/p1ppppp1/bpn5/7p/6P1/2N2P2/PPPPP1QP/RKB1NBR1 w GAga - 2 9	24	687	18206	544627	15518417	484217179
+       759	rkbn1r1b/pp1pppnp/6q1/2p3p1/5P1P/4N3/PPPPP1P1/RKB1NRQB w FAfa - 1 9	23	831	21254	754622	21126103	744755212
+       760	rbknb1rq/ppp1p1p1/3pnp1p/8/6PP/2PP4/PP2PP2/RBKNBNRQ w GAga - 0 9	31	838	26800	736910	24008129	677776408
+       761	rknbb1rq/p1pn1ppp/4p3/1p1p4/2P5/1P2N1P1/P2PPP1P/RKNBB1RQ w GAga - 1 9	29	830	24798	721630	22243832	660040360
+       762	rk1nbbrq/pp1p1ppp/3n4/P3p3/2p4P/8/1PPPPPP1/RKNNBBRQ w GAga - 1 9	24	484	12776	297419	8379748	214004367
+       763	rknnbr1b/ppp2pqp/3p4/4p1p1/7P/3P1P2/PPP1P1P1/RKNNBRQB w FAfa - 0 9	32	838	26408	740701	23472124	699211365
+       764	rb1k1rbq/ppppN1pp/2nn4/5p2/7P/8/PPPPPPP1/RBK1NRBQ w FA - 1 9	27	800	22785	701742	20804424	660917073
+       765	r1nbnrbq/kppppp1p/6p1/8/p1PP1P2/4P3/PP4PP/RKNBNRBQ w FA - 1 9	28	757	21198	602699	17180857	507618340
+       766	rkn1rbbq/p1pppppp/2n5/1pP5/8/1N2P3/PP1P1PPP/RK1NRBBQ w EAea - 1 9	22	483	11890	283679	7497674	191130942
+       767	rknnrqbb/2pppppp/8/p7/Np3P2/3P4/PPP1P1PP/RKN1RQBB w EAea - 0 9	25	536	14456	339180	9694947	245669668
+       768	bb1rknrn/1qppppp1/1p4B1/p6N/8/2P5/PP1PPPPP/B1QRK1RN w GDgd - 1 9	32	715	22421	575008	17860156	502410909
+       769	b1rbknrn/qpp1ppp1/p6p/3p4/2P5/1P1P1P2/P3P1PP/BQRBKNRN w GCgc - 0 9	30	818	24421	688711	20981488	611986786
+       770	bqkrnbrn/1pp1pp1p/p7/1B1p2p1/4P3/7P/PPPP1PP1/BQKRN1RN w - - 0 9	28	676	18366	478054	13126287	363765666
+       771	bqrknrnb/1p2ppp1/p1pp3p/8/3P1P2/1PP5/P3P1PP/BQRKNRNB w FCfc - 0 9	31	646	20686	455607	14984618	349082278
+       772	qbbrkn1r/pppppp1p/8/6p1/2P1Pn1P/6N1/PP1P1PP1/QBBRKNR1 w GDd - 3 9	20	532	11581	303586	7512432	202967948
+       773	1rbbknr1/p1ppp1pp/1pq2pn1/8/3P4/P3P3/QPP2PPP/1RBBKNRN w GBgb - 3 9	31	1002	30581	999607	30642468	1009228283
+       774	qrbkn1rn/pppp1ppp/8/6b1/P1P1Pp2/8/1P1P2PP/QRBKNBRN w GBgb - 0 9	22	505	12447	304863	8192621	214730959
+       775	qrbk1rnb/p2ppp1p/5n2/1pp3p1/8/7P/PPPPPPPN/QRBKR1NB w Bfb - 0 9	20	619	13448	449630	10571176	369603424
+       776	qbrkb1r1/ppp2ppp/3pn1n1/P3p3/4P3/3P4/1PP2PPP/QBRKBNRN w GCgc - 1 9	26	755	20596	604483	17164382	510878835
+       777	qrkbb1r1/ppp1pnpp/3p2n1/5p2/1P3P2/2Q3N1/P1PPP1PP/1RKBB1RN w GBgb - 0 9	35	918	32244	870888	30933394	867833733
+       778	qrknbbrn/ppp1ppp1/8/7p/2Bp4/4PPP1/PPPP3P/QRKNB1RN w GBgb - 0 9	27	593	16168	376808	10422676	258348640
+       779	qrk1brnb/ppppp3/4n2p/5pp1/2PP4/2N4P/PP2PPP1/QRK1BRNB w FBfb - 2 9	24	672	17447	506189	13765777	414930519
+       780	qbrknrb1/p2ppppp/2p3n1/8/p4P2/6PP/1PPPP3/QBRKNRBN w FCfc - 0 9	29	759	23235	634493	20416668	584870558
+       781	1rkb1rbn/p1pp1ppp/3np3/1p6/4qP2/3NB3/PPPPPRPP/QRKB3N w Bfb - 0 9	22	923	22585	914106	24049880	957218571
+       782	1rknrbbn/p1pp1p1p/8/1p2p1p1/4qPP1/2P5/PP1PP1BP/QRKNR1BN w EBeb - 0 9	28	1309	36355	1568968	44576409	1846382333
+       783	qrk1rn1b/ppppp2p/4n3/3b1pp1/4P2P/5BP1/PPPP1P2/QRKNRNB1 w EBeb - 3 9	26	839	22189	726354	19978260	661207281
+       784	bbrqk1rn/pp1ppppp/8/2p5/2P1P3/5n1P/PPBP1PP1/B1RQKNRN w GCgc - 1 9	3	95	2690	85038	2518864	80775549
+       785	brqbk2n/pppppprp/8/6p1/1P3n2/5P2/P1PPP1PP/R1QBKNRN w Gb - 2 9	22	593	13255	362760	8922397	253271592
+       786	brqknbr1/pp3ppp/3p2n1/2p1p3/2P5/5P2/PPKPP1PP/BRQ1NBRN w gb - 0 9	21	590	13190	397355	9581695	304103516
+       787	1rqknrnb/2pp1ppp/p3p3/1p6/P2P4/5bP1/1PP1PP1P/BRQKNRNB w FBfb - 0 9	24	737	20052	598439	17948681	536330341
+       788	rbb1k1rn/p1pqpppp/6n1/1p1p4/5P2/3PP3/PPP1K1PP/RBBQ1NRN w ga - 3 9	24	694	16773	513782	13094823	419402704
+       789	rqbbknr1/1ppp2pp/p5n1/4pp2/P7/1PP5/1Q1PPPPP/R1BBKNRN w GAga - 0 9	24	600	15347	408207	11029596	308553169
+       790	rqbknbrn/2pppppp/6Q1/pp6/8/2P5/PP1PPPPP/R1BKNBRN w GAga - 2 9	40	949	34100	889887	31296485	881529007
+       791	rqbknr1b/pp1ppp2/2p2n1p/6p1/8/3P1PPP/PPP1P3/RQBKNRNB w FAfa - 0 9	20	560	12275	373921	8687544	277906201
+       792	rbqkbnrn/p3pppp/1p6/3p4/P1p3P1/1P6/1QPPPP1P/RB1KBNRN w GAga - 0 9	30	1155	35865	1351455	43092716	1614019629
+       793	rqkbb1rn/p1p1pppn/1p1p4/7p/4PP2/7P/PPPPB1P1/RQK1BNRN w GAga - 1 9	30	701	20804	515942	15450970	401499189
+       794	rqknbbrn/1p2pp1p/3p2p1/p1p5/P2P4/1P6/1KP1PPPP/RQ1NBBRN w ga - 0 9	28	756	21655	610320	17989811	525585996
+       795	rqknbrnb/1pp3pp/5p2/p2pp3/P7/3PPN2/1PP2PPP/RQKNBR1B w FAfa - 0 9	26	731	19509	550395	15209404	439767476
+       796	rbqkr1bn/p1pppp1p/1p1n4/6p1/7P/3P1PP1/PPP1P3/RBQKNRBN w FAa - 0 9	27	586	16282	381604	10905865	274364342
+       797	rqk1nrb1/ppbp1ppp/4p1n1/2p5/7P/1PP5/P2PPPP1/RQKBNRBN w FAfa - 1 9	27	749	21480	602318	18084787	520547029
+       798	rqknrbbn/pp1p1ppp/4p3/2p5/3P2P1/7P/PPP1PP2/RQKNRBBN w EAa - 0 9	20	533	11829	336248	8230417	245871540
+       799	rqknrnbb/pp1ppp1p/2p3p1/8/8/1P2P1NP/P1PP1PP1/RQKNR1BB w EAea - 0 9	22	633	14480	441877	10827868	343525739
+       800	1brkq1rn/2pppppp/1p2n3/p2bN3/8/7P/PPPPPPP1/BBRKQ1RN w GCgc - 2 9	27	748	20134	580054	16010135	475206624
+       801	brkbqnrn/2pp1ppp/8/1p2p3/Pp2N3/8/2PPPPPP/BRKBQNR1 w GBgb - 0 9	30	827	25308	757837	23746165	751690068
+       802	brk1nbrn/pp1ppppp/2p5/7P/5P2/q2P4/PPP1P1P1/BRKQNBRN w GBgb - 1 9	15	471	8716	276424	5960901	190316951
+       803	brkqnrnb/1p1pp1p1/p4p2/2p4p/8/P2PP3/1PP1QPPP/BRK1NRNB w FBfb - 0 9	24	479	12584	280081	7830230	190419716
+       804	rbbkqnrn/2ppp2p/pp3p2/6p1/P6P/8/RPPPPPP1/1BBKQNRN w Gga - 0 9	21	523	12125	328733	8322614	242240658
+       805	rkbbqr1n/1ppppppn/7p/p7/4P3/2P2P2/PP1PB1PP/RKB1QNRN w GAa - 3 9	27	563	16026	372148	11105151	283211800
+       806	rkbqnbrn/ppppp3/8/5ppp/2P3P1/7P/PPQPPP2/RKB1NBRN w GAga - 0 9	28	639	19250	469250	14872172	384663405
+       807	rkb1nrnb/pppp1pp1/5q1p/8/P3p3/4R1P1/1PPPPP1P/1KBQNRNB w Ffa - 0 9	28	873	23690	720814	20209424	625281937
+       808	rbkqb1rn/1p1ppppp/4n3/p1p5/8/3PBP2/PPP1P1PP/RBKQ1NRN w GAga - 0 9	26	798	21416	667496	18475618	591681956
+       809	rk1qbnrn/1p1ppppp/1b6/p1p5/P7/2P3NP/1P1PPPP1/RKQBB1RN w GAga - 0 9	22	506	12313	301029	7891676	205739580
+       810	rk1nbbrn/ppp1ppp1/8/3p3p/1P1P2q1/5PB1/P1P1P1PP/RKQN1BRN w GAga - 1 9	31	956	29219	903799	27827461	876341492
+       811	rkqnbr1b/pp1pppp1/7p/2p2n2/P2P4/7N/RPP1PPPP/1KQNBR1B w Ffa - 0 9	31	750	24267	646252	21639104	617064197
+       812	rbkq1rbn/2p1pppp/pp3n2/3p4/5P2/3N2N1/PPPPP1PP/RBKQR1B1 w Afa - 2 9	26	647	18027	465119	13643783	369702807
+       813	rkqbr1bn/p2ppppp/1pp2n2/8/5P2/3P1N2/PPP1PRPP/RKQB2BN w Aa - 3 9	24	574	14593	371597	10066892	271121237
+       814	rk1qrbbn/p1ppp1pp/1p2n3/5p2/1P6/K3N3/P1PPPPPP/R1Q1RBBN w ea - 0 9	25	548	14069	340734	9043111	235545764
+       815	rkqnrnbb/pp1pp3/2p5/5ppp/8/PP4NP/2PPPPP1/RKQNR1BB w EAea - 0 9	23	727	18228	566572	15078056	471296844
+       816	bbrknq1r/ppppppp1/8/7p/5n2/3P4/PPP1PNPP/BBKRNQR1 w c - 0 9	21	610	13300	394705	9605845	293532398
+       817	brkbnqr1/2pppnpp/pp3p2/8/4PPPP/8/PPPP4/BRKBNQRN w GBgb - 1 9	30	757	23908	621332	20360394	548380577
+       818	brk1qb1n/ppppppr1/2n3pp/8/2P3P1/2N5/PP1PPP1P/BR1KQBRN w b - 1 9	26	570	15537	352883	10081351	242864559
+       819	brknq1nb/pp2prpp/8/2pP1p2/6P1/2N5/PPPP1P1P/BRK1QRNB w FBb - 1 9	33	830	27897	764915	26262884	765831403
+       820	rbbk1qrn/ppp1p1pp/5p2/3p1n2/7N/P7/1PPPPPPP/RBB1KQRN w ga - 0 9	21	562	13060	378883	9520963	290579255
+       821	rk1b1qrn/ppp1pppp/5n2/3pN3/P6P/7b/1PPPPPP1/RKBB1QRN w GAga - 4 9	28	677	19235	488740	14354779	383207197
+       822	rkbnqbrn/pp1ppp1p/2p5/6p1/P7/4P3/KPPPQPPP/R1BN1BRN w - - 3 9	28	585	17443	401483	12574541	310495538
+       823	rk1nqrnb/pbpppp2/1p4p1/7p/P7/5NP1/1PPPPPBP/RKBNQR2 w FAfa - 2 9	26	774	21626	645200	19093408	576325868
+       824	rbknb1rn/p1pp2pp/1p6/4pp2/1q3P1B/2N5/PPPPPNPP/RBK2QR1 w GAga - 2 9	31	1206	36940	1374158	42849564	1555711209
+       825	rk1bbqrn/pp1pp1pp/3n4/5p2/3p4/1PP5/PK2PPPP/R1NBBQRN w ga - 0 9	21	629	14059	429667	10587910	332632033
+       826	rknqbbr1/p1pp1pp1/1p4n1/4p2p/4P1P1/6RB/PPPP1P1P/RKNQB2N w Aga - 0 9	27	753	20918	593155	17318772	507563675
+       827	rknqbr1b/pppp1ppp/4p2n/8/1P3P2/4P3/P1PPN1PP/RKNQBR1B w FAfa - 2 9	26	623	17177	460663	13389799	383508368
+       828	r2kqrbn/bppppppp/2n5/p4B2/5P2/2P5/PP1PP1PP/1RKNQRBN w F - 2 9	39	1026	37800	1011922	35946987	992756232
+       829	rk1bqrb1/ppppppp1/1n6/7p/2P2P1n/4P1Q1/PP1P2PP/RKNB1RBN w FAfa - 0 9	35	760	25817	610557	21014787	536852043
+       830	rkq1rb1n/ppppp1pp/1n6/5p2/PPb2P2/8/1KPPP1PP/R1NQRBBN w ea - 1 9	27	754	21009	568788	16461795	448313956
+       831	rknqr2b/pppnp1pp/3p4/3b1p2/8/1N1P2N1/PPP1PPPP/RKQ1R1BB w EAea - 1 9	27	803	23708	700453	21875031	654754840
+       832	bbrknrqn/ppppp1pB/8/2P2p1p/8/5N2/PP1PPPPP/B1RK1RQN w FCfc - 0 9	30	799	23923	671112	20532790	603059376
+       833	brkbnrq1/1pppp1p1/6np/p4p2/4P3/1PP5/P1KP1PPP/BR1BNRQN w fb - 1 9	27	726	19329	555622	15156662	457601127
+       834	brknrbq1/1p1p1ppp/p3p1n1/2p5/8/1P1BPP2/P1PP2PP/BRKNR1QN w EBeb - 0 9	36	786	27868	655019	22852433	577223409
+       835	brknrqnb/p2ppp1p/2p5/1p6/3P2p1/P1P1N3/1P2PPPP/BRK1RQNB w EBeb - 0 9	23	649	15169	440504	10687843	320881984
+       836	rbbk1rqn/1ppppppp/3n4/p7/2P5/3N4/PP1PPPPP/RBB1KRQN w fa - 1 9	20	478	11094	275250	7094988	185488058
+       837	rkbbnrqn/p2p1ppp/1p2p3/8/P1p1P3/1BP5/1P1P1PPP/RKB1NRQN w FAfa - 0 9	22	570	13295	346811	8671852	229898448
+       838	rkb1rb1n/ppppppqp/8/2n3p1/2P1P1P1/8/PP1P1P1P/RKBNRBQN w EAea - 1 9	23	663	16212	490748	12900485	404944553
+       839	rkb1rqnb/pppp3p/2n3p1/4pp2/P2P3P/2P5/1P2PPP1/RKBNRQNB w EAea - 0 9	25	845	22188	741972	20276176	683290790
+       840	rbk1brqn/ppp1pppp/8/3p4/7P/1P4P1/2PPPP2/RBKNBRQN w FAfa - 0 9	24	526	13862	322175	9054028	222704171
+       841	rknbbrqn/pp3pp1/4p3/2pp3p/2P5/8/PPBPPPPP/RKN1BRQN w FAfa - 0 9	26	756	19280	559186	14697705	433719427
+       842	1knrbbqn/rp1p1ppp/p3p3/2p5/8/5P1P/PPPPP1P1/RKNRBBQN w DAd - 0 9	26	539	15194	345070	10223443	248715580
+       843	rknr1qnb/ppp1p1pp/3p2b1/8/4p3/1P3P1P/P1PP2P1/RKNRBQNB w DAda - 0 9	25	701	18969	561369	16047041	496340789
+       844	rbk1r1bn/ppppp1pp/4n3/5p2/1P3P2/4N2P/PqPPP1P1/RBK1RQBN w EAea - 1 9	2	60	1319	41765	1017864	33183408
+       845	r1nbrqbn/k1ppp1pp/1p6/p4p2/2P5/6PQ/PP1PPP1P/RKNBR1BN w EA - 0 9	27	699	20436	561765	17192121	499247248
+       846	rknrqbbn/1pp1pp2/p5p1/3p3p/6P1/PN5P/1PPPPP2/RK1RQBBN w DAda - 0 9	23	611	15515	435927	11917036	352885930
+       847	rknrqn1b/p1pp1ppb/8/1p2p1Qp/3P4/3N4/PPP1PPPP/RK1R1NBB w DAda - 0 9	45	1170	48283	1320341	52213677	1500007485
+       848	bbkrnrnq/p2p1ppp/2p1p3/1p6/1P2Q3/6P1/P1PPPP1P/BBKRNRN1 w - - 0 9	41	1035	39895	1035610	38555608	1037686769
+       849	brkbnr2/1ppppp1p/7n/p5N1/P2q4/8/1PPPPPPP/BRKBNRQ1 w FBfb - 1 9	22	869	19234	679754	16453359	567287944
+       850	brknrbnq/p1ppppp1/1p6/7p/2PP4/5P2/PPK1P1PP/BR1NRBNQ w eb - 1 9	23	641	14748	422240	10192718	302864305
+       851	brk1r1qb/pp1ppnpp/2p2pn1/8/6N1/2N3P1/PPPPPP1P/BRK1R1QB w EBeb - 3 9	32	863	28379	773191	25848794	720443112
+       852	rbbk1rnq/pppp1pp1/4p2p/8/3P2n1/4BN1P/PPP1PPP1/RB1K1RNQ w FAfa - 3 9	26	628	16151	411995	11237919	300314373
+       853	rkbbnr1q/p1pppppp/5n2/1p5B/PP6/4P3/2PP1PPP/RKB1NRNQ w FAfa - 0 9	30	692	21036	519283	16025428	420887328
+       854	rkb1rbnq/1pppp1pp/5p2/p7/5n1P/1PN3P1/P1PPPP2/RKB1RBNQ w EAea - 0 9	32	825	27130	697251	23593363	622249676
+       855	rkbnrnqb/1ppp1p1p/p5p1/4p3/4P3/2N2P2/PPPP2PP/RKBR1NQB w Aea - 0 9	24	487	13300	301989	8782713	215787079
+       856	rbknbr1q/pppp2pp/4p3/5p1n/1P2P2N/8/P1PP1PPP/RBKNBR1Q w FAfa - 0 9	23	571	13799	365272	9224232	257288920
+       857	rknbb1nq/pppppr2/5pp1/7p/8/1N4P1/PPPPPP1P/RK1BBRNQ w FAa - 2 9	26	548	15618	350173	10587626	253006082
+       858	rknr1bnq/p2pp1pp/1p3p2/2p4b/6PP/2P2N2/PP1PPP2/RKNRBB1Q w DAda - 1 9	25	502	13150	279098	7824941	175766730
+       859	rknrb1qb/ppp1pppp/3p4/8/4P1nP/2P5/PPKP1PP1/R1NRBNQB w da - 1 9	23	643	14849	426616	10507328	312096061
+       860	rbk1rnbq/pppp1npp/4p3/5p2/4P1P1/7P/PPPP1P1N/RBKNR1BQ w EAea - 1 9	24	591	15178	376988	10251465	263574861
+       861	rknbrnb1/p1pppp1p/1p6/3N2p1/P3q1P1/8/1PPPPP1P/RKNBR1BQ w EAea - 1 9	28	948	27343	864588	26241141	812343987
+       862	rknrn1b1/ppppppqp/8/6p1/2P5/2P1BP2/PP2P1PP/RKNRNB1Q w DAda - 1 9	31	807	24360	672973	20455205	588518645
+       863	1k1rnqbb/npppppp1/r7/p2B3p/5P2/1N4P1/PPPPP2P/RK1RNQB1 w DAd - 0 9	40	1122	44297	1249989	48711073	1412437357
+       864	bbqr1rkn/pp1ppppp/8/2p5/1P2P1n1/7N/P1PP1P1P/BBQRKR1N w FD - 0 9	26	841	22986	746711	21328001	705170410
+       865	bqkr1rnn/1ppp1ppp/p4b2/4p3/P7/3PP2N/1PP2PPP/BQRBKR1N w FC - 3 9	24	500	12802	293824	7928916	197806842
+       866	bqrkrbnn/1pp1ppp1/8/p6p/3p4/P3P2P/QPPP1PP1/B1RKRBNN w ECec - 0 9	31	592	18585	396423	12607528	298629240
+       867	bqkrrnnb/2p1pppp/p7/1P1p4/8/2R3P1/PP1PPP1P/BQ1KRNNB w E - 0 9	42	1124	45187	1276664	50052573	1483524894
+       868	qbbrkrn1/p1pppn1p/8/1p3Pp1/2P5/8/PP1PPP1P/QBBRKRNN w FDfd - 0 9	21	577	13244	392131	9683808	300294295
+       869	qrbbkrnn/pp1p2pp/4p3/5p2/2p2P1P/2P5/PP1PP1P1/QRBBKRNN w FBfb - 0 9	21	571	12736	345681	8239872	228837930
+       870	qrbkrbn1/1pp1pppp/p2p4/8/5PPn/2P5/PP1PP3/QRBKRBNN w EBeb - 0 9	18	466	9443	257776	5679073	162883949
+       871	qrb1rnnb/pp1p1ppp/2pk4/4p3/1P2P3/1R6/P1PP1PPP/Q1BKRNNB w E - 4 9	37	760	26863	562201	19486022	421740856
+       872	qbrkbrn1/p1pppp1p/6n1/1p4p1/1P6/5P2/P1PPPBPP/QBRK1RNN w FCfc - 1 9	33	824	27385	750924	25176664	734656217
+       873	qrkbbr2/2pppppp/5nn1/pp1Q4/P7/3P4/1PP1PPPP/1RKBBRNN w FBfb - 0 9	42	1147	44012	1311247	48216013	1522548864
+       874	qrkrbbnn/pp2pp2/2pp2pp/1B6/P7/4P3/1PPP1PPP/QRKRB1NN w DBdb - 0 9	26	464	12653	242892	6928220	142507795
+       875	qrkrbnnb/p1pp1pp1/1p5p/4p3/1P6/6PN/PKPPPP1P/QR1RBN1B w db - 0 9	29	705	20000	529810	15055365	419552571
+       876	qbrkr1bn/p1p1pp1p/1p1p2n1/6p1/3P1P2/4P3/PPP3PP/QBKRRNBN w ec - 2 9	23	613	14835	426484	10747407	323905533
+       877	qrk1rnb1/p1pp1ppp/1p2Bbn1/8/4P3/6P1/PPPP1P1P/QRK1RNBN w EBeb - 1 9	28	927	24887	846839	23063284	807913585
+       878	1qkrnbbn/1rpppppp/pp6/5N2/P4P2/8/1PPPP1PP/QRKRNBB1 w DBd - 3 9	30	542	16646	345172	10976745	251694423
+       879	qrkr2bb/pppppppp/8/1n2n3/1N5P/1P6/P1PPPPP1/QRKR1NBB w DBdb - 1 9	28	719	21048	562015	17351761	479400272
+       880	bbrqkrnn/3ppppp/8/ppp5/6P1/4P2N/PPPPKP1P/BBRQ1R1N w fc - 0 9	21	704	16119	546215	13676371	470796854
+       881	brqbkrnn/1pp2p1p/3pp1p1/p5N1/8/1P6/P1PPPPPP/BRQBK1RN w Bfb - 0 9	34	688	22827	505618	16639723	402140795
+       882	br1krb1n/2qppppp/pp3n2/8/1P4P1/8/P1PPPP1P/1RQKRBNN w EBeb - 0 9	24	945	23943	926427	25019636	959651619
+       883	brqkr1nb/2ppp1pp/1p2np2/p7/2P1PN2/8/PP1P1PPP/BRQKRN1B w EBeb - 0 9	28	675	19728	504128	15516491	417396563
+       884	rbbqkrnn/3pppp1/p7/1pp4p/2P1P2P/8/PP1P1PP1/RBBQKRNN w FAfa - 0 9	26	671	18164	496806	14072641	404960259
+       885	rqbbkr1n/pp1p1p1p/4pn2/2p3p1/4P1P1/3P3P/PPP2P2/RQBBKRNN w FAfa - 0 9	22	633	14629	441809	10776416	335689685
+       886	rqbkrbnn/p1ppp3/1p3pp1/7p/3P4/P1P5/1PQ1PPPP/R1BKRBNN w EAea - 0 9	32	607	20339	454319	15586203	383515709
+       887	rqbkrnn1/pp2ppbp/3p4/2p3p1/2P5/1P3N1P/P2PPPP1/RQBKRN1B w EAea - 1 9	29	943	28732	908740	28761841	907579129
+       888	rbqkb1nn/1ppppr1p/p5p1/5p2/1P6/2P4P/P1KPPPP1/RBQ1BRNN w a - 1 9	22	441	10403	231273	5784206	140934555
+       889	rqkb1rnn/1pp1pp1p/p5p1/1b1p4/3P4/P5P1/RPP1PP1P/1QKBBRNN w Ffa - 1 9	21	505	11592	290897	7147063	188559137
+       890	rq1rbbnn/pkp1ppp1/3p3p/1p2N1P1/8/8/PPPPPP1P/RQKRBB1N w DA - 0 9	27	608	16419	387751	10808908	268393274
+       891	rqkrb2b/p2ppppp/2p3nn/1p6/5P2/PP1P4/2P1P1PP/RQKRBNNB w DAda - 1 9	30	749	21563	581531	16916813	485406712
+       892	rbqkr1bn/pp1ppp2/2p1n2p/6p1/8/4BPNP/PPPPP1P1/RBQKRN2 w EAea - 0 9	23	600	15082	410057	11041820	314327867
+       893	rqkbrnb1/2ppp1pp/pp3pn1/8/5P2/B2P4/PPP1P1PP/RQKBRN1N w EAea - 2 9	22	569	13541	371471	9395816	269460607
+       894	rqkrnbb1/p1p1pppp/1p4n1/3p4/7P/P3P3/1PPPBPP1/RQKRN1BN w DAda - 0 9	27	579	15565	373079	10238486	266047417
+       895	rqkrn1bb/p1ppp1pp/4n3/1p6/6p1/4N3/PPPPPPPP/RQKR2BB w DAda - 0 9	20	462	10234	274162	6563859	193376359
+       896	bbrkqr2/pppp1ppp/6nn/8/2P1p3/3PP2N/PP3PPP/BBRKQR1N w FCfc - 0 9	28	724	21688	619064	19318355	593204629
+       897	brk1qrnn/1pppbppp/4p3/8/1p6/P1P4P/3PPPP1/BRKBQRNN w FBfb - 1 9	24	662	16920	468215	12610387	355969349
+       898	1r1qrbnn/p1pkpppp/1p1p4/8/3P1PP1/P4b2/1PP1P2P/BRKQRBNN w EB - 1 9	22	696	17021	510247	13697382	401903030
+       899	1rkqrnnb/p1p1p1pp/1p1p4/3b1p1N/4P3/5N2/PPPP1PPP/BRKQR2B w EBeb - 1 9	29	887	27035	816176	26051242	791718847
+       900	rbbkq1rn/pppppppp/7n/8/P7/3P3P/1PPKPPP1/RBB1QRNN w a - 3 9	22	417	9900	216855	5505063	134818483
+       901	rkbbqr1n/1p1pppp1/2p2n2/p4NBp/8/3P4/PPP1PPPP/RK1BQRN1 w FAfa - 0 9	37	832	30533	728154	26676373	673756141
+       902	rkbqrb1n/3pBppp/ppp2n2/8/8/P2P4/1PP1PPPP/RK1QRBNN w EAea - 0 9	28	685	19718	543069	16033316	482288814
+       903	rkb1rn1b/ppppqppp/4p3/8/1P2n1P1/5Q2/P1PP1P1P/RKB1RNNB w EAea - 2 9	37	1158	40114	1234768	44672979	1389312729
+       904	r1kqbrnn/pp1pp1p1/7p/2P2p2/5b2/3P4/P1P1P1PP/RBKQBRNN w FAfa - 0 9	5	161	4745	154885	4734999	157499039
+       905	rkqbbr1n/ppp1ppp1/8/Q2p3p/4n3/3P1P2/PPP1P1PP/RK1BBRNN w FAfa - 2 9	38	1144	40433	1236877	43832975	1366087771
+       906	rkqrbbn1/p1ppppp1/Bp5p/8/P6n/2P1P3/1P1P1PPP/RKQRB1NN w DAda - 0 9	28	551	15488	350861	9944107	251179183
+       907	rkqrb1nb/1ppp1ppp/p7/4p3/5n2/3P2N1/PPPQPPPP/RK1RB1NB w DAda - 0 9	26	690	19877	513628	15965907	418191735
+       908	rbkqrnbn/pppp1p2/4p1p1/7p/7P/P2P4/BPP1PPP1/R1KQRNBN w EAea - 0 9	27	515	13992	309727	8792550	218658292
+       909	rkqbrnbn/pp1ppp2/8/2p3p1/P1P4p/5P2/1PKPP1PP/R1QBRNBN w ea - 0 9	27	627	16843	431101	11978698	328434174
+       910	rkqrnbbn/1p2pp1p/3p2p1/p1p5/P5PP/3N4/1PPPPP2/RKQR1BBN w DAda - 0 9	23	624	15512	451860	11960861	367311176
+       911	rk2rnbb/ppqppppp/2pn4/8/1P3P2/6P1/P1PPP1NP/RKQR1NBB w DAa - 1 9	27	727	20206	581003	16633696	505212747
+       912	b1krrqnn/pp1ppp1p/2p3p1/8/P3Pb1P/1P6/2PP1PP1/BBRKRQNN w EC - 0 9	32	943	30759	865229	28672582	800922511
+       913	1rkbrqnn/p1pp1ppp/1p6/8/P2Pp3/8/1PPKPPQP/BR1BR1NN w eb - 0 9	28	916	24892	817624	22840279	759318058
+       914	brkrqb1n/1pppp1pp/p7/3n1p2/P5P1/3PP3/1PP2P1P/BRKRQBNN w DBdb - 0 9	27	669	18682	484259	13956472	380267099
+       915	brkrqnnb/3pppp1/1p6/p1p4p/2P3P1/6N1/PP1PPP1P/BRKRQ1NB w DBdb - 0 9	29	699	20042	512639	15093909	406594531
+       916	r1bkrq1n/pp2pppp/3b1n2/2pp2B1/6P1/3P1P2/PPP1P2P/RB1KRQNN w EAea - 2 9	27	835	22848	713550	19867800	631209313
+       917	rk1brq1n/p1p1pppp/3p1n2/1p3b2/4P3/2NQ4/PPPP1PPP/RKBBR2N w EAea - 4 9	36	1004	35774	979608	35143142	966310885
+       918	rkbrqbnn/1p2ppp1/B1p5/p2p3p/4P2P/8/PPPP1PP1/RKBRQ1NN w DAda - 0 9	27	748	21005	597819	17597073	515304215
+       919	rkbrqn1b/pp1pp1pp/2p2p2/5n2/8/2P2P2/PP1PP1PP/RKBRQ1NB w DAda - 0 9	20	479	10485	266446	6253775	167767913
+       920	rbkrbnn1/ppppp1pp/5q2/5p2/5P2/P3P2N/1PPP2PP/RBKRBQ1N w DAda - 3 9	28	947	26900	876068	26007841	838704143
+       921	rkr1bqnn/1ppp1p1p/p5p1/4p3/3PP2b/2P2P2/PP4PP/RKRBBQNN w CAca - 0 9	31	1004	32006	1006830	32688124	1024529879
+       922	rkrqbbnn/pppp3p/8/4ppp1/1PP4P/8/P2PPPP1/RKRQBBNN w CAca - 0 9	24	717	18834	564137	15844525	484884485
+       923	rkrqbn1b/pppp2pp/8/4pp2/1P1P2n1/5N2/P1P1PP1P/RKRQBN1B w CAca - 0 9	25	718	19654	587666	17257753	537354146
+       924	rbkrqnbn/p1p1ppp1/1p1p4/8/3PP2p/2PB4/PP3PPP/R1KRQNBN w DAda - 0 9	30	754	23298	611322	19338246	532603566
+       925	1krbqnbn/1p2pppp/r1pp4/p7/8/1P1P2PP/P1P1PP2/RKRBQNBN w CAc - 0 9	21	566	13519	375128	9700847	279864836
+       926	rkrq1b2/pppppppb/3n2np/2N5/4P3/7P/PPPP1PP1/RKRQ1BBN w CAca - 1 9	33	654	21708	479678	15990307	382218272
+       927	rkr1nnbb/ppp2p1p/3p1qp1/4p3/P5P1/3PN3/1PP1PP1P/RKRQN1BB w CAca - 1 9	28	715	20361	555328	16303092	468666425
+       928	bbrkrnqn/1p1ppppp/8/8/p2pP3/PP6/2P2PPP/BBRKRNQN w ECec - 0 9	24	757	19067	603231	15957628	509307623
+       929	brkbrnqn/ppp2p2/4p3/P2p2pp/6P1/5P2/1PPPP2P/BRKBRNQN w EBeb - 0 9	25	548	14563	348259	9688526	247750144
+       930	brkr1bqn/1pppppp1/3n3p/1p6/P7/4P1P1/1PPP1P1P/BRKRN1QN w DBdb - 0 9	19	359	7430	157099	3521652	81787718
+       931	brkr1qnb/pppp2pp/2B1p3/5p2/2n5/6PP/PPPPPPN1/BRKR1QN1 w DBdb - 1 9	27	854	23303	741626	20558538	667089231
+       932	rbbkrnqn/p1p1p1pp/8/1p1p4/1P1Pp3/6N1/P1P2PPP/RBBKRNQ1 w EAea - 0 9	28	723	19844	514440	14621108	397454100
+       933	rkbbrn1n/pppppp2/5q1p/6p1/3P3P/4P3/PPP2PP1/RKBBRNQN w EAea - 1 9	25	741	19224	585198	15605840	485037906
+       934	rkbr1bq1/ppnppppp/6n1/2p5/2P1N2P/8/PP1PPPP1/RKBRNBQ1 w DAda - 3 9	24	547	14359	339497	9410221	234041078
+       935	1kbrnqnb/r1ppppp1/8/pp5p/8/1P1NP3/P1PP1PPP/RKB1RQNB w Ad - 2 9	26	618	17305	442643	13112297	357030697
+       936	rbkrb1qn/1pp1ppp1/3pn2p/pP6/8/4N1P1/P1PPPP1P/RBKRB1QN w DAda - 0 9	21	544	12492	338832	8381483	236013157
+       937	rkrbbnqn/ppppp3/5p2/6pp/5PBP/4P3/PPPP2P1/RKR1BNQN w CAca - 0 9	30	891	25435	764356	21894752	669256602
+       938	rkr1bb1n/ppppp1pp/5p2/4n3/3QP3/5P2/RPPP2PP/1KRNBB1N w Cca - 1 9	45	1172	51766	1332060	57856784	1501852662
+       939	rkr1bqnb/pp1ppppp/8/2pN4/1P6/5N2/P1PPnPPP/RKR1BQ1B w CAca - 0 9	28	730	20511	559167	16323242	463032124
+       940	rbkrnqb1/2ppppp1/p5np/1p6/8/3N4/PPPPPPPP/RBKRQNB1 w DAda - 2 9	20	417	9159	217390	5180716	133936564
+       941	rkrbnqb1/p1pppnpp/5p2/1p6/2P5/1P1P1N2/P3PPPP/RKRB1QBN w CAca - 0 9	25	546	14039	330316	8813781	222026485
+       942	rkr1qbbn/ppppppp1/4n3/7p/8/P7/KPPPPPPP/R1RNQBBN w ca - 0 9	22	484	11458	267495	6633319	163291279
+       943	rkrnqnb1/1ppppp2/p5p1/7p/8/P1bPP3/1PP1QPPP/RKRN1NBB w CAca - 0 9	22	636	15526	441001	11614241	331083405
+       944	b2krn1q/p1rppppp/1Q3n2/2p1b3/1P4P1/8/P1PPPP1P/BBRKRNN1 w ECe - 3 9	36	1192	42945	1406795	50382104	1650202838
+       945	brkbrnn1/pp1pppp1/7q/2p5/6Pp/4P1NP/PPPP1P2/BRKBR1NQ w EBeb - 2 9	30	978	29593	942398	29205057	936568065
+       946	brkrnb1q/pp1p1ppp/2p1p3/5n2/1P6/5N1N/P1PPPPPP/BRKR1B1Q w DBdb - 1 9	31	897	27830	810187	25423729	755334868
+       947	brkr1nqb/pp1p1pp1/2pn3p/P3p3/4P3/6P1/1PPP1P1P/BRKRNNQB w DBdb - 0 9	19	382	8052	182292	4232274	103537333
+       948	r1bkrn1q/ppbppppp/5n2/2p5/3P4/P6N/1PP1PPPP/RBBKRNQ1 w EAea - 3 9	27	822	22551	678880	19115128	578210135
+       949	rkbbrnnq/pp2pppp/8/2pp4/P1P5/1P3P2/3PP1PP/RKBBRNNQ w EAea - 1 9	23	643	15410	442070	11170489	329615708
+       950	rkbr1b1q/p1pppppp/1p1n4/7n/5QP1/3N4/PPPPPP1P/RKBR1BN1 w DAda - 4 9	37	943	34382	880474	31568111	842265141
+       951	rkbr1nqb/pppp2np/8/4ppp1/1P6/6N1/P1PPPPPP/RKBRN1QB w DAda - 1 9	23	574	13260	362306	9020291	261247606
+       952	rbkr1nnq/p1p1pp1p/1p4p1/3p4/b3P3/4N3/PPPPNPPP/RBKRB1Q1 w DAda - 0 9	26	900	23414	805006	21653203	745802405
+       953	rkrbb1nq/p2pppp1/1p4n1/2p4p/3N4/4P1P1/PPPP1P1P/RKRBBN1Q w CAca - 0 9	32	697	22231	531121	17150175	441578567
+       954	rkrnbb1q/pp2pp1p/6pn/2pp4/2B1P2P/8/PPPP1PP1/RKRNB1NQ w CAca - 0 9	28	854	23853	755990	21823412	712787248
+       955	rk2bnqb/pprpppp1/4n2p/2p5/P7/3P2NP/1PP1PPP1/RKRNB1QB w CAa - 1 9	26	596	16251	414862	11758184	323043654
+       956	r1krnnbq/pp1ppp1p/6p1/2p5/2P5/P3P3/Rb1P1PPP/1BKRNNBQ w Dda - 0 9	2	61	1312	40072	937188	28753562
+       957	1krbnnbq/1pp1p1pp/r7/p2p1p2/3PP3/2P3P1/PP3P1P/RKRBNNBQ w CAc - 0 9	30	953	28033	860530	25531358	787205262
+       958	rkr1nbbq/2ppp1pp/1pn5/p4p2/P6P/3P4/1PP1PPPB/RKRNNB1Q w CAca - 1 9	24	645	15689	446423	11484012	341262639
+       959	rkrnnqbb/p1ppp2p/Qp6/4Pp2/5p2/8/PPPP2PP/RKRNN1BB w CAca - 0 9	35	929	32020	896130	31272517	915268405
+       960	bbq1nr1r/pppppk1p/2n2p2/6p1/P4P2/4P1P1/1PPP3P/BBQNNRKR w HF - 1 9	23	589	14744	387556	10316716	280056112
+       """;
+
+  }
+}
+
+

--- a/src/Ceres.Chess/MoveGen/MGPosition.cs
+++ b/src/Ceres.Chess/MoveGen/MGPosition.cs
@@ -74,6 +74,7 @@ namespace Ceres.Chess.MoveGen
 
     public short MoveNumber;
     public short Rule50Count;
+
     //    public short material;
 
 #if MG_USE_HASH
@@ -411,11 +412,11 @@ namespace Ceres.Chess.MoveGen
       ulong whitePawnsRank7 = whitePawns & BOARD_RANK_7;
       ulong blackPawnsRank7 = blackPawns & BOARD_RANK_2;
 
-      return  white ? BitOperations.PopCount(whitePawnsRank7)
-                    : BitOperations.PopCount(blackPawnsRank7);      
+      return white ? BitOperations.PopCount(whitePawnsRank7)
+                    : BitOperations.PopCount(blackPawnsRank7);
     }
 
-    
+
     /// <summary>
     /// Returns number of pawns still on their second rank (not yet advanced).
     /// </summary>
@@ -438,10 +439,10 @@ namespace Ceres.Chess.MoveGen
 
     #region Overrides
 
-    public static bool operator ==(MGPosition pos1, MGPosition pos2) =>  pos1.Equals(pos2);
-    
+    public static bool operator ==(MGPosition pos1, MGPosition pos2) => pos1.Equals(pos2);
+
     public static bool operator !=(MGPosition pos1, MGPosition pos2) => !pos1.Equals(pos2);
-    
+
 
     public override bool Equals(object obj) => obj is MGPosition && Equals(obj);
 

--- a/src/Ceres.Chess/MoveGen/MGPosition.cs
+++ b/src/Ceres.Chess/MoveGen/MGPosition.cs
@@ -340,8 +340,8 @@ namespace Ceres.Chess.MoveGen
         Square square = Square.FromFileAndRank(file, rank);
         if (GetPieceAtSquare(square).Type == PieceType.None)
         {
-          var priorFrom = GetPieceAtSquare(Square.FromFileAndRank(file, rankPriorFrom));
-          var priorTo = GetPieceAtSquare(Square.FromFileAndRank(file, rankPriorTo));
+          Piece priorFrom = GetPieceAtSquare(Square.FromFileAndRank(file, rankPriorFrom));
+          Piece priorTo = GetPieceAtSquare(Square.FromFileAndRank(file, rankPriorTo));
 
           if (priorFrom.Type == PieceType.None
            && priorTo.Type == PieceType.Pawn

--- a/src/Ceres.Chess/MoveGen/MGPositionConstants.cs
+++ b/src/Ceres.Chess/MoveGen/MGPositionConstants.cs
@@ -126,7 +126,7 @@ namespace Ceres.Chess.MoveGen
       int end = endSquare;
       while (end >= start)
       {
-        var inCheck = MGMoveGen.IsWhiteInCheck(A, B, C, D);
+        bool inCheck = MGMoveGen.IsWhiteInCheck(A, B, C, D);
         if (inCheck)
         {
           return false;

--- a/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
+++ b/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
@@ -176,9 +176,13 @@ namespace Ceres.Chess.MoveGen
           rookPos = rookPos == 288230376151711744 ? 0 : rookPos | 288230376151711744;
           BitBoard kingAndRooks = kingPos == rookPos ? 0 : kingPos | rookPos;
           if (rookPos == kingPos)
+          {
             kingAndRooks = 0;
+          }
           else if ((rookPos & kingPos) != 0)
+          {
             kingAndRooks = kingPos ^ rookPos;
+          }
           A ^= kingPos;
           B ^= kingPos;
           C ^= kingAndRooks;
@@ -203,10 +207,15 @@ namespace Ceres.Chess.MoveGen
           rookPos = rookPos == 1152921504606846976 ? 0 : rookPos | 1152921504606846976;
           kingPos = nFromSquare == nToSquare ? 0 : kingPos;
           BitBoard kingAndRooks = kingPos == rookPos ? 0 : kingPos | rookPos;
+          
           if (rookPos == kingPos)
+          {
             kingAndRooks = 0;
+          }
           else if ((rookPos & kingPos) != 0)
+          {
             kingAndRooks = kingPos ^ rookPos;
+          }
 
           A ^= kingPos;
           B ^= kingPos;
@@ -245,7 +254,7 @@ namespace Ceres.Chess.MoveGen
         Square rookToSq = new Square((int)nToSquare, Square.SquareIndexType.BottomToTopRightToLeft);
         MGPositionConstants.MCChessPositionPieceEnum pieceToSq = RawPieceAtSquare(rookToSq);
         bool performedCastling = pieceToSq == MGPositionConstants.MCChessPositionPieceEnum.WhiteRook;
-        
+
         if (M.CastleShort && performedCastling)
         {
           Debug.Assert(M.ToString() == "O-O");
@@ -256,9 +265,13 @@ namespace Ceres.Chess.MoveGen
           BitBoard kingPos = nFromSquare == kingIdx ? 0 : (1UL << (int)nFromSquare) | kingToSq;
           BitBoard kingAndRooks = kingPos | rookPos;
           if (rookPos == kingPos)
+          {
             kingAndRooks = 0;
+          }
           else if ((rookPos & kingPos) != 0)
+          {
             kingAndRooks = kingPos ^ rookPos;
+          }
           A ^= kingPos;
           B ^= kingPos;
           C ^= kingAndRooks;
@@ -281,11 +294,15 @@ namespace Ceres.Chess.MoveGen
           BitBoard kingToSq = 32; //c1 in decimals
           BitBoard kingIdx = 5; //c1 represented as index from h1..a8
           BitBoard kingPos = nFromSquare == kingIdx ? 0 : (1UL << (int)nFromSquare) | kingToSq;
-          var kingAndRooks = kingPos == rookPos ? 0 : kingPos | rookPos;
+          BitBoard kingAndRooks = kingPos == rookPos ? 0 : kingPos | rookPos;
           if (rookPos == kingPos)
+          {
             kingAndRooks = 0;
+          }
           else if ((rookPos & kingPos) != 0)
+          {
             kingAndRooks = kingPos ^ rookPos;
+          }
 
           A ^= kingPos;
           B ^= kingPos;
@@ -336,7 +353,7 @@ namespace Ceres.Chess.MoveGen
         bool rQMoved = nFromSquare == rQSq && bKingSquare < nFromSquare;
 
         if (rKMoved && rooks != 0)
-        {          
+        {
           // Black moved K-side Rook and forfeits right to castle K-side
           if (BlackCanCastle)
           {
@@ -371,7 +388,7 @@ namespace Ceres.Chess.MoveGen
         bool rKMoved = nFromSquare == rKSq && wKingSquare > nFromSquare;
         bool rQMoved = nFromSquare == rQSq && wKingSquare < nFromSquare;
         Debug.Assert((rQMoved && rKMoved) != true);
-      
+
         if (rKMoved && rooks != 0)
         {
           // White moved K-side Rook and forfeits right to castle K-side

--- a/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
+++ b/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
@@ -371,11 +371,7 @@ namespace Ceres.Chess.MoveGen
         bool rKMoved = nFromSquare == rKSq && wKingSquare > nFromSquare;
         bool rQMoved = nFromSquare == rQSq && wKingSquare < nFromSquare;
         Debug.Assert((rQMoved && rKMoved) != true);
-
-        int pieceCode = GetPieceAtBitboardSquare(wKingSquare & MGPositionConstants.firstRank);
-        PieceType pieceType = MGPieceCodeToPieceType[pieceCode];
-
-        //if((1LL<<nFromSquare) & WHITEKRPOS)
+      
         if (rKMoved && rooks != 0)
         {
           // White moved K-side Rook and forfeits right to castle K-side

--- a/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
+++ b/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
@@ -53,7 +53,11 @@ SOFTWARE.
 
 #region Using directives
 
+using Ceres.Chess.Textual.PgnFileTools;
+using System;
 using System.Diagnostics;
+using System.Threading.Tasks.Sources;
+using static Ceres.Chess.MoveGen.Converters.ConverterMGMoveEncodedMove;
 using BitBoard = System.UInt64;
 
 #endregion
@@ -99,8 +103,8 @@ namespace Ceres.Chess.MoveGen
 
       To = 1UL << M.ToSquareIndex;
       O = ~((1UL << M.FromSquareIndex) | To);
-      ulong nFromSquare = M.FromSquareIndex;
-      ulong nToSquare = M.ToSquareIndex;
+      BitBoard nFromSquare = M.FromSquareIndex;
+      BitBoard nToSquare = M.ToSquareIndex;
 
       // Increment ply count
       MoveNumber++;
@@ -158,31 +162,56 @@ namespace Ceres.Chess.MoveGen
 
       if ((byte)M.Piece == MGPositionConstants.BKING)
       {
-        if (M.CastleShort)
+        Square rookToSq = new Square((int)nToSquare, Square.SquareIndexType.BottomToTopRightToLeft);
+        MGPositionConstants.MCChessPositionPieceEnum pieceToSq = RawPieceAtSquare(rookToSq);
+        bool performedCastling = pieceToSq == MGPositionConstants.MCChessPositionPieceEnum.BlackRook;
+
+        if (M.CastleShort && performedCastling)
         {
-          A ^= 0x0a00000000000000;
-          B ^= 0x0a00000000000000;
-          C ^= 0x0f00000000000000;
-          D ^= 0x0f00000000000000;
-          
+          Debug.Assert(M.ToString() == "O-O");
+          BitBoard kingToSq = 144115188075855872; //g8 in decimals
+          BitBoard kingIdx = 57; //g8 represented as index from h1..a1
+          BitBoard kingPos = nFromSquare == kingIdx ? 0 : (1UL << (int)nFromSquare) | kingToSq;
+          BitBoard rookPos = 1UL << (int)nToSquare;
+          rookPos = rookPos == 288230376151711744 ? 0 : rookPos | 288230376151711744;
+          BitBoard kingAndRooks = kingPos == rookPos ? 0 : kingPos | rookPos;
+          if (rookPos == kingPos)
+            kingAndRooks = 0;
+          else if ((rookPos & kingPos) != 0)
+            kingAndRooks = kingPos ^ rookPos;
+          A ^= kingPos;
+          B ^= kingPos;
+          C ^= kingAndRooks;
+          D ^= kingAndRooks;
+
 #if MG_USE_HASH
           HK ^= MGZobristKeySet.zkDoBlackCastle;
 	    		if (BlackCanCastleLong) HK ^= MGZobristKeySet.zkBlackCanCastleLong; // conditionally flip black castling long
 #endif
           Flags |= FlagsEnum.BlackDidCastle;
-
-          //  bf = bf &= ~BitFields.DrawerPresenceSw; //attackType &= ~ AttackType.Fire;
-
           Flags &= ~FlagsEnum.BlackCanCastle;
           Flags &= ~FlagsEnum.BlackCanCastleLong;
           return;
         }
-        else if (M.CastleLong)
+        else if (M.CastleLong && performedCastling)
         {
-          A ^= 0x2800000000000000;
-          B ^= 0x2800000000000000;
-          C ^= 0xb800000000000000;
-          D ^= 0xb800000000000000;
+          Debug.Assert(M.ToString() == "O-O-O");
+          BitBoard kingToSq = 2305843009213693952; //c8 in decimals
+          BitBoard kingIdx = 61; //c8 represented as index from h1..a8
+          BitBoard kingPos = nFromSquare == kingIdx ? 0 : (1UL << (int)nFromSquare) | kingToSq;
+          BitBoard rookPos = 1UL << (int)nToSquare;
+          rookPos = rookPos == 1152921504606846976 ? 0 : rookPos | 1152921504606846976;
+          kingPos = nFromSquare == nToSquare ? 0 : kingPos;
+          BitBoard kingAndRooks = kingPos == rookPos ? 0 : kingPos | rookPos;
+          if (rookPos == kingPos)
+            kingAndRooks = 0;
+          else if ((rookPos & kingPos) != 0)
+            kingAndRooks = kingPos ^ rookPos;
+
+          A ^= kingPos;
+          B ^= kingPos;
+          C ^= kingAndRooks;
+          D ^= kingAndRooks;
 
 #if MG_USE_HASH
           HK ^= MGZobristKeySet.zkDoBlackCastleLong;
@@ -213,13 +242,26 @@ namespace Ceres.Chess.MoveGen
 
       else if ((byte)M.Piece == MGPositionConstants.WKING)
       {
-        // White
-        if (M.CastleShort)
+        Square rookToSq = new Square((int)nToSquare, Square.SquareIndexType.BottomToTopRightToLeft);
+        MGPositionConstants.MCChessPositionPieceEnum pieceToSq = RawPieceAtSquare(rookToSq);
+        bool performedCastling = pieceToSq == MGPositionConstants.MCChessPositionPieceEnum.WhiteRook;
+        
+        if (M.CastleShort && performedCastling)
         {
-          A ^= 0x000000000000000a;
-          B ^= 0x000000000000000a;
-          C ^= 0x000000000000000f;
-          D &= 0xfffffffffffffff0;  // clear colour of e1,f1,g1,h1 (make white)
+          Debug.Assert(M.ToString() == "O-O");
+          BitBoard rookPos = 1UL << (int)nToSquare;
+          rookPos = rookPos == 4 ? 0 : rookPos | 4;
+          BitBoard kingToSq = 2; //g1 in decimals
+          BitBoard kingIdx = 1; //g1 represented as index from h1..a8
+          BitBoard kingPos = nFromSquare == kingIdx ? 0 : (1UL << (int)nFromSquare) | kingToSq;
+          BitBoard kingAndRooks = kingPos | rookPos;
+          if (rookPos == kingPos)
+            kingAndRooks = 0;
+          else if ((rookPos & kingPos) != 0)
+            kingAndRooks = kingPos ^ rookPos;
+          A ^= kingPos;
+          B ^= kingPos;
+          C ^= kingAndRooks;
 
 #if MG_USE_HASH
 			HK^=MGZobristKeySet.zkDoWhiteCastle;
@@ -231,12 +273,24 @@ namespace Ceres.Chess.MoveGen
           return;
         }
 
-        if (M.CastleLong)
+        if (M.CastleLong && performedCastling)
         {
-          A ^= 0x0000000000000028;
-          B ^= 0x0000000000000028;
-          C ^= 0x00000000000000b8;
-          D &= 0xffffffffffffff07;  // clear colour of a1,b1,c1,d1,e1 (make white)
+          Debug.Assert(M.ToString() == "O-O-O");
+          BitBoard rookPos = 1UL << (int)nToSquare;
+          rookPos = rookPos == 16 ? 0 : rookPos | 16;
+          BitBoard kingToSq = 32; //c1 in decimals
+          BitBoard kingIdx = 5; //c1 represented as index from h1..a8
+          BitBoard kingPos = nFromSquare == kingIdx ? 0 : (1UL << (int)nFromSquare) | kingToSq;
+          var kingAndRooks = kingPos == rookPos ? 0 : kingPos | rookPos;
+          if (rookPos == kingPos)
+            kingAndRooks = 0;
+          else if ((rookPos & kingPos) != 0)
+            kingAndRooks = kingPos ^ rookPos;
+
+          A ^= kingPos;
+          B ^= kingPos;
+          C ^= kingAndRooks;
+
 #if MG_USE_HASH
 			HK^=MGZobristKeySet.zkDoWhiteCastleLong;
 			if (WhiteCanCastle) HK ^= MGZobristKeySet.zkWhiteCanCastle; // conditionally flip white castling
@@ -274,9 +328,15 @@ namespace Ceres.Chess.MoveGen
       // LOOK FOR FORFEITED CASTLING RIGHTS DUE to ROOK MOVES:
       else if ((byte)M.Piece == MGPositionConstants.BROOK)
       {
-        //	if((1LL<<nFromSquare) & BLACKKRPOS)
-        if (nFromSquare == 56)
-        {
+        BitBoard rooks = (~A & ~B & C & D) & MGPositionConstants.lastRank;
+        BitBoard rKSq = QBBoperations.LSB(rooks);
+        BitBoard rQSq = QBBoperations.MSB(rooks);
+        BitBoard bKingSquare = QBBoperations.LSB(D & C & B & A); //black king
+        bool rKMoved = nFromSquare == rKSq && bKingSquare > nFromSquare;
+        bool rQMoved = nFromSquare == rQSq && bKingSquare < nFromSquare;
+
+        if (rKMoved && rooks != 0)
+        {          
           // Black moved K-side Rook and forfeits right to castle K-side
           if (BlackCanCastle)
           {
@@ -288,7 +348,7 @@ namespace Ceres.Chess.MoveGen
           }
         }
         //else if ((1LL<<nFromSquare) & BLACKQRPOS)
-        else if (nFromSquare == 63)
+        else if (rQMoved && rooks != 0)
         {
           // Black moved the QS Rook and forfeits right to castle Q-side
           if (BlackCanCastleLong)
@@ -304,8 +364,19 @@ namespace Ceres.Chess.MoveGen
 
       else if ((byte)M.Piece == MGPositionConstants.WROOK)
       {
+        BitBoard rooks = (~A & ~B & C & ~D) & MGPositionConstants.firstRank;
+        BitBoard rKSq = QBBoperations.LSB(rooks);
+        BitBoard rQSq = QBBoperations.MSB(rooks);
+        BitBoard wKingSquare = QBBoperations.LSB(~D & C & B & A);
+        bool rKMoved = nFromSquare == rKSq && wKingSquare > nFromSquare;
+        bool rQMoved = nFromSquare == rQSq && wKingSquare < nFromSquare;
+        Debug.Assert((rQMoved && rKMoved) != true);
+
+        int pieceCode = GetPieceAtBitboardSquare(wKingSquare & MGPositionConstants.firstRank);
+        PieceType pieceType = MGPieceCodeToPieceType[pieceCode];
+
         //if((1LL<<nFromSquare) & WHITEKRPOS)
-        if (nFromSquare == 0)
+        if (rKMoved && rooks != 0)
         {
           // White moved K-side Rook and forfeits right to castle K-side
           if (WhiteCanCastle)
@@ -318,7 +389,7 @@ namespace Ceres.Chess.MoveGen
           }
         }
         //	else if((1LL<<nFromSquare) & WHITEQRPOS)
-        else if (nFromSquare == 7)
+        else if (rQMoved && rooks != 0)
         {
           // White moved the QSide Rook and forfeits right to castle Q-side
           if (WhiteCanCastleLong)
@@ -371,7 +442,6 @@ namespace Ceres.Chess.MoveGen
       B &= O;
       C &= O;
       D &= O;
-
       // Populate new square (Branchless method):
       A |= (BitBoard)(((ulong)M.Piece & 1) << M.ToSquareIndex);
       B |= (BitBoard)((((ulong)M.Piece & 2) >> 1) << M.ToSquareIndex);

--- a/src/Ceres.Chess/Textual/FENParser.cs
+++ b/src/Ceres.Chess/Textual/FENParser.cs
@@ -143,9 +143,13 @@ namespace Ceres.Chess.Textual
       char sideMoveChar = char.ToLower(fen[charIndex++]);
       SideType sideToMove;
       if (sideMoveChar == 'b')
+      {
         sideToMove = SideType.Black;
+      }
       else if (sideMoveChar == 'w')
+      {
         sideToMove = SideType.White;
+      }
       else
         throw new Exception($"Illegal FEN, side to move character {sideMoveChar}");
 
@@ -174,7 +178,9 @@ namespace Ceres.Chess.Textual
 
       // Only proceed if there are castling rights specified (i.e., the string is not "-")
       if (castlingRights == "-")
+      {
         charIndex++;
+      }
       else
       {
         //error here - needs to use another approach to get the castling rights
@@ -186,24 +192,32 @@ namespace Ceres.Chess.Textual
 
         foreach (PieceOnSquare ps in pieces)
         {
-          var mgPiece = MGChessPositionConverter.MGPieceFromPiece(ps.Piece);
-          var mgSquare = MGPosition.MGBitBoardFromSquare(ps.Square);
+          int mgPiece = MGChessPositionConverter.MGPieceFromPiece(ps.Piece);
+          ulong mgSquare = MGPosition.MGBitBoardFromSquare(ps.Square);
           pos.SetPieceAtBitboardSquare((ulong)mgPiece, mgSquare);
 
           // Identify king and rook positions
           if (ps.Piece.Type == PieceType.King)
           {
             if (ps.Piece.Side == SideType.White)
+            {
               whiteKingSquare = ps.Square;
+            }
             else
+            {
               blackKingSquare = ps.Square;
+            }
           }
           else if (ps.Piece.Type == PieceType.Rook)
           {
             if (ps.Piece.Side == SideType.White)
+            {
               whiteRookSquares.Add(ps.Square);
+            }
             else
+            {
               blackRookSquares.Add(ps.Square);
+            }
           }
         }
 
@@ -212,7 +226,7 @@ namespace Ceres.Chess.Textual
 
         for (int i = 0; i < whiteRookSquares.Count; i++)
         {
-          var rook = whiteRookSquares[i].SquareIndexStartH1;
+          byte rook = whiteRookSquares[i].SquareIndexStartH1;
           if (rook < whiteKingSq && rook < 8)
           {
             wKRsquare = whiteRookSquares[i].SquareIndexStartH1;
@@ -225,7 +239,7 @@ namespace Ceres.Chess.Textual
 
         for (int i = 0; i < blackRookSquares.Count; i++)
         {
-          var rook = blackRookSquares[i].SquareIndexStartH1;
+          byte rook = blackRookSquares[i].SquareIndexStartH1;
           if (rook < blackKingSq && rook > 55)
           {
             bKRsquare = blackRookSquares[i].SquareIndexStartH1;
@@ -244,8 +258,8 @@ namespace Ceres.Chess.Textual
 
         foreach (char c in castlingRights)
         {
-          var idx = Array.IndexOf(FileArrayLower, c);
-          var idxUpper = Array.IndexOf(FileArrayUpper, c);
+          int idx = Array.IndexOf(FileArrayLower, c);
+          int idxUpper = Array.IndexOf(FileArrayUpper, c);
           if (char.IsUpper(c) && idxUpper == wKRsquare && wKRsquare < whiteKingSq) // White's castling rights
           {
             whiteKingSideRook = c;

--- a/src/Ceres.Features/UCI/UCIManager.SetOption.cs
+++ b/src/Ceres.Features/UCI/UCIManager.SetOption.cs
@@ -21,6 +21,7 @@ using Ceres.Chess.NNEvaluators.Specifications;
 using Ceres.Chess.UserSettings;
 using Ceres.MCTS.Params;
 using Ceres.MCTS.Managers.Limits;
+using Ceres.Chess.MoveGen;
 
 
 #endregion
@@ -43,6 +44,11 @@ namespace Ceres.Features.UCI
     /// If verbose move stats should be output at periodic intervals.
     /// </summary>
     bool logLiveStats = false;
+
+    /// <summary>
+    /// If chess960 is selected enable chess960 logic.
+    /// </summary>
+    bool UCI_Chess960 = false;
 
     /// <summary>
     /// If detailed top-level move info should be output at end of move selection.
@@ -195,6 +201,10 @@ namespace Ceres.Features.UCI
           SetBool(value, ref logLiveStats);
           break;
 
+        case "uci_chess960":
+          SetBool(value, ref UCI_Chess960);
+          break;
+
         case "maxtreevisits":
           SetInt(value, 1, int.MaxValue, ref maxTreeVisits);
           break;
@@ -258,7 +268,7 @@ namespace Ceres.Features.UCI
 
         case "enablesiblingeval":
           SetBool(value, ref enableSiblingEval);
-          break;          
+          break;
 
         case "uci_showwdl":
           SetBool(value, ref showWDL);
@@ -268,12 +278,12 @@ namespace Ceres.Features.UCI
           bool reducedMemory = false;
           SetBool(value, ref reducedMemory);
           CeresUserSettingsManager.Settings.ReducedMemoryMode = reducedMemory;
-          break;          
+          break;
 
         case "syzygypath":
           if (!Directory.Exists(value))
           {
-            OutStream.WriteLine($"Path not found: { value }");
+            OutStream.WriteLine($"Path not found: {value}");
           }
           else
           {
@@ -387,6 +397,7 @@ namespace Ceres.Features.UCI
       {
         OutStream.WriteLine("Invalid value, expected true or false");
       }
+      MGPositionConstants.IsChess960 = value;
     }
 
 
@@ -468,6 +479,7 @@ option name MaxTreeNodes type string default
 option name ReducedMemoryMode type check default false
 option name EnableSiblingEval type check default false
 option name EnableUncertaintyBoosting type check default false
+option name UCI_Chess960 type check default false
 ");
     /* 
 option name ConfigFile type string default lc0.config

--- a/src/Ceres/Commands/DispatchCommands.cs
+++ b/src/Ceres/Commands/DispatchCommands.cs
@@ -240,6 +240,12 @@ namespace Ceres.Commands
         FeatureBenchmarkSearch analyzeParams = FeatureBenchmarkSearch.ParseBenchmarkCommand(keyValueArgs);
         analyzeParams.Execute();
       }
+
+      else if (featureName == "PERFT")
+      {        
+        FeatureBenchmarkPerft.Execute(keyValueArgs);        
+      }
+
       else if (featureName == "GRAPH")
       {
         KeyValueSetParsed keys = new KeyValueSetParsed(args, null);
@@ -249,7 +255,7 @@ namespace Ceres.Commands
       else
       {
         ShowErrorExit("Expected argument to begin with one of the features " +
-                       "UCI, ANALYZE, SUITE, TOURN, SYSBENCH, BACKENDBENCH, BACKENDCOMPARE, BENCHMARK, GRAPH or SETOPT");
+                       "UCI, ANALYZE, SUITE, TOURN, SYSBENCH, BACKENDBENCH, BACKENDCOMPARE, BENCHMARK, PERFT, GRAPH or SETOPT");
       }
     }
 

--- a/src/Ceres/Commands/FeatureBenchmarkPerft.cs
+++ b/src/Ceres/Commands/FeatureBenchmarkPerft.cs
@@ -1,0 +1,54 @@
+#region License notice
+
+/*
+  This file is part of the Ceres project at https://github.com/dje-dev/ceres.
+  Copyright (C) 2020- by David Elliott and the Ceres Authors.
+
+  Ceres is free software under the terms of the GNU General Public License v3.0.
+  You should have received a copy of the GNU General Public License
+  along with Ceres. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+#region Using directives
+
+using System;
+using System.Collections.Generic;
+
+using Ceres.Chess;
+using Ceres.Chess.GameEngines;
+using Ceres.Chess.NNEvaluators.Defs;
+using Ceres.Chess.Positions;
+using Ceres.MCTS.Params;
+using Ceres.Features.GameEngines;
+
+#endregion
+
+namespace Ceres.Commands
+{
+  public record FeatureBenchmarkPerft
+  {
+
+    /// <summary>
+    /// Constructor which parses arguments.
+    /// </summary>
+    /// <param name="fen"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    public static void Execute(string args)
+    {
+      //Console.WriteLine("Perft benchmark under development: ");
+      var perftParts = args.Split(" ");
+      if (perftParts.Length == 1 && int.TryParse(args, out int n1) && n1 > 1 && n1 < 7)
+        Chess.MoveGen.Test.MGMoveGenTest.RunChess960Verification(n1, 960);
+      else if (perftParts.Length == 2 && int.TryParse(perftParts[1], out int n2) && n2 > 1 && n2 < 7)
+        Chess.MoveGen.Test.MGMoveGenTest.RunChess960Verification(n2, int.Parse(perftParts[0]));
+      else
+      {
+        Console.WriteLine("No valid depth number given to Perft, defaulting to depth 5 and 960 positions");
+        Chess.MoveGen.Test.MGMoveGenTest.RunChess960Verification(5, 960);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added full support for Chess960 aka Fischer Random Chess. Several move gen related files had to be changes, including these:
- MGMoveGen.cs: castling moves now follow the rule King takes Rook in order to supports Chess960.
- EncodedMove.cs: Simplified castling checks.
- ConverterMGMoveEncodedMove.cs: Enhanced castling move handling and refactored methods.
- MGChessPositionConverter.cs: Adjusted method visibility.
- MGMoveConverter.cs, MoveInMGMovesArrayLocator.cs, MGMove.cs, MGMoveDump.cs, MGMoveFromString.cs: Formatting changes and added new castling format.

Enhanced move generation and bitboard updates:
- Added helper methods for castling checks.
- Refactored bitboard updates for castling.
- Improved readability and maintainability.

Added Chess960 support:
- Updated FENParser.cs for Chess960 castling rights.
- Added UCI_Chess960 option in UCIManager.SetOption.cs.
- Added Chess960 verification tests in FeatureBenchmarkPerft.cs.

Miscellaneous:
- Added new feature command PERFT