### PR TITLE
Removed dependency on global variable for chess960 detection and update move notation styles.

### DIFF
--- a/src/Ceres.Chess/MoveGen/MGMove.cs
+++ b/src/Ceres.Chess/MoveGen/MGMove.cs
@@ -328,7 +328,7 @@ namespace Ceres.Chess.MoveGen
     /// <summary>
     /// Determines if the move is a chess960 castling move (either kingside or queenside).
     /// </summary>
-    public bool IsChess960Caslte => IsCastle && !IsLegacyCastle;
+    public bool IsChess960Castle => IsCastle && !IsLegacyCastle;
 
     /// <summary>
     /// Returns if the move is a castle short move.

--- a/src/Ceres.Chess/MoveGen/MGMove.cs
+++ b/src/Ceres.Chess/MoveGen/MGMove.cs
@@ -285,6 +285,52 @@ namespace Ceres.Chess.MoveGen
     public bool IsCastle => (Flags & (MGChessMoveFlags.CastleShort | MGChessMoveFlags.CastleLong)) != 0;
 
     /// <summary>
+    /// Determines if the move is a legacy queenside castling move.
+    /// </summary>
+    public bool IsLegacyCastleQueenside
+    {
+      get
+      {
+        if (!CastleLong)
+        {
+          return false;
+        }
+
+        return BlackToMove ?
+            FromSquareIndex == 59 && ToSquareIndex == 63 :
+            FromSquareIndex == 3 && ToSquareIndex == 7;        
+      }
+    }
+
+    /// <summary>
+    /// Determines if the move is a legacy kingside castling move.
+    /// </summary>
+    public bool IsLegacyCastleKingside
+    {
+      get
+      {
+        if (!CastleShort)
+        {
+          return false;
+        }
+        
+        return BlackToMove ?
+          FromSquareIndex == 59 && ToSquareIndex == 56 :
+          FromSquareIndex == 3 && ToSquareIndex == 0;
+      }
+    }
+
+    /// <summary>
+    /// Determines if the move is a legacy castling move (either kingside or queenside).
+    /// </summary>
+    public bool IsLegacyCastle => IsLegacyCastleQueenside || IsLegacyCastleKingside;
+
+    /// <summary>
+    /// Determines if the move is a chess960 castling move (either kingside or queenside).
+    /// </summary>
+    public bool IsChess960Caslte => IsCastle && !IsLegacyCastle;
+
+    /// <summary>
     /// Returns if the move is a castle short move.
     /// </summary>
     public bool CastleShort

--- a/src/Ceres.Chess/MoveGen/MGMoveDump.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveDump.cs
@@ -74,24 +74,19 @@ namespace Ceres.Chess.MoveGen
     LongAlgebraic,
 
     /// <summary>
-    /// Short algebraic
+    /// Short algebraic, e.g. d4, 0-0 or 0-0-0.
     /// </summary>
     ShortAlgebraic,
 
     /// <summary>
-    /// Coordinate style, e.g. e7f8q.
+    /// Coordinate style, e.g. Ng1f3 and e7f8q.
     /// </summary>
-    CoOrdinate,
+    PieceAndCoordinates,
 
     /// <summary>
-    /// Leela chess zero coordinate format.
+    /// Ceres coordinate format, e.g. e2e4 and e1h1 indicates king takes rook for castling
     /// </summary>
-    LC0Coordinate,
-
-    /// <summary>
-    /// Normal castling moves, e.g. e1g1 and e1c1.
-    /// </summary>
-    StandardCastlingFormat
+    Coordinates
   };
 
 
@@ -114,24 +109,20 @@ namespace Ceres.Chess.MoveGen
         return "(none)";
       }
 
-      if (style == MGMoveNotationStyle.StandardCastlingFormat)
+      if (IsLegacyCastle)
       {
-        if (IsCastle)
+        bool isWhite = Piece == MGPositionConstants.MCChessPositionPieceEnum.WhiteKing;
+        if (isWhite && FromSquareIndex == 3)
         {
-          bool isWhite = Piece == MGPositionConstants.MCChessPositionPieceEnum.WhiteKing;
-          if (isWhite && FromSquareIndex == 3)
-          {
-            return CastleLong ? "e1c1" : "e1g1";
-          }
-          else if (!isWhite && FromSquareIndex == 59)
-          {
-            return CastleLong ? "e8c8" : "e8g8";
-          }
+          return CastleLong ? "e1c1" : "e1g1";
         }
-        return string.Empty;
+        else if (!isWhite && FromSquareIndex == 59)
+        {
+          return CastleLong ? "e8c8" : "e8g8";
+        }
       }
 
-      if (style != MGMoveNotationStyle.CoOrdinate && style != MGMoveNotationStyle.LC0Coordinate)
+      if (style == MGMoveNotationStyle.ShortAlgebraic)
       {
         if (CastleShort)
         {
@@ -167,14 +158,14 @@ namespace Ceres.Chess.MoveGen
 
       if ((style == MGMoveNotationStyle.LongAlgebraic)
        || (style == MGMoveNotationStyle.ShortAlgebraic)
-       || (style == MGMoveNotationStyle.LC0Coordinate))
+       || (style == MGMoveNotationStyle.Coordinates))
       {
         // Determine if move is a capture
         char capChar = (Capture || EnPassantCapture) ? 'x' : '-';
 
         StringBuilder sb = new StringBuilder();
-        if ((style == MGMoveNotationStyle.ShortAlgebraic) 
-         || (style == MGMoveNotationStyle.LC0Coordinate))
+        if ((style == MGMoveNotationStyle.ShortAlgebraic)
+         || (style == MGMoveNotationStyle.Coordinates))
         {
           sb.Append(c1);
           sb.Append(1 + (from >> 3));
@@ -199,7 +190,7 @@ namespace Ceres.Chess.MoveGen
         return s;
       }
 
-      if (style == MGMoveNotationStyle.CoOrdinate)
+      if (style == MGMoveNotationStyle.PieceAndCoordinates)
       {
         StringBuilder sb = new StringBuilder();
         sb.Append(p);

--- a/src/Ceres.Chess/MoveGen/MGMoveFromString.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveFromString.cs
@@ -46,7 +46,6 @@ namespace Ceres.Chess.MoveGen
         System.Diagnostics.Debug.Assert(pos.IsLegalMove(move));
         return move;
       }
-
     }
 
     /// <summary>
@@ -70,17 +69,11 @@ namespace Ceres.Chess.MoveGen
       foreach (MGMove moveTry in moves.MovesArray)
       {
         // Accept moves in any of multiple formats, including Chess 960 (for castling variation)
-        if (String.Equals(moveTry.MoveStr(MGMoveNotationStyle.LC0Coordinate), moveStr, StringComparison.OrdinalIgnoreCase)
+        if (String.Equals(moveTry.MoveStr(MGMoveNotationStyle.Coordinates), moveStr, StringComparison.OrdinalIgnoreCase)
          || String.Equals(moveTry.MoveStr(MGMoveNotationStyle.LongAlgebraic), moveStr, StringComparison.OrdinalIgnoreCase)
-         || String.Equals(moveTry.MoveStr(MGMoveNotationStyle.StandardCastlingFormat), moveStr, StringComparison.OrdinalIgnoreCase))
+         || String.Equals(moveTry.MoveStr(MGMoveNotationStyle.ShortAlgebraic), moveStr, StringComparison.OrdinalIgnoreCase))
         {
-          move = moveTry;
-          //if (moveTry.IsCastle)
-          //{
-          //  var res1 = moveTry.MoveStr(MGMoveNotationStyle.LC0Coordinate);
-          //  var res2 = moveTry.MoveStr(MGMoveNotationStyle.LongAlgebraic);
-          //  var res3 = moveTry.MoveStr(MGMoveNotationStyle.StandardCastlingFormat);
-          //}
+          move = moveTry;         
           return true;
         }
       }

--- a/src/Ceres.Chess/MoveGen/MGMoveGenTest.cs
+++ b/src/Ceres.Chess/MoveGen/MGMoveGenTest.cs
@@ -489,7 +489,7 @@ namespace Ceres.Chess.MoveGen.Test
       Console.WriteLine("Num generated: " + moves.NumMovesUsed);
 
       for (int i = 0; i < moves.NumMovesUsed; i++)
-        Console.WriteLine(i + ": " + moves.MovesArray[i].MoveStr(MGMoveNotationStyle.CoOrdinate) + " " + moves.MovesArray[i].FromSquareIndex + " " + moves.MovesArray[i].ToSquareIndex + " " + moves.MovesArray[i].Flags);
+        Console.WriteLine(i + ": " + moves.MovesArray[i].MoveStr(MGMoveNotationStyle.PieceAndCoordinates) + " " + moves.MovesArray[i].FromSquareIndex + " " + moves.MovesArray[i].ToSquareIndex + " " + moves.MovesArray[i].Flags);
       System.Environment.Exit(3);
 
 

--- a/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
+++ b/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
@@ -168,7 +168,6 @@ namespace Ceres.Chess.MoveGen
 
         if (M.CastleShort && performedCastling)
         {
-          Debug.Assert(M.ToString() == "O-O");
           BitBoard kingToSq = 144115188075855872; //g8 in decimals
           BitBoard kingIdx = 57; //g8 represented as index from h1..a1
           BitBoard kingPos = nFromSquare == kingIdx ? 0 : (1UL << (int)nFromSquare) | kingToSq;
@@ -288,7 +287,6 @@ namespace Ceres.Chess.MoveGen
 
         if (M.CastleLong && performedCastling)
         {
-          Debug.Assert(M.ToString() == "O-O-O");
           BitBoard rookPos = 1UL << (int)nToSquare;
           rookPos = rookPos == 16 ? 0 : rookPos | 16;
           BitBoard kingToSq = 32; //c1 in decimals

--- a/src/Ceres.Chess/Positions/PositionWithHistory.cs
+++ b/src/Ceres.Chess/Positions/PositionWithHistory.cs
@@ -537,12 +537,8 @@ namespace Ceres.Chess.Positions
       {
         string moveStr = "";
         foreach (MGMove move in Moves)
-        {
-          MGMoveNotationStyle moveStyle = (!MGPositionConstants.IsChess960 && move.IsCastle)
-                                            ? MGMoveNotationStyle.StandardCastlingFormat
-                                            : MGMoveNotationStyle.LC0Coordinate;
-
-          moveStr += move.MoveStr(moveStyle) + " ";
+        {          
+          moveStr += move.MoveStr(MGMoveNotationStyle.Coordinates) + " ";
         }
         return moveStr;
       }

--- a/src/Ceres.Features/GameEngines/GameEngineCeresInProcess.cs
+++ b/src/Ceres.Features/GameEngines/GameEngineCeresInProcess.cs
@@ -372,12 +372,9 @@ namespace Ceres.Features.GameEngines
 
       isFirstMoveOfGame = false;
       // TODO is the RootNWhenSearchStarted correct because we may be following a continuation (BestMoveRoot)
-      MGMoveNotationStyle style = (!MGPositionConstants.IsChess960 && bestMoveMG.IsCastle)
-                       ? MGMoveNotationStyle.StandardCastlingFormat
-                       : MGMoveNotationStyle.LC0Coordinate;
 
       GameEngineSearchResultCeres result =
-        new GameEngineSearchResultCeres(bestMoveMG.MoveStr(style),
+        new GameEngineSearchResultCeres(bestMoveMG.MoveStr(MGMoveNotationStyle.Coordinates),
                                         (float)bestMoveInfo.QOfBest, scoreCeresCP, searchResult.SearchRootNode.MAvg, searchResult.Manager.SearchLimit,
                                         this.LastSearch.TimingInfo,
                                         searchResult.Manager.RootNWhenSearchStarted, N, (int)Math.Round(searchResult.Manager.Context.AvgDepth),

--- a/src/Ceres.Features/UCI/UCIManager.cs
+++ b/src/Ceres.Features/UCI/UCIManager.cs
@@ -1054,10 +1054,7 @@ namespace Ceres.Features.UCI
       OutputUCIInfo(result.Search.Manager, result.Search.SearchRootNode, true);
 
       // Send the best move (using appropriate castling move style).
-      MGMoveNotationStyle style = (!MGPositionConstants.IsChess960 && result.Search.BestMove.IsCastle)
-                                    ? MGMoveNotationStyle.StandardCastlingFormat
-                                    : MGMoveNotationStyle.LC0Coordinate;
-      UCIWriteLine("bestmove " + result.Search.BestMove.MoveStr(style));
+      UCIWriteLine("bestmove " + result.Search.BestMove.MoveStr(MGMoveNotationStyle.Coordinates));
 
       return result;
     }

--- a/src/Ceres.Features/UCI/VerboseMoveStatsFromMCTSNode.cs
+++ b/src/Ceres.Features/UCI/VerboseMoveStatsFromMCTSNode.cs
@@ -88,12 +88,7 @@ namespace Ceres.Features.UCI
     static VerboseMoveStat BuildStatNoSearch(VerboseMoveStats statsParent, MCTSNode parent, BestMoveInfo info)
     {
       VerboseMoveStat stat = new VerboseMoveStat(statsParent, null);
-
-      MGMoveNotationStyle style = (!MGPositionConstants.IsChess960 && info.BestMove.IsCastle)
-                             ? MGMoveNotationStyle.StandardCastlingFormat
-                             : MGMoveNotationStyle.LC0Coordinate;
-
-      stat.MoveString = info.BestMove.MoveStr(style);
+      stat.MoveString = info.BestMove.MoveStr(MGMoveNotationStyle.Coordinates);
       float v = parent.V;
       stat.WL = v;
       stat.Q = new EncodedEvalLogistic(v);
@@ -122,11 +117,7 @@ namespace Ceres.Features.UCI
       node.Annotate();
 
       MGMove move = node.Annotation.PriorMoveMG;
-      MGMoveNotationStyle style = (!MGPositionConstants.IsChess960 && move.IsCastle)
-                                   ? MGMoveNotationStyle.StandardCastlingFormat
-                                   : MGMoveNotationStyle.LC0Coordinate;
-
-      stat.MoveString = isSearchRoot ? "node" : move.MoveStr(style);
+      stat.MoveString = isSearchRoot ? "node" : move.MoveStr(MGMoveNotationStyle.Coordinates);
       stat.MoveCode = isSearchRoot ? 20 : node.Parent.ChildAtIndexInfo(node.IndexInParentsChildren).move.IndexNeuralNet;
       stat.VisitCount = node.N;
       stat.P = isSearchRoot ? 100 : (node.P * 100.0f);

--- a/src/Ceres.MCTS/Iteration/MCTSManager.Dump.cs
+++ b/src/Ceres.MCTS/Iteration/MCTSManager.Dump.cs
@@ -120,15 +120,11 @@ namespace Ceres.MCTS.Iteration
           }
         }
 
-        MGMoveNotationStyle style = (!MGPositionConstants.IsChess960 && bestMove.IsCastle)
-                 ? MGMoveNotationStyle.StandardCastlingFormat
-                 : MGMoveNotationStyle.LC0Coordinate;
-
         // Output position (with history) information.
         writer.WriteLine("Position            : " + searchRootNode.Annotation.Pos.FEN);
         writer.WriteLine("Tree root position  : " + Context.Tree.Store.Nodes.PriorMoves);
         writer.WriteLine("Search stop status  : " + StopStatus);
-        writer.WriteLine("Best move selected  : " + bestMove.MoveStr(style) + " " + bestMoveInfo);
+        writer.WriteLine("Best move selected  : " + bestMove.MoveStr(MGMoveNotationStyle.Coordinates) + " " + bestMoveInfo);
         writer.WriteLine();
 
         string infoUpdate = UCIInfo.UCIInfoString(this, searchRootNode);

--- a/src/Ceres.MCTS/MCTSNodes/Node/BestMoveInfo.cs
+++ b/src/Ceres.MCTS/MCTSNodes/Node/BestMoveInfo.cs
@@ -208,11 +208,7 @@ namespace Ceres.MCTS.MTCSNodes
       string bestQStr = QMaximal == QOfBest ? "(same)" : $"{QMaximal:F3}";
       string mlhStr = MLHBonusApplied == 0 ? "" : $" MLHBonus={MLHBonusApplied}";
 
-      MGMoveNotationStyle style = (!MGPositionConstants.IsChess960 && BestMove.IsCastle)
-         ? MGMoveNotationStyle.StandardCastlingFormat
-         : MGMoveNotationStyle.LC0Coordinate;
-
-      return $"<BestMoveInfo {BestMove.MoveStr(style)} N={N} Q={QOfBest} BestN={bestNStr} BestQ={bestQStr} BestN2={BestNSecond,5:F1} {mlhStr}>";
+      return $"<BestMoveInfo {BestMove.MoveStr(MGMoveNotationStyle.Coordinates)} N={N} Q={QOfBest} BestN={bestNStr} BestQ={bestQStr} BestN2={BestNSecond,5:F1} {mlhStr}>";
     }
   }
 }

--- a/src/Ceres.MCTS/MCTSNodes/Node/MCTSNodeInitPolicy.cs
+++ b/src/Ceres.MCTS/MCTSNodes/Node/MCTSNodeInitPolicy.cs
@@ -144,10 +144,10 @@ namespace Ceres.MCTS.MTCSNodes
         if (indexLegalMove != -1)
         {
           /** FIX ME **/
-          const float threshold = 0.15f;
+          const float threshold = 0.05f;
           MGMove policyMoveMG = ConverterMGMoveEncodedMove.EncodedMoveToMGChessMove(thisPolicyMove, in posMG);
           
-          if (thisPolicyProb < threshold && policyMoveMG.IsChess960Caslte)
+          if (thisPolicyProb < threshold && policyMoveMG.IsChess960Castle)
           {
             // Force castling moves in Chess960 to have somewhat higher minimum probability
             // neural networks may not be trained to recognize them.

--- a/src/Ceres.MCTS/Utils/SearchPrincipalVariation.cs
+++ b/src/Ceres.MCTS/Utils/SearchPrincipalVariation.cs
@@ -180,12 +180,8 @@ namespace Ceres.MCTS.Utils
       if (Nodes.Count == 1)
       {
         // In the special case of only root evaluated, show the best policy move so the pv is not completely empty.
-        // Otherwise, we choose not to show the best policy move at the terminal node.
-        MGMove bestMoveSingle = Nodes[0].BestMoveInfo(false).BestMove;
-        MGMoveNotationStyle moveStyleSingle = (!MGPositionConstants.IsChess960 && bestMoveSingle.IsCastle)
-                                          ? MGMoveNotationStyle.StandardCastlingFormat
-                                          : MGMoveNotationStyle.LC0Coordinate;
-        return bestMoveSingle.MoveStr(moveStyleSingle);
+        // Otherwise, we choose not to show the best policy move at the terminal node.        
+        return Nodes[0].BestMoveInfo(false).BestMove.MoveStr(MGMoveNotationStyle.Coordinates);
       }
 
       StringBuilder sb = new StringBuilder();
@@ -194,13 +190,8 @@ namespace Ceres.MCTS.Utils
       foreach (MCTSNode node in Nodes)
       {
         if (haveSkippedSearchRoot)
-        {
-          MGMove bestMoveSkipped = node.Annotation.PriorMoveMG;
-          MGMoveNotationStyle moveStyleSkipped = (!MGPositionConstants.IsChess960 && bestMoveSkipped.IsCastle)
-                                            ? MGMoveNotationStyle.StandardCastlingFormat
-                                            : MGMoveNotationStyle.LC0Coordinate;
-
-          sb.Append(bestMoveSkipped.MoveStr(moveStyleSkipped) + " ");
+        {         
+          sb.Append(node.Annotation.PriorMoveMG.MoveStr(MGMoveNotationStyle.Coordinates) + " ");
         }
         else
         {

--- a/src/Ceres.MCTS/Utils/UCIInfo.cs
+++ b/src/Ceres.MCTS/Utils/UCIInfo.cs
@@ -76,10 +76,7 @@ namespace Ceres.MCTS.Utils
 
         MCTSNode root = overrideRootMove.IsNotNull ? overrideRootMove : manager.Root;
         float topVScoreToShow = ScoreToShow(scoreAsQ, (float)root.Q);
-        MGMoveNotationStyle style = (!MGPositionConstants.IsChess960 && manager.Context.TopVForcedMove.IsCastle)
-                                   ? MGMoveNotationStyle.StandardCastlingFormat
-                                   : MGMoveNotationStyle.LC0Coordinate;
-        string moveStr = manager.Context.TopVForcedMove.MoveStr(style);
+        string moveStr = manager.Context.TopVForcedMove.MoveStr(MGMoveNotationStyle.Coordinates);
         string str = $"info depth 1 seldepth 1 time 0 nodes 1 score cp {topVScoreToShow} pv {moveStr}";
         return str;
       }
@@ -215,11 +212,7 @@ namespace Ceres.MCTS.Utils
         scoreStr = scoreAsQ ? "-1.0" : "-9999";
       }
 
-      MGMoveNotationStyle style = (!MGPositionConstants.IsChess960 && manager.TablebaseImmediateBestMove.IsCastle)
-                                 ? MGMoveNotationStyle.StandardCastlingFormat
-                                 : MGMoveNotationStyle.LC0Coordinate;
-
-      string moveStr = manager.TablebaseImmediateBestMove.MoveStr(style);
+      string moveStr = manager.TablebaseImmediateBestMove.MoveStr(MGMoveNotationStyle.Coordinates);
       string str = $"info depth 1 seldepth 1 time 0 nodes 1 score cp {scoreStr} pv {moveStr}";
       return str;
     }


### PR DESCRIPTION
Introduced new properties for castling moves and updated move notation styles to use `Coordinates`.
- Removed dependency on static variable MGPositionConstants.IsChess960
- `MGMove`: Added properties for legacy and Chess960 castling.
- `MGMoveDump`, `MGMoveFromString`, `PositionWithHistory`: Updated to use `Coordinates` notation style.
- `MCTSNodeInitPolicy`: Adjusted threshold for Chess960 castling moves.
- `UCIManager`, `UCIInfo`: Updated best move output to use `Coordinates` notation style.