### PR TITLE
Add Chess960 support to tournament manager

### DIFF
--- a/src/Ceres.Chess/Basic/Move.cs
+++ b/src/Ceres.Chess/Basic/Move.cs
@@ -119,6 +119,7 @@ namespace Ceres.Chess
       PieceType movePiece = pos.PieceOnSquare(startSquare).Type;
       if (movePiece == PieceType.King)
       {
+        // Standard castling notation.
         if (uciUpper == "E1G1" || uciUpper == "E8G8")
         {
           return new Move(MoveType.MoveCastleShort);
@@ -126,6 +127,15 @@ namespace Ceres.Chess
         else if (uciUpper == "E1C1" || uciUpper == "E8C8")
         {
           return new Move(MoveType.MoveCastleLong);
+        }
+
+        // Chess960 castling: king captures own rook.
+        Square destSquare = uciMoveStr.Substring(2, 2);
+        Piece destPiece = pos.PieceOnSquare(destSquare);
+        if (destPiece.Type == PieceType.Rook && destPiece.Side == pos.MiscInfo.SideToMove)
+        {
+          bool isKingSide = destSquare.FileChar > startSquare.FileChar;
+          return new Move(isKingSide ? MoveType.MoveCastleShort : MoveType.MoveCastleLong);
         }
       }
 

--- a/src/Ceres.Chess/GameEngines/GameEngineUCI.cs
+++ b/src/Ceres.Chess/GameEngines/GameEngineUCI.cs
@@ -100,6 +100,11 @@ namespace Ceres.Chess.GameEngines
     public virtual string OverrideLaunchExecutable => null;
 
     /// <summary>
+    /// If position communication should use Chess960 king-captures-rook castling notation.
+    /// </summary>
+    public bool IsChess960 { get; set; }
+
+    /// <summary>
     /// If this engine supports playing best value move.
     /// </summary>
     public virtual bool SupportsBestValueMoveMode => false;
@@ -238,11 +243,11 @@ namespace Ceres.Chess.GameEngines
       switch (searchLimit.Type)
       {
         case SearchLimitType.SecondsPerMove:
-          gameInfo = UCIRunner.EvalPositionToMovetime(curPositionAndMoves.FENAndMovesString, (int)(searchLimit.Value * 1000));
+          gameInfo = UCIRunner.EvalPositionToMovetime(curPositionAndMoves.GetFENAndMovesString(IsChess960), (int)(searchLimit.Value * 1000));
           break;
 
         case SearchLimitType.NodesPerMove:
-          gameInfo = UCIRunner.EvalPositionToNodes(curPositionAndMoves.FENAndMovesString, (int)(searchLimit.Value));
+          gameInfo = UCIRunner.EvalPositionToNodes(curPositionAndMoves.GetFENAndMovesString(IsChess960), (int)(searchLimit.Value));
           break;
 
         case SearchLimitType.NodesPerTree:
@@ -252,7 +257,7 @@ namespace Ceres.Chess.GameEngines
         case SearchLimitType.BestValueMove:
           if (SupportsBestValueMoveMode)
           {
-            gameInfo = UCIRunner.EvalPosition(curPositionAndMoves.FENAndMovesString, "value", 1, "go value");
+            gameInfo = UCIRunner.EvalPosition(curPositionAndMoves.GetFENAndMovesString(IsChess960), "value", 1, "go value");
             break;
           }
           else
@@ -263,7 +268,7 @@ namespace Ceres.Chess.GameEngines
         case SearchLimitType.BestActionMove:
           if (SupportsBestActionMoveMode)
           {
-            gameInfo = UCIRunner.EvalPosition(curPositionAndMoves.FENAndMovesString, "action", 1, "go action");
+            gameInfo = UCIRunner.EvalPosition(curPositionAndMoves.GetFENAndMovesString(IsChess960), "action", 1, "go action");
             break;
           }
           else
@@ -275,7 +280,7 @@ namespace Ceres.Chess.GameEngines
         case SearchLimitType.NodesForAllMoves:
            using (new TimingBlock(new TimingStats(), TimingBlock.LoggingType.None))
           {
-            gameInfo = UCIRunner.EvalPositionRemainingNodes(curPositionAndMoves.FENAndMovesString,
+            gameInfo = UCIRunner.EvalPositionRemainingNodes(curPositionAndMoves.GetFENAndMovesString(IsChess960),
                                                             weAreWhite,
                                                             searchLimit.MaxMovesToGo,
                                                             (int)(searchLimit.Value),
@@ -287,7 +292,7 @@ namespace Ceres.Chess.GameEngines
         case SearchLimitType.SecondsForAllMoves:
            using (new TimingBlock(new TimingStats(), TimingBlock.LoggingType.None))
           {
-            gameInfo = UCIRunner.EvalPositionRemainingTime(curPositionAndMoves.FENAndMovesString,
+            gameInfo = UCIRunner.EvalPositionRemainingTime(curPositionAndMoves.GetFENAndMovesString(IsChess960),
                                                            weAreWhite,
                                                            searchLimit.MaxMovesToGo,
                                                            (int)(searchLimit.Value * 1000),

--- a/src/Ceres.Chess/Games/PGNWriter.cs
+++ b/src/Ceres.Chess/Games/PGNWriter.cs
@@ -38,6 +38,11 @@ namespace Ceres.Chess.Games
     int numPlyWritten = 0;
     Position startingPos;
 
+    /// <summary>
+    /// If set, emits [Variant "Chess960"] and [SetUp "1"] tags and always writes the FEN.
+    /// </summary>
+    public bool IsChess960 { get; set; }
+
     StringBuilder header = new StringBuilder();
     StringBuilder body = new StringBuilder();
 
@@ -78,13 +83,20 @@ namespace Ceres.Chess.Games
 
     public void WriteStartPosition(string startingFEN)
     {
-      if (startingFEN != Position.StartPosition.FEN)
+      if (IsChess960)
+      {
+        WriteTag("Variant", "Chess960");
+        WriteTag("SetUp", "1");
+        FENParseResult parsedFEN = FENParser.ParseFEN(startingFEN);
+        startingPos = parsedFEN.AsPosition;
+        WriteTag("FEN", startingFEN);
+      }
+      else if (startingFEN != Position.StartPosition.FEN)
       {
         FENParseResult parsedFEN = FENParser.ParseFEN(startingFEN);
         startingPos = parsedFEN.AsPosition;
         WriteTag("FEN", startingFEN);
       }
-
     }
 
 

--- a/src/Ceres.Chess/Games/Utils/EPDEntry.cs
+++ b/src/Ceres.Chess/Games/Utils/EPDEntry.cs
@@ -221,7 +221,10 @@ namespace Ceres.Chess.Games.Utils
 
       if (posBMOrAM == -1)
       {
-        GetFENAndStartMovesFromFENStr(epdLine, out FEN, out StartMoves);
+        // Strip EPD annotations (everything after first semicolon).
+        int semiPos = epdLine.IndexOf(';');
+        string fenPart = semiPos >= 0 ? epdLine.Substring(0, semiPos).TrimEnd() : epdLine;
+        GetFENAndStartMovesFromFENStr(fenPart, out FEN, out StartMoves);
       }
       else
       {

--- a/src/Ceres.Chess/Positions/PositionWithHistory.cs
+++ b/src/Ceres.Chess/Positions/PositionWithHistory.cs
@@ -307,6 +307,26 @@ namespace Ceres.Chess.Positions
 
 
     /// <summary>
+    /// Returns the FEN followed by "moves" and the move list (if any),
+    /// using Chess960 king-captures-rook castling notation when isChess960 is true.
+    /// </summary>
+    public string GetFENAndMovesString(bool isChess960)
+    {
+      if (!isChess960)
+      {
+        return FENAndMovesString;
+      }
+
+      string ret = InitialPosition.FEN;
+      if (Moves != null && Moves.Count > 0)
+      {
+        ret += " moves " + GetMovesStr(isChess960);
+      }
+      return ret;
+    }
+
+
+    /// <summary>
     /// Constructs a new MGMoveSequence given a starting position (as a FEN) 
     /// and an optional string containing a sequence of subsequent moves (in coordinate notation).
     /// </summary>
@@ -614,6 +634,26 @@ namespace Ceres.Chess.Positions
         }
         return moveStr;
       }
+    }
+
+
+    /// <summary>
+    /// Returns space separated sequence of consecutive history moves (in coordinate style),
+    /// using Chess960 king-captures-rook castling notation when isChess960 is true.
+    /// </summary>
+    public string GetMovesStr(bool isChess960)
+    {
+      if (!isChess960)
+      {
+        return MovesStr;
+      }
+
+      string moveStr = "";
+      foreach (MGMove move in Moves)
+      {
+        moveStr += move.MoveStr(MGMoveNotationStyle.Coordinates, isChess960) + " ";
+      }
+      return moveStr;
     }
 
 

--- a/src/Ceres.Features/Tournaments/TournamentGameThread.cs
+++ b/src/Ceres.Features/Tournaments/TournamentGameThread.cs
@@ -28,7 +28,9 @@ using Chess.Ceres.PlayEvaluation;
 using Ceres.Chess.GameEngines;
 using Ceres.Chess.UserSettings;
 using Ceres.MCTS.Iteration;
+using Ceres.Chess.MoveGen;
 using Ceres.Chess.MoveGen.Converters;
+using Ceres.MCTS.GameEngines;
 
 #endregion
 
@@ -280,6 +282,80 @@ namespace Ceres.Features.Tournaments
 
     Dictionary<int, TournamentGameInfo> GameInfoFirstFinishedForByOpening = new();
 
+    /// <summary>
+    /// Returns true if the given position has Chess960 characteristics
+    /// (non-standard rook placement or non-standard king file with castling rights).
+    /// </summary>
+    static bool PositionIsChess960(in Position pos)
+    {
+      if (!pos.MiscInfo.CastlingRightsAny)
+      {
+        return false;
+      }
+
+      // Non-standard rook placement detected by FENParser.
+      if (pos.MiscInfo.RookInfo.RawValue != 0)
+      {
+        return true;
+      }
+
+      // Standard rook placement but check if king is not on standard e-file.
+      // E-file = file index 4. Check both white and black kings.
+      if (pos.MiscInfo.WhiteCanOO || pos.MiscInfo.WhiteCanOOO)
+      {
+        Piece whiteKingPiece = pos.PieceOnSquare(new Square("e1"));
+        if (whiteKingPiece.Type != PieceType.King || whiteKingPiece.Side != SideType.White)
+        {
+          return true;
+        }
+      }
+
+      if (pos.MiscInfo.BlackCanOO || pos.MiscInfo.BlackCanOOO)
+      {
+        Piece blackKingPiece = pos.PieceOnSquare(new Square("e8"));
+        if (blackKingPiece.Type != PieceType.King || blackKingPiece.Side != SideType.Black)
+        {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    bool? lastChess960Mode = null;
+
+    /// <summary>
+    /// Sets Chess960 mode on all engines if it has changed since last game.
+    /// For UCI engines, sends the UCI_Chess960 option.
+    /// For Ceres in-process engines, sets the IsChess960 property.
+    /// </summary>
+    void SetEnginesChess960Mode(bool isChess960)
+    {
+      if (lastChess960Mode == isChess960)
+      {
+        return;
+      }
+
+      lastChess960Mode = isChess960;
+      MGPositionConstants.IsChess960 = isChess960;
+
+      string valueStr = isChess960 ? "true" : "false";
+      foreach (GameEngine engine in Run.Engines)
+      {
+        if (engine is GameEngineUCI uciEngine)
+        {
+          uciEngine.IsChess960 = isChess960;
+          uciEngine.UCIRunner.SendCommand($"setoption name UCI_Chess960 value {valueStr}");
+        }
+        else if (engine is GameEngineCeresInProcess ceresEngine)
+        {
+          ceresEngine.IsChess960 = isChess960;
+        }
+      }
+    }
+
+
     private TournamentGameInfo RunGame(string pgnFileName, bool engine2White, int openingIndex, int gameSequenceNum, int roundNumber)
     {
       TournamentGameInfo thisResult;
@@ -293,6 +369,13 @@ namespace Ceres.Features.Tournaments
                                   engine2White ? Run.Engine1.ID : Run.Engine2.ID,
                                   extraTags.ToArray());
 
+      // Auto-detect Chess960 from current opening's initial position.
+      // Uses RookPlacementInfo populated by FENParser (RawValue == 0 for standard rook placement)
+      // and king square check for the case where rooks are on standard files but king is not on e-file.
+      PositionWithHistory opening = openings.GetAtIndex(openingIndex);
+      bool gameIsChess960 = PositionIsChess960(opening.InitialPosMG.ToPosition);
+      SetEnginesChess960Mode(gameIsChess960);
+      pgnWriter.IsChess960 = gameIsChess960;
 
       TimingStats gameTimingStats = new TimingStats();
       using (new TimingBlock(gameTimingStats, TimingBlock.LoggingType.None))

--- a/src/Ceres.MCTS/GameEngines/GameEngineCeresInProcess.cs
+++ b/src/Ceres.MCTS/GameEngines/GameEngineCeresInProcess.cs
@@ -118,6 +118,11 @@ public class GameEngineCeresInProcess : GameEngine
   /// </summary>
   public List<MGMove> ForcedMoves = null;
 
+  /// <summary>
+  /// If Chess960 mode is active (controls bestmove notation and internal Chess960 flag).
+  /// </summary>
+  public bool IsChess960 { get; set; }
+
 
   #region Internal data
 
@@ -377,7 +382,7 @@ public class GameEngineCeresInProcess : GameEngine
     // TODO is the RootNWhenSearchStarted correct because we may be following a continuation (BestMoveRoot)
 
     GameEngineSearchResultCeres result =
-      new GameEngineSearchResultCeres(bestMoveMG.MoveStr(MGMoveNotationStyle.Coordinates),
+      new GameEngineSearchResultCeres(bestMoveMG.MoveStr(MGMoveNotationStyle.Coordinates, IsChess960),
                                       bestMoveInfo.QOfBest, scoreCeresCP,
                                       searchResult.SearchRootNode.MAvg,
                                       searchResult.Manager.SearchLimit,


### PR DESCRIPTION
Per-game auto-detection from opening position using FENParser's RookPlacementInfo and king square check. Sends UCI_Chess960 to external engines, sets IsChess960 on Ceres in-process engine. Chess960-aware move notation (king-captures-rook) for UCI position strings. PGN output emits [Variant "Chess960"] tag. Also fixes EPD parser to strip annotations after semicolon.