### PR TITLE
Add rook placement fields and update FEN handling for Chess960

### DIFF
--- a/src/Ceres.Chess/MoveGen/Converters/MGChessPositionConverter.cs
+++ b/src/Ceres.Chess/MoveGen/Converters/MGChessPositionConverter.cs
@@ -88,6 +88,10 @@ namespace Ceres.Chess.MoveGen.Converters
       pos.BlackCanCastle = position.MiscInfo.BlackCanOO;
       pos.WhiteCanCastleLong = position.MiscInfo.WhiteCanOOO;
       pos.BlackCanCastleLong = position.MiscInfo.BlackCanOOO;
+      pos.WhiteKRInitPlacement = position.MiscInfo.WhiteKRInitPlacement;
+      pos.WhiteQRInitPlacement = position.MiscInfo.WhiteQRInitPlacement;
+      pos.BlackKRInitPlacement = position.MiscInfo.BlackKRInitPlacement;
+      pos.BlackQRInitPlacement = position.MiscInfo.BlackQRInitPlacement;
 
       if (position.MiscInfo.EnPassantFileIndex != PositionMiscInfo.EnPassantFileIndexEnum.FileNone)
       {
@@ -220,6 +224,10 @@ namespace Ceres.Chess.MoveGen.Converters
       pos.BlackCanCastle = fenParsed.MiscInfo.BlackCanOO;
       pos.WhiteCanCastleLong = fenParsed.MiscInfo.WhiteCanOOO;
       pos.BlackCanCastleLong = fenParsed.MiscInfo.BlackCanOOO;
+      pos.BlackKRInitPlacement = fenParsed.MiscInfo.BlackKRInitPlacement;
+      pos.BlackQRInitPlacement = fenParsed.MiscInfo.BlackQRInitPlacement;
+      pos.WhiteKRInitPlacement = fenParsed.MiscInfo.WhiteKRInitPlacement;
+      pos.WhiteQRInitPlacement = fenParsed.MiscInfo.WhiteQRInitPlacement;
 
       if (fenParsed.MiscInfo.EnPassantFileIndex != PositionMiscInfo.EnPassantFileIndexEnum.FileNone)
       {

--- a/src/Ceres.Chess/MoveGen/Converters/MGChessPositionConverter.cs
+++ b/src/Ceres.Chess/MoveGen/Converters/MGChessPositionConverter.cs
@@ -87,11 +87,8 @@ namespace Ceres.Chess.MoveGen.Converters
       pos.WhiteCanCastle = position.MiscInfo.WhiteCanOO;
       pos.BlackCanCastle = position.MiscInfo.BlackCanOO;
       pos.WhiteCanCastleLong = position.MiscInfo.WhiteCanOOO;
-      pos.BlackCanCastleLong = position.MiscInfo.BlackCanOOO;
-      pos.WhiteKRInitPlacement = position.MiscInfo.WhiteKRInitPlacement;
-      pos.WhiteQRInitPlacement = position.MiscInfo.WhiteQRInitPlacement;
-      pos.BlackKRInitPlacement = position.MiscInfo.BlackKRInitPlacement;
-      pos.BlackQRInitPlacement = position.MiscInfo.BlackQRInitPlacement;
+      pos.BlackCanCastleLong = position.MiscInfo.BlackCanOOO;      
+      pos.rookInfo = position.MiscInfo.RookInfo;
 
       if (position.MiscInfo.EnPassantFileIndex != PositionMiscInfo.EnPassantFileIndexEnum.FileNone)
       {
@@ -192,7 +189,7 @@ namespace Ceres.Chess.MoveGen.Converters
       PositionMiscInfo miscInfo = new PositionMiscInfo(mgPos.WhiteCanCastle, mgPos.WhiteCanCastleLong,
                               mgPos.BlackCanCastle, mgPos.BlackCanCastleLong,
                               sideToMove, mgPos.Rule50Count, 0,
-                              mgPos.MoveNumber, enPassantColIndex);
+                              mgPos.MoveNumber, enPassantColIndex, mgPos.rookInfo);
 
       pos.SetMiscInfo(miscInfo);
       pos.SetPieceCount(pieceCount);
@@ -224,10 +221,7 @@ namespace Ceres.Chess.MoveGen.Converters
       pos.BlackCanCastle = fenParsed.MiscInfo.BlackCanOO;
       pos.WhiteCanCastleLong = fenParsed.MiscInfo.WhiteCanOOO;
       pos.BlackCanCastleLong = fenParsed.MiscInfo.BlackCanOOO;
-      pos.BlackKRInitPlacement = fenParsed.MiscInfo.BlackKRInitPlacement;
-      pos.BlackQRInitPlacement = fenParsed.MiscInfo.BlackQRInitPlacement;
-      pos.WhiteKRInitPlacement = fenParsed.MiscInfo.WhiteKRInitPlacement;
-      pos.WhiteQRInitPlacement = fenParsed.MiscInfo.WhiteQRInitPlacement;
+      pos.rookInfo = fenParsed.MiscInfo.RookInfo;
 
       if (fenParsed.MiscInfo.EnPassantFileIndex != PositionMiscInfo.EnPassantFileIndexEnum.FileNone)
       {

--- a/src/Ceres.Chess/MoveGen/MGPosition.cs
+++ b/src/Ceres.Chess/MoveGen/MGPosition.cs
@@ -74,6 +74,10 @@ namespace Ceres.Chess.MoveGen
 
     public short MoveNumber;
     public short Rule50Count;
+    public byte WhiteKRInitPlacement;
+    public byte WhiteQRInitPlacement;
+    public byte BlackKRInitPlacement;
+    public byte BlackQRInitPlacement;
 
     //    public short material;
 

--- a/src/Ceres.Chess/MoveGen/MGPosition.cs
+++ b/src/Ceres.Chess/MoveGen/MGPosition.cs
@@ -74,10 +74,7 @@ namespace Ceres.Chess.MoveGen
 
     public short MoveNumber;
     public short Rule50Count;
-    public byte WhiteKRInitPlacement;
-    public byte WhiteQRInitPlacement;
-    public byte BlackKRInitPlacement;
-    public byte BlackQRInitPlacement;
+    public RookPlacementInfo rookInfo;
 
     //    public short material;
 

--- a/src/Ceres.Chess/MoveGen/MGPositionConstants.cs
+++ b/src/Ceres.Chess/MoveGen/MGPositionConstants.cs
@@ -153,9 +153,12 @@ namespace Ceres.Chess.MoveGen
       BitBoard bKing = (pos.D & pos.C & pos.B & pos.A) & MGPositionConstants.lastRank;
       BitBoard bRooks = (pos.D & pos.C & ~pos.B & ~pos.A) & MGPositionConstants.lastRank;
       int kingSq = (int)LSB(bKing);
-      int rookSq = (int)(MSB(bRooks));
+      int rookSq = pos.BlackQRInitPlacement;
+      BitBoard rookBitBoard = 1UL << rookSq;
+      bool rookAtStartSquare = (bRooks & rookBitBoard) != 0;
       rookPos = 1UL << rookSq;
-      if (bKing == 0 || bRooks == 0UL || kingSq > rookSq)
+
+      if (bKing == 0 || bRooks == 0UL || kingSq > rookSq || !rookAtStartSquare )
       {
         return false;
       }
@@ -188,9 +191,12 @@ namespace Ceres.Chess.MoveGen
       BitBoard wRooks = (~pos.D & pos.C & ~pos.B & ~pos.A) & MGPositionConstants.firstRank;
       BitBoard wKing = (~pos.D & pos.C & pos.B & pos.A) & MGPositionConstants.firstRank;
       int kingSq = (int)LSB(wKing);
-      int rookSq = (int)MSB(wRooks);
+      int rookSq = pos.WhiteQRInitPlacement;
+      BitBoard rookBitBoard = 1UL << rookSq;
+      bool rookAtStartSquare = (wRooks & rookBitBoard) != 0;      
       rookPos = 1UL << rookSq;
-      if (wKing == 0 || wRooks == 0UL || kingSq > rookSq)
+
+      if (wKing == 0 || wRooks == 0UL || kingSq > rookSq || !rookAtStartSquare )
       {
         return false;
       }
@@ -221,9 +227,12 @@ namespace Ceres.Chess.MoveGen
       BitBoard bKing = (pos.D & pos.C & pos.B & pos.A) & MGPositionConstants.lastRank;
       BitBoard bRooks = (pos.D & pos.C & ~pos.B & ~pos.A) & MGPositionConstants.lastRank;
       int kingSq = (int)LSB(bKing);
-      int rookSq = (int)(LSB(bRooks));
+      int rookSq = pos.BlackKRInitPlacement;
+      BitBoard rookBitBoard = 1UL << rookSq;
+      bool rookAtStartSquare = (bRooks & rookBitBoard) != 0;     
       rookPos = 1UL << rookSq;
-      if (bKing == 0 || bRooks == 0UL || kingSq < rookSq)
+
+      if (bKing == 0 || bRooks == 0UL || kingSq < rookSq || !rookAtStartSquare)
       {
         return false;
       }
@@ -248,9 +257,12 @@ namespace Ceres.Chess.MoveGen
       BitBoard wKing = (~pos.D & pos.C & pos.B & pos.A) & MGPositionConstants.firstRank; // pos.B & pos.C; //GetKings(pos.A, pos.B, pos.C, pos.D);
       BitBoard wRooks = (~pos.D & pos.C & ~pos.B & ~pos.A) & MGPositionConstants.firstRank;
       int kingSq = (int)LSB(wKing);
-      int rookSq = (int)(LSB(wRooks));
+      int rookSq = pos.WhiteKRInitPlacement; //(int)(LSB(wRooks));
+      BitBoard rookBitBoard = 1UL << rookSq;
+      bool rookAtStartSquare = (wRooks & rookBitBoard) != 0;
       rookPos = 1UL << rookSq;
-      if (wKing == 0 || wRooks == 0UL || kingSq < rookSq)
+
+      if (wKing == 0 || wRooks == 0UL || kingSq < rookSq || !rookAtStartSquare)
       {
         return false;
       }

--- a/src/Ceres.Chess/MoveGen/MGPositionConstants.cs
+++ b/src/Ceres.Chess/MoveGen/MGPositionConstants.cs
@@ -106,7 +106,7 @@ namespace Ceres.Chess.MoveGen
 
       return true;
     }
-   
+
     public static bool CanWhiteKingMoveToCastlingPos(in MGPosition pos, int kingSq, int rookSq, int startSquare, int endSquare, bool moveLeft)
     {
       BitBoard rook = 1UL << rookSq;
@@ -153,12 +153,12 @@ namespace Ceres.Chess.MoveGen
       BitBoard bKing = (pos.D & pos.C & pos.B & pos.A) & MGPositionConstants.lastRank;
       BitBoard bRooks = (pos.D & pos.C & ~pos.B & ~pos.A) & MGPositionConstants.lastRank;
       int kingSq = (int)LSB(bKing);
-      int rookSq = pos.BlackQRInitPlacement;
+      int rookSq = pos.rookInfo.BlackQRInitPlacement + 56;
       BitBoard rookBitBoard = 1UL << rookSq;
       bool rookAtStartSquare = (bRooks & rookBitBoard) != 0;
       rookPos = 1UL << rookSq;
 
-      if (bKing == 0 || bRooks == 0UL || kingSq > rookSq || !rookAtStartSquare )
+      if (bKing == 0 || bRooks == 0UL || kingSq > rookSq || !rookAtStartSquare)
       {
         return false;
       }
@@ -191,12 +191,12 @@ namespace Ceres.Chess.MoveGen
       BitBoard wRooks = (~pos.D & pos.C & ~pos.B & ~pos.A) & MGPositionConstants.firstRank;
       BitBoard wKing = (~pos.D & pos.C & pos.B & pos.A) & MGPositionConstants.firstRank;
       int kingSq = (int)LSB(wKing);
-      int rookSq = pos.WhiteQRInitPlacement;
+      int rookSq = pos.rookInfo.WhiteQRInitPlacement;
       BitBoard rookBitBoard = 1UL << rookSq;
-      bool rookAtStartSquare = (wRooks & rookBitBoard) != 0;      
+      bool rookAtStartSquare = (wRooks & rookBitBoard) != 0;
       rookPos = 1UL << rookSq;
 
-      if (wKing == 0 || wRooks == 0UL || kingSq > rookSq || !rookAtStartSquare )
+      if (wKing == 0 || wRooks == 0UL || kingSq > rookSq || !rookAtStartSquare)
       {
         return false;
       }
@@ -227,9 +227,9 @@ namespace Ceres.Chess.MoveGen
       BitBoard bKing = (pos.D & pos.C & pos.B & pos.A) & MGPositionConstants.lastRank;
       BitBoard bRooks = (pos.D & pos.C & ~pos.B & ~pos.A) & MGPositionConstants.lastRank;
       int kingSq = (int)LSB(bKing);
-      int rookSq = pos.BlackKRInitPlacement;
+      int rookSq = pos.rookInfo.BlackKRInitPlacement + 56;
       BitBoard rookBitBoard = 1UL << rookSq;
-      bool rookAtStartSquare = (bRooks & rookBitBoard) != 0;     
+      bool rookAtStartSquare = (bRooks & rookBitBoard) != 0;
       rookPos = 1UL << rookSq;
 
       if (bKing == 0 || bRooks == 0UL || kingSq < rookSq || !rookAtStartSquare)
@@ -257,7 +257,7 @@ namespace Ceres.Chess.MoveGen
       BitBoard wKing = (~pos.D & pos.C & pos.B & pos.A) & MGPositionConstants.firstRank; // pos.B & pos.C; //GetKings(pos.A, pos.B, pos.C, pos.D);
       BitBoard wRooks = (~pos.D & pos.C & ~pos.B & ~pos.A) & MGPositionConstants.firstRank;
       int kingSq = (int)LSB(wKing);
-      int rookSq = pos.WhiteKRInitPlacement; //(int)(LSB(wRooks));
+      int rookSq = pos.rookInfo.WhiteKRInitPlacement;
       BitBoard rookBitBoard = 1UL << rookSq;
       bool rookAtStartSquare = (wRooks & rookBitBoard) != 0;
       rookPos = 1UL << rookSq;

--- a/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
+++ b/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
@@ -109,6 +109,37 @@ namespace Ceres.Chess.MoveGen
       // Increment ply count
       MoveNumber++;
 
+      //reset opponents castling rights if there is a capture of one of his rooks
+      if (M.Capture)
+      {
+        if (M.BlackToMove)
+        {
+          if (M.ToSquareIndex == rookInfo.WhiteKRInitPlacement)
+          {
+            WhiteCanCastle = false;
+            WhiteForfeitedCastle = true;
+          }
+          else if (M.ToSquareIndex == rookInfo.WhiteQRInitPlacement)
+          {
+            WhiteCanCastleLong = false;
+            WhiteForfeitedCastleLong = true;
+          }
+        }
+        else
+        {
+          if (M.ToSquareIndex == rookInfo.BlackKRInitPlacement + 56)
+          {
+            BlackCanCastle = false;
+            BlackForfeitedCastle = true;
+          }
+          else if (M.ToSquareIndex == rookInfo.BlackQRInitPlacement + 56)
+          {
+            BlackCanCastleLong = false;
+            BlackForfeitedCastleLong = true;
+          }
+        }
+      }
+
       // Update Rule 50 count (upon any pawn move or capture)
       if (M.Capture || (byte)M.Piece == MGPositionConstants.WPAWN 
                     || (byte)M.Piece == MGPositionConstants.BPAWN)

--- a/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
+++ b/src/Ceres.Chess/MoveGen/MGPositionPerformMove.cs
@@ -167,11 +167,7 @@ namespace Ceres.Chess.MoveGen
 
       if ((byte)M.Piece == MGPositionConstants.BKING)
       {
-        Square rookToSq = new Square((int)nToSquare, Square.SquareIndexType.BottomToTopRightToLeft);
-        MGPositionConstants.MCChessPositionPieceEnum pieceToSq = RawPieceAtSquare(rookToSq);
-        bool performedCastling = pieceToSq == MGPositionConstants.MCChessPositionPieceEnum.BlackRook;
-
-        if (M.CastleShort && performedCastling)
+        if (M.CastleShort)
         {
           BitBoard kingToSq = 144115188075855872; //g8 in decimals
           BitBoard kingIdx = 57; //g8 represented as index from h1..a1
@@ -201,7 +197,7 @@ namespace Ceres.Chess.MoveGen
           Flags &= ~FlagsEnum.BlackCanCastleLong;
           return;
         }
-        else if (M.CastleLong && performedCastling)
+        else if (M.CastleLong)
         {
           BitBoard kingToSq = 2305843009213693952; //c8 in decimals
           BitBoard kingIdx = 61; //c8 represented as index from h1..a8
@@ -254,11 +250,7 @@ namespace Ceres.Chess.MoveGen
 
       else if ((byte)M.Piece == MGPositionConstants.WKING)
       {
-        Square rookToSq = new Square((int)nToSquare, Square.SquareIndexType.BottomToTopRightToLeft);
-        MGPositionConstants.MCChessPositionPieceEnum pieceToSq = RawPieceAtSquare(rookToSq);
-        bool performedCastling = pieceToSq == MGPositionConstants.MCChessPositionPieceEnum.WhiteRook;
-
-        if (M.CastleShort && performedCastling)
+        if (M.CastleShort)
         {
           BitBoard rookPos = 1UL << (int)nToSquare;
           rookPos = rookPos == 4 ? 0 : rookPos | 4;
@@ -288,7 +280,7 @@ namespace Ceres.Chess.MoveGen
           return;
         }
 
-        if (M.CastleLong && performedCastling)
+        if (M.CastleLong)
         {
           BitBoard rookPos = 1UL << (int)nToSquare;
           rookPos = rookPos == 16 ? 0 : rookPos | 16;
@@ -346,14 +338,7 @@ namespace Ceres.Chess.MoveGen
       // LOOK FOR FORFEITED CASTLING RIGHTS DUE to ROOK MOVES:
       else if ((byte)M.Piece == MGPositionConstants.BROOK)
       {
-        BitBoard rooks = (~A & ~B & C & D) & MGPositionConstants.lastRank;
-        BitBoard rKSq = QBBoperations.LSB(rooks);
-        BitBoard rQSq = QBBoperations.MSB(rooks);
-        BitBoard bKingSquare = QBBoperations.LSB(D & C & B & A); //black king
-        bool rKMoved = nFromSquare == rKSq && bKingSquare > nFromSquare;
-        bool rQMoved = nFromSquare == rQSq && bKingSquare < nFromSquare;
-
-        if (rKMoved && rooks != 0)
+        if (M.FromSquareIndex == (rookInfo.BlackKRInitPlacement + 56))
         {
           // Black moved K-side Rook and forfeits right to castle K-side
           if (BlackCanCastle)
@@ -366,7 +351,7 @@ namespace Ceres.Chess.MoveGen
           }
         }
         //else if ((1LL<<nFromSquare) & BLACKQRPOS)
-        else if (rQMoved && rooks != 0)
+        else if (M.FromSquareIndex == (rookInfo.BlackQRInitPlacement + 56))
         {
           // Black moved the QS Rook and forfeits right to castle Q-side
           if (BlackCanCastleLong)
@@ -381,16 +366,8 @@ namespace Ceres.Chess.MoveGen
       }
 
       else if ((byte)M.Piece == MGPositionConstants.WROOK)
-      {
-        BitBoard rooks = (~A & ~B & C & ~D) & MGPositionConstants.firstRank;
-        BitBoard rKSq = QBBoperations.LSB(rooks);
-        BitBoard rQSq = QBBoperations.MSB(rooks);
-        BitBoard wKingSquare = QBBoperations.LSB(~D & C & B & A);
-        bool rKMoved = nFromSquare == rKSq && wKingSquare > nFromSquare;
-        bool rQMoved = nFromSquare == rQSq && wKingSquare < nFromSquare;
-        Debug.Assert((rQMoved && rKMoved) != true);
-
-        if (rKMoved && rooks != 0)
+      {        
+        if (M.FromSquareIndex == rookInfo.WhiteKRInitPlacement)
         {
           // White moved K-side Rook and forfeits right to castle K-side
           if (WhiteCanCastle)
@@ -403,7 +380,7 @@ namespace Ceres.Chess.MoveGen
           }
         }
         //	else if((1LL<<nFromSquare) & WHITEQRPOS)
-        else if (rQMoved && rooks != 0)
+        else if (M.FromSquareIndex == rookInfo.WhiteQRInitPlacement)
         {
           // White moved the QSide Rook and forfeits right to castle Q-side
           if (WhiteCanCastleLong)

--- a/src/Ceres.Chess/MoveGen/RookPlacementInfo.cs
+++ b/src/Ceres.Chess/MoveGen/RookPlacementInfo.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ceres.Chess.MoveGen
+{
+  /// <summary>
+  /// Efficiently represents initial rook palcement information used in Chess960.
+  /// Each of the 4 fields supports values in the range [0..15].
+  /// 
+  /// Initialized such that values returned by default object will return as 15.
+  /// </summary>
+  [StructLayout(LayoutKind.Sequential, Pack = 1)]
+  public record struct RookPlacementInfo
+  {
+    // Data representation. Encoded such that the default C#
+    // value of 0 will map to our default value of 15.
+    private ushort rookInitPlacementBits;
+
+    private static byte EncodeValue(byte value) => (byte)(((value + 1) & 0x0F) % 16);
+    private static byte DecodeValue(byte value) => (byte)(((value - 1) & 0x0F) % 16);
+
+    public byte WhiteKRInitPlacement
+    {
+      get => DecodeValue((byte)((rookInitPlacementBits >> 12) & 0x0F)); // Extract bits 12-15
+      set => rookInitPlacementBits = (ushort)((rookInitPlacementBits & ~(0x0F << 12)) | (EncodeValue(value) << 12)); // Set bits 12-15
+    }
+
+    public byte WhiteQRInitPlacement
+    {
+      get => DecodeValue((byte)((rookInitPlacementBits >> 8) & 0x0F)); // Extract bits 8-11
+      set => rookInitPlacementBits = (ushort)((rookInitPlacementBits & ~(0x0F << 8)) | (EncodeValue(value) << 8)); // Set bits 8-11
+    }
+
+    public byte BlackKRInitPlacement
+    {
+      get => DecodeValue((byte)((rookInitPlacementBits >> 4) & 0x0F)); // Extract bits 4-7
+      set => rookInitPlacementBits = (ushort)((rookInitPlacementBits & ~(0x0F << 4)) | (EncodeValue(value) << 4)); // Set bits 4-7
+    }
+
+    public byte BlackQRInitPlacement
+    {
+      get => DecodeValue((byte)(rookInitPlacementBits & 0x0F)); // Extract bits 0-3
+      set => rookInitPlacementBits = (ushort)((rookInitPlacementBits & ~0x0F) | EncodeValue(value)); // Set bits 0-3
+    }
+  }
+}

--- a/src/Ceres.Chess/Positions/Position.cs
+++ b/src/Ceres.Chess/Positions/Position.cs
@@ -283,7 +283,7 @@ namespace Ceres.Chess
       MiscInfo = reversedSide ? new(copyPosition.MiscInfo.BlackCanOO, copyPosition.MiscInfo.BlackCanOOO,
                                 copyPosition.MiscInfo.WhiteCanOO, copyPosition.MiscInfo.WhiteCanOOO,
                                 copyPosition.MiscInfo.SideToMove.Reversed(), copyPosition.MiscInfo.Move50Count,
-                                copyPosition.MiscInfo.RepetitionCount, copyPosition.MiscInfo.MoveNum, copyPosition.MiscInfo.EnPassantFileIndex)
+                                copyPosition.MiscInfo.RepetitionCount, copyPosition.MiscInfo.MoveNum, copyPosition.MiscInfo.EnPassantFileIndex, copyPosition.MiscInfo.RookInfo)
                           : copyPosition.MiscInfo;
 
       for (int i = 0; i < 64; i++)
@@ -423,13 +423,13 @@ namespace Ceres.Chess
       {
         newMiscInfo = new PositionMiscInfo(MiscInfo.WhiteCanOO, MiscInfo.WhiteCanOOO, MiscInfo.BlackCanOO, MiscInfo.BlackCanOOO,
                                            MiscInfo.SideToMove.Reversed(), MiscInfo.Move50Count, MiscInfo.RepetitionCount, moveNum,
-                                           PositionMiscInfo.EnPassantFileIndexEnum.FileNone);
+                                           PositionMiscInfo.EnPassantFileIndexEnum.FileNone, MiscInfo.RookInfo);
       }
       else
       {
         newMiscInfo = new PositionMiscInfo(MiscInfo.BlackCanOO, MiscInfo.BlackCanOOO, MiscInfo.WhiteCanOO, MiscInfo.WhiteCanOOO,
                                            MiscInfo.SideToMove.Reversed(), MiscInfo.Move50Count, MiscInfo.RepetitionCount, moveNum,
-                                           PositionMiscInfo.EnPassantFileIndexEnum.FileNone);
+                                           PositionMiscInfo.EnPassantFileIndexEnum.FileNone, MiscInfo.RookInfo);
       }
 
       // TODO: for efficiency, make a [ThreadStatic] PieceOnSquare[] for the temporary here
@@ -1214,9 +1214,14 @@ namespace Ceres.Chess
           (E7, Black,Pawn), (F7, Black,Pawn), (G7, Black,Pawn), (H7, Black,Pawn),
       };
 
+      RookPlacementInfo rookInfo = default;
+      rookInfo.WhiteKRInitPlacement = 0;
+      rookInfo.WhiteQRInitPlacement = 7;
+      rookInfo.BlackKRInitPlacement = 0;
+      rookInfo.BlackQRInitPlacement = 7;
       // NOTE: use 2 for ply number so translates to 1 for move number
       PositionMiscInfo miscInfo = new PositionMiscInfo(true, true, true, true, SideType.White,
-                                                       0, 0, 2, PositionMiscInfo.EnPassantFileIndexEnum.FileNone);
+                                                       0, 0, 2, PositionMiscInfo.EnPassantFileIndexEnum.FileNone, rookInfo);
       return new Position(pieces, in miscInfo);
     }
 

--- a/src/Ceres.Chess/Positions/PositionMiscInfo.cs
+++ b/src/Ceres.Chess/Positions/PositionMiscInfo.cs
@@ -18,6 +18,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using Ceres.Base.Environment;
+using Ceres.Chess.MoveGen;
 
 #endregion
 
@@ -32,10 +33,7 @@ namespace Ceres.Chess
   public readonly struct PositionMiscInfo : IEquatable<PositionMiscInfo>
   {
     public enum HashMove50Mode { Ignore, Value, ValueBoolIfAbove98 };
-    public readonly byte WhiteKRInitPlacement = 100;
-    public readonly byte WhiteQRInitPlacement = 100;
-    public readonly byte BlackKRInitPlacement = 100;
-    public readonly byte BlackQRInitPlacement = 100;
+    public readonly RookPlacementInfo RookInfo;
 
     [Flags]
     enum CastlingFlagsEnum : byte
@@ -300,8 +298,7 @@ namespace Ceres.Chess
     public PositionMiscInfo(bool whiteCanCastleOO, bool whiteCanCastleOOO,
                             bool blackCanCastleOO, bool blackCanCastleOOO,
                             SideType sideToMove, int move50Count, int repetitionCount,
-                            int moveNum, EnPassantFileIndexEnum enPassantColIndex,
-                            byte wKR, byte wQR, byte bKR, byte bQR)
+                            int moveNum, EnPassantFileIndexEnum enPassantColIndex, RookPlacementInfo rookInfo)
     {
       Debug.Assert(repetitionCount >= 0 && move50Count >= 0);
 
@@ -317,11 +314,8 @@ namespace Ceres.Chess
       SideToMove = sideToMove;
       Move50Count = move50Count > 255 ? (byte)255 : (byte)move50Count;
       RepetitionCount = repetitionCount > 3 ? (byte)3 : (byte)repetitionCount;
-      MoveNum = (short)moveNum;
-      WhiteKRInitPlacement = wKR;
-      WhiteQRInitPlacement = wQR;
-      BlackKRInitPlacement = bKR;
-      BlackQRInitPlacement = bQR;
+      MoveNum = (short)moveNum;     
+      RookInfo = rookInfo;
     }
 
 

--- a/src/Ceres.Chess/Positions/PositionMiscInfo.cs
+++ b/src/Ceres.Chess/Positions/PositionMiscInfo.cs
@@ -32,6 +32,10 @@ namespace Ceres.Chess
   public readonly struct PositionMiscInfo : IEquatable<PositionMiscInfo>
   {
     public enum HashMove50Mode { Ignore, Value, ValueBoolIfAbove98 };
+    public readonly byte WhiteKRInitPlacement = 100;
+    public readonly byte WhiteQRInitPlacement = 100;
+    public readonly byte BlackKRInitPlacement = 100;
+    public readonly byte BlackQRInitPlacement = 100;
 
     [Flags]
     enum CastlingFlagsEnum : byte
@@ -273,7 +277,7 @@ namespace Ceres.Chess
     /// <param name="enPassantColIndex"></param>
     public PositionMiscInfo(bool whiteCanCastleOO, bool whiteCanCastleOOO,
                             bool blackCanCastleOO, bool blackCanCastleOOO,
-                            SideType sideToMove, int move50Count, int repetitionCount, 
+                            SideType sideToMove, int move50Count, int repetitionCount,
                             int moveNum, EnPassantFileIndexEnum enPassantColIndex)
     {
       Debug.Assert(repetitionCount >= 0 && move50Count >= 0);
@@ -291,6 +295,33 @@ namespace Ceres.Chess
       Move50Count = move50Count > 255 ? (byte)255 : (byte)move50Count;
       RepetitionCount = repetitionCount > 3 ? (byte)3 : (byte)repetitionCount;
       MoveNum = (short)moveNum;
+    }
+
+    public PositionMiscInfo(bool whiteCanCastleOO, bool whiteCanCastleOOO,
+                            bool blackCanCastleOO, bool blackCanCastleOOO,
+                            SideType sideToMove, int move50Count, int repetitionCount,
+                            int moveNum, EnPassantFileIndexEnum enPassantColIndex,
+                            byte wKR, byte wQR, byte bKR, byte bQR)
+    {
+      Debug.Assert(repetitionCount >= 0 && move50Count >= 0);
+
+      int epc = 0;
+      if (whiteCanCastleOO) epc |= (int)CastlingFlagsEnum.WhiteCanOO;
+      if (whiteCanCastleOOO) epc |= (int)CastlingFlagsEnum.WhiteCanOOO;
+      if (blackCanCastleOO) epc |= (int)CastlingFlagsEnum.BlackCanOO;
+      if (blackCanCastleOOO) epc |= (int)CastlingFlagsEnum.BlackCanOOO;
+
+      epc |= (byte)enPassantColIndex * 16;
+      EnPassantFileIndexAndCastlingFlags = (byte)epc;
+
+      SideToMove = sideToMove;
+      Move50Count = move50Count > 255 ? (byte)255 : (byte)move50Count;
+      RepetitionCount = repetitionCount > 3 ? (byte)3 : (byte)repetitionCount;
+      MoveNum = (short)moveNum;
+      WhiteKRInitPlacement = wKR;
+      WhiteQRInitPlacement = wQR;
+      BlackKRInitPlacement = bKR;
+      BlackQRInitPlacement = bQR;
     }
 
 

--- a/src/Ceres.Chess/Textual/FENGenerator.cs
+++ b/src/Ceres.Chess/Textual/FENGenerator.cs
@@ -25,6 +25,15 @@ namespace Ceres.Chess.Textual
   /// </summary>
   internal static class FENGenerator
   {
+    internal static char GetCastlingFileChar(int fileIndex, bool isWhite)
+    {
+      if (isWhite)
+      {
+        return Char.ToUpper((char)('h' - fileIndex));
+      }
+
+      return (char)('h' - (fileIndex - 56));
+    }
     internal static string GetFEN(Position pos)
     {
       // KQkq - 0 1
@@ -39,19 +48,55 @@ namespace Ceres.Chess.Textual
       StringBuilder castlingSB = new ();
       if (pos.MiscInfo.WhiteCanOO)
       {
-        castlingSB.Append("K");
+        char file = GetCastlingFileChar(pos.MiscInfo.WhiteKRInitPlacement, true);
+        
+        if (file == 'H')
+        {
+          castlingSB.Append("K");
+        }
+        else
+        {
+          castlingSB.Append(file);
+        }
       }
+      
       if (pos.MiscInfo.WhiteCanOOO)
       {
-        castlingSB.Append("Q");
+        char file = GetCastlingFileChar(pos.MiscInfo.WhiteQRInitPlacement, true);        
+        if (file == 'A')
+        {
+          castlingSB.Append("Q");
+        }
+        else
+        {
+          castlingSB.Append(file);
+        }        
       }
+      
       if (pos.MiscInfo.BlackCanOO)
       {
-        castlingSB.Append("k");
+        var file = GetCastlingFileChar(pos.MiscInfo.BlackKRInitPlacement,false);        
+        if (file == 'h')
+        {
+          castlingSB.Append("k");
+        }
+        else
+        {
+          castlingSB.Append(file);
+        }        
       }
+      
       if (pos.MiscInfo.BlackCanOOO)
       {
-        castlingSB.Append("q");
+        var file = GetCastlingFileChar(pos.MiscInfo.BlackQRInitPlacement, false);
+        if (file == 'a')
+        {
+          castlingSB.Append("q");
+        }
+        else
+        {
+          castlingSB.Append(file);
+        }        
       }
 
       string castling = castlingSB.ToString();

--- a/src/Ceres.Chess/Textual/FENParser.cs
+++ b/src/Ceres.Chess/Textual/FENParser.cs
@@ -15,7 +15,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using Ceres.Base.Misc;
 using Ceres.Chess.MoveGen;
 using Ceres.Chess.MoveGen.Converters;
@@ -58,35 +58,6 @@ namespace Ceres.Chess.Textual
     }
 
     /// <summary>
-    /// Get the file index from a character.
-    /// </summary>
-    /// <param name="c"></param>
-    /// <param name="white"></param>
-    /// <returns></returns>
-    public static int CharToNumber(char c, bool white)
-    {
-      char lowerCase = char.ToLower(c);
-      char baseChar = 'a';
-      int file = 7 - (lowerCase - baseChar);
-
-      if (white)
-      {
-        return file;
-      }
-      else
-      {
-        return 56 + file;
-      }
-    }
-
-
-    //create a char array from h..a as a helper for parsing Chess960 fens
-    private static readonly char[] FileArrayLower = ['h', 'g', 'f', 'e', 'd', 'c', 'b', 'a'];
-
-    //create a char array from H..A as a helper for parsing Chess960 fens
-    private static readonly char[] FileArrayUpper = ['H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
-
-    /// <summary>
     /// Worker method to do FEN parsing.
     /// NOTE: performance could be improved by passing in the Piece[] preallocated
     /// </summary>
@@ -96,7 +67,7 @@ namespace Ceres.Chess.Textual
     static FENParseResult DoParseFEN(string fen, int repetitionCount = 0)
     {
       int charIndex = 0;
-
+      RookPlacementInfo rookInfo = default;
       void SkipAnySpaces() { while (charIndex < fen.Length && char.IsWhiteSpace(fen[charIndex])) charIndex++; }
       void SkipAnySpacesOrDash() { while (charIndex < fen.Length && (fen[charIndex] == '-' || char.IsWhiteSpace(fen[charIndex]))) charIndex++; }
 
@@ -104,10 +75,6 @@ namespace Ceres.Chess.Textual
 
       int curRank = 0;
       int curFile = 0;
-      int wKRsquare = -999;
-      int wQRsquare = -999;
-      int bKRsquare = -999;
-      int bQRsquare = -999;
 
       // Parse pieces
       while (true)
@@ -182,9 +149,9 @@ namespace Ceres.Chess.Textual
       {
         charIndex++;
       }
+
       else
       {
-        //error here - needs to use another approach to get the castling rights
         MGPosition pos = default;
         Square whiteKingSquare = default;
         Square blackKingSquare = default;
@@ -225,102 +192,75 @@ namespace Ceres.Chess.Textual
         int whiteKingSq = whiteKingSquare.SquareIndexStartH1;
         int blackKingSq = blackKingSquare.SquareIndexStartH1;
 
-        for (int i = 0; i < whiteRookSquares.Count; i++)
-        {
-          byte rook = whiteRookSquares[i].SquareIndexStartH1;
-          if (rook < whiteKingSq && rook < 8)
-          {
-            wKRsquare = whiteRookSquares[i].SquareIndexStartH1;
-          }
-          else if (rook > whiteKingSq && rook < 8)
-          {
-            wQRsquare = whiteRookSquares[i].SquareIndexStartH1;
-          }
-        }
-
-        for (int i = 0; i < blackRookSquares.Count; i++)
-        {
-          byte rook = blackRookSquares[i].SquareIndexStartH1;
-          if (rook < blackKingSq && rook > 55)
-          {
-            bKRsquare = blackRookSquares[i].SquareIndexStartH1;
-          }
-          else if (rook > blackKingSq && rook > 55)
-          {
-            bQRsquare = blackRookSquares[i].SquareIndexStartH1;
-          }
-        }
-
-        // Variables to hold the rook positions - crucial in chess960
-        char whiteKingSideRook = ' ';
-        char whiteQueenSideRook = ' ';
-        char blackKingSideRook = ' ';
-        char blackQueenSideRook = ' ';
-
         foreach (char c in castlingRights)
         {
-          int idx = Array.IndexOf(FileArrayLower, c);
-          int idxUpper = Array.IndexOf(FileArrayUpper, c);
-          if (char.IsUpper(c) && idxUpper == wKRsquare && wKRsquare < whiteKingSq) // White's castling rights
+          //first check for normal castling rights
+          if (c == 'K')
           {
-            whiteKingSideRook = c;
-          }
-          else if (char.IsUpper(c) && idxUpper == wQRsquare && wQRsquare > whiteKingSq)
-          {
-            whiteQueenSideRook = c;
-          }
-          else if (char.IsLower(c) && (idx + 56) == bKRsquare && bKRsquare < blackKingSq) // Black's castling rights
-          {
-            blackKingSideRook = c;
-          }
-          else if (char.IsLower(c) && (idx + 56) == bQRsquare && bQRsquare > blackKingSq)
-          {
-            blackQueenSideRook = c;
-          }
-
-          else if (c == 'K' && wKRsquare < whiteKingSq)
-          {
-            whiteKingSideRook = c;
-          }
-
-          else if (c == 'Q' && wQRsquare > whiteKingSq)
-          {
-            whiteQueenSideRook = c;
-          }
-
-          else if (c == 'k' && bKRsquare < blackKingSq)
-          {
-            blackKingSideRook = c;
-          }
-
-          else if (c == 'q' && bQRsquare > blackKingSq)
-          {
-            blackQueenSideRook = c;
-          }
-        }
-
-        // Process the castling rights in the FEN string
-        foreach (char thisChar in castlingRights)
-        {
-          if (thisChar == 'K' || thisChar == whiteKingSideRook)
-          {
+            Square rook = whiteRookSquares.First(x => x.FileChar > whiteKingSquare.FileChar); //this is needed when KQkq castling rights is in use in chess960
             whiteCanOO = true;
+            rookInfo.WhiteKRInitPlacement = rook.SquareIndexStartH1;
           }
-          else if (thisChar == 'Q' || thisChar == whiteQueenSideRook)
+
+          else if (c == 'Q')
           {
+            Square rook = whiteRookSquares.First(x => x.FileChar < whiteKingSquare.FileChar);
             whiteCanOOO = true;
+            rookInfo.WhiteQRInitPlacement = rook.SquareIndexStartH1;
           }
-          else if (thisChar == 'k' || thisChar == blackKingSideRook)
+          
+          else if (c == 'k')
           {
+            Square rook = blackRookSquares.First(x => x.FileChar > blackKingSquare.FileChar);
             blackCanOO = true;
+            rookInfo.BlackKRInitPlacement = (byte)(rook.SquareIndexStartH1 - 56);
           }
-          else if (thisChar == 'q' || thisChar == blackQueenSideRook)
+          
+          else if (c == 'q')
           {
+            Square rook = blackRookSquares.First(x => x.FileChar < blackKingSquare.FileChar);
             blackCanOOO = true;
+            rookInfo.BlackQRInitPlacement = (byte)(rook.SquareIndexStartH1 - 56);
+          }
+
+          else //next chess960 castling rights
+          {
+            if (char.IsUpper(c)) // White's castling rights
+            {
+              bool kingIsLowerChar = whiteKingSquare.FileChar < c;
+              Square whiteRook = whiteRookSquares.First(x => x.FileChar == c);
+              if (kingIsLowerChar)
+              {
+                whiteCanOO = true;
+                rookInfo.WhiteKRInitPlacement = (byte)whiteRook.SquareIndexStartH1;
+              }
+              else
+              {
+                whiteCanOOO = true;
+                rookInfo.WhiteQRInitPlacement = (byte)whiteRook.SquareIndexStartH1;
+              }
+
+            }
+
+            if (char.IsLower(c)) // black's castling rights
+            {
+              bool kingIsLowerChar = blackKingSquare.FileChar < Char.ToUpper(c);
+              Square blackRook = blackRookSquares.First(x => x.FileChar == Char.ToUpper(c));
+              if (kingIsLowerChar)
+              {
+                blackCanOO = true;
+                rookInfo.BlackKRInitPlacement = (byte)(blackRook.SquareIndexStartH1 - 56);
+              }
+              else
+              {
+                blackCanOOO = true;
+                rookInfo.BlackQRInitPlacement = (byte)(blackRook.SquareIndexStartH1 - 56);
+              }
+            }
           }
         }
-
       }
+
       charIndex += castlingRights.Length;
 
       SkipAnySpaces();
@@ -424,9 +364,7 @@ namespace Ceres.Chess.Textual
       }
 
       PositionMiscInfo miscInfo = new PositionMiscInfo(whiteCanOO, whiteCanOOO, blackCanOO, blackCanOOO,
-                                                        sideToMove, move50Count, repetitionCount, plyCount, epColIndex, 
-                                                        (byte)wKRsquare, (byte)wQRsquare, (byte)bKRsquare, (byte)bQRsquare);
-
+                                                        sideToMove, move50Count, repetitionCount, plyCount, epColIndex, rookInfo);
       return new FENParseResult(pieces, miscInfo);
     }
 

--- a/src/Ceres.Chess/Textual/FENParser.cs
+++ b/src/Ceres.Chess/Textual/FENParser.cs
@@ -424,7 +424,8 @@ namespace Ceres.Chess.Textual
       }
 
       PositionMiscInfo miscInfo = new PositionMiscInfo(whiteCanOO, whiteCanOOO, blackCanOO, blackCanOOO,
-                                                        sideToMove, move50Count, repetitionCount, plyCount, epColIndex);
+                                                        sideToMove, move50Count, repetitionCount, plyCount, epColIndex, 
+                                                        (byte)wKRsquare, (byte)wQRsquare, (byte)bKRsquare, (byte)bQRsquare);
 
       return new FENParseResult(pieces, miscInfo);
     }


### PR DESCRIPTION
Added new fields to track initial rook placements in `PositionMiscInfo`. Updated `MGChessPositionConverter`, `MGPosition`, and `MGPositionConstants` to handle new rook placement fields. Introduced a new constructor in `PositionMiscInfo` for initializing these fields. Added `GetCastlingFileChar` helper method in `FENGenerator` and updated it to use new fields for FEN generation. Modified `FENParser` to parse and set new rook placement fields for proper Chess960 handling.